### PR TITLE
Add flare-loader: GGUF, SafeTensors, quantization

### DIFF
--- a/flare-loader/Cargo.toml
+++ b/flare-loader/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "flare-loader"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Model weight loading for Flare (GGUF, SafeTensors, progressive streaming)"
+
+[dependencies]
+flare-core = { path = "../flare-core" }
+thiserror = { workspace = true }
+byteorder = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -1,0 +1,467 @@
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::collections::HashMap;
+use std::io::{self, Read, Seek, SeekFrom};
+use thiserror::Error;
+
+use crate::quantize::{self, QuantFormat};
+use flare_core::config::{Architecture, ModelConfig};
+use flare_core::tensor::Tensor;
+
+const GGUF_MAGIC: u32 = 0x46475547; // "GGUF" in little-endian
+
+#[derive(Debug, Error)]
+pub enum GgufError {
+    #[error("invalid GGUF magic number: expected 0x{:08X}, got 0x{got:08X}", GGUF_MAGIC)]
+    InvalidMagic { got: u32 },
+    #[error("unsupported GGUF version: {0}")]
+    UnsupportedVersion(u32),
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("invalid metadata value type: {0}")]
+    InvalidValueType(u32),
+    #[error("tensor not found: {0}")]
+    TensorNotFound(String),
+    #[error("unsupported architecture: {0}")]
+    UnsupportedArchitecture(String),
+    #[error("missing metadata key: {0}")]
+    MissingMetadata(String),
+    #[error("unsupported quantization format: {0:?}")]
+    UnsupportedQuant(QuantFormat),
+}
+
+/// Represents a parsed GGUF file header and metadata.
+/// Tensor data is read lazily via offsets.
+pub struct GgufFile {
+    pub version: u32,
+    pub metadata: HashMap<String, MetadataValue>,
+    pub tensors: Vec<TensorInfo>,
+    pub tensor_data_offset: u64,
+}
+
+#[derive(Debug, Clone)]
+pub enum MetadataValue {
+    Uint8(u8),
+    Int8(i8),
+    Uint16(u16),
+    Int16(i16),
+    Uint32(u32),
+    Int32(i32),
+    Uint64(u64),
+    Int64(i64),
+    Float32(f32),
+    Float64(f64),
+    Bool(bool),
+    String(String),
+    Array(Vec<MetadataValue>),
+}
+
+impl MetadataValue {
+    pub fn as_u32(&self) -> Option<u32> {
+        match self {
+            MetadataValue::Uint32(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    pub fn as_u64(&self) -> Option<u64> {
+        match self {
+            MetadataValue::Uint64(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    pub fn as_f32(&self) -> Option<f32> {
+        match self {
+            MetadataValue::Float32(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            MetadataValue::String(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TensorInfo {
+    pub name: String,
+    pub dimensions: Vec<u64>,
+    pub dtype: QuantFormat,
+    pub offset: u64,
+}
+
+impl TensorInfo {
+    /// Total number of elements in this tensor.
+    pub fn numel(&self) -> u64 {
+        self.dimensions.iter().product::<u64>().max(1)
+    }
+
+    /// Size in bytes for this tensor's data.
+    pub fn byte_size(&self) -> u64 {
+        let elements = self.numel();
+        self.dtype.bytes_for_elements(elements)
+    }
+}
+
+impl GgufFile {
+    /// Parse GGUF header and metadata from a reader.
+    /// Does NOT read tensor data — only parses the header to get tensor offsets.
+    pub fn parse_header<R: Read + Seek>(reader: &mut R) -> Result<Self, GgufError> {
+        // Magic number
+        let magic = reader.read_u32::<LittleEndian>()?;
+        if magic != GGUF_MAGIC {
+            return Err(GgufError::InvalidMagic { got: magic });
+        }
+
+        // Version
+        let version = reader.read_u32::<LittleEndian>()?;
+        if version < 2 || version > 3 {
+            return Err(GgufError::UnsupportedVersion(version));
+        }
+
+        // Counts
+        let tensor_count = reader.read_u64::<LittleEndian>()?;
+        let metadata_count = reader.read_u64::<LittleEndian>()?;
+
+        // Parse metadata
+        let mut metadata = HashMap::new();
+        for _ in 0..metadata_count {
+            let key = read_gguf_string(reader)?;
+            let value = read_metadata_value(reader)?;
+            metadata.insert(key, value);
+        }
+
+        // Parse tensor infos
+        let mut tensors = Vec::with_capacity(tensor_count as usize);
+        for _ in 0..tensor_count {
+            let name = read_gguf_string(reader)?;
+            let n_dims = reader.read_u32::<LittleEndian>()?;
+            let mut dimensions = Vec::with_capacity(n_dims as usize);
+            for _ in 0..n_dims {
+                dimensions.push(reader.read_u64::<LittleEndian>()?);
+            }
+            let dtype_raw = reader.read_u32::<LittleEndian>()?;
+            let dtype = QuantFormat::from_gguf_type(dtype_raw);
+            let offset = reader.read_u64::<LittleEndian>()?;
+
+            tensors.push(TensorInfo {
+                name,
+                dimensions,
+                dtype,
+                offset,
+            });
+        }
+
+        // Tensor data starts at the next alignment boundary after the header
+        let header_end = reader.stream_position()?;
+        let alignment = 32u64;
+        let tensor_data_offset = (header_end + alignment - 1) / alignment * alignment;
+
+        Ok(Self {
+            version,
+            metadata,
+            tensors,
+            tensor_data_offset,
+        })
+    }
+
+    /// Find a tensor by name.
+    pub fn find_tensor(&self, name: &str) -> Option<&TensorInfo> {
+        self.tensors.iter().find(|t| t.name == name)
+    }
+
+    /// Get the architecture string from metadata.
+    pub fn architecture(&self) -> Option<&str> {
+        self.metadata
+            .get("general.architecture")
+            .and_then(|v| v.as_str())
+    }
+
+    /// Helper: get a metadata value as usize, trying multiple integer types.
+    fn meta_usize(&self, key: &str) -> Result<usize, GgufError> {
+        let val = self
+            .metadata
+            .get(key)
+            .ok_or_else(|| GgufError::MissingMetadata(key.to_string()))?;
+        match val {
+            MetadataValue::Uint32(v) => Ok(*v as usize),
+            MetadataValue::Int32(v) => Ok(*v as usize),
+            MetadataValue::Uint64(v) => Ok(*v as usize),
+            MetadataValue::Int64(v) => Ok(*v as usize),
+            MetadataValue::Uint16(v) => Ok(*v as usize),
+            MetadataValue::Uint8(v) => Ok(*v as usize),
+            _ => Err(GgufError::MissingMetadata(format!("{key} (not an integer)"))),
+        }
+    }
+
+    /// Helper: get a metadata value as f32.
+    fn meta_f32(&self, key: &str) -> Result<f32, GgufError> {
+        let val = self
+            .metadata
+            .get(key)
+            .ok_or_else(|| GgufError::MissingMetadata(key.to_string()))?;
+        match val {
+            MetadataValue::Float32(v) => Ok(*v),
+            MetadataValue::Float64(v) => Ok(*v as f32),
+            _ => Err(GgufError::MissingMetadata(format!("{key} (not a float)"))),
+        }
+    }
+
+    /// Extract ModelConfig from GGUF metadata.
+    pub fn to_model_config(&self) -> Result<ModelConfig, GgufError> {
+        let arch_str = self
+            .architecture()
+            .ok_or_else(|| GgufError::MissingMetadata("general.architecture".into()))?;
+
+        let architecture = match arch_str.to_lowercase().as_str() {
+            "llama" => Architecture::Llama,
+            "qwen2" => Architecture::Qwen2,
+            "mistral" => Architecture::Mistral,
+            other => return Err(GgufError::UnsupportedArchitecture(other.to_string())),
+        };
+
+        let prefix = arch_str.to_lowercase();
+
+        let vocab_size = self.meta_usize(&format!("{prefix}.vocab_size"))
+            .or_else(|_| self.meta_usize("tokenizer.ggml.tokens").map(|_| {
+                // Count tokens from the token array if vocab_size not explicit
+                self.metadata.get("tokenizer.ggml.tokens")
+                    .and_then(|v| if let MetadataValue::Array(a) = v { Some(a.len()) } else { None })
+                    .unwrap_or(32000)
+            }))
+            .unwrap_or(32000);
+
+        let hidden_dim = self.meta_usize(&format!("{prefix}.embedding_length"))?;
+        let num_layers = self.meta_usize(&format!("{prefix}.block_count"))?;
+        let num_heads = self.meta_usize(&format!("{prefix}.attention.head_count"))?;
+        let num_kv_heads = self
+            .meta_usize(&format!("{prefix}.attention.head_count_kv"))
+            .unwrap_or(num_heads);
+        let head_dim = hidden_dim / num_heads;
+
+        let intermediate_dim = self
+            .meta_usize(&format!("{prefix}.feed_forward_length"))
+            .unwrap_or(hidden_dim * 4);
+
+        let max_seq_len = self
+            .meta_usize(&format!("{prefix}.context_length"))
+            .unwrap_or(2048);
+
+        let rope_theta = self
+            .meta_f32(&format!("{prefix}.rope.freq_base"))
+            .unwrap_or(10000.0);
+
+        let rms_norm_eps = self
+            .meta_f32(&format!("{prefix}.attention.layer_norm_rms_epsilon"))
+            .unwrap_or(1e-5);
+
+        Ok(ModelConfig {
+            architecture,
+            vocab_size,
+            hidden_dim,
+            intermediate_dim,
+            num_layers,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            max_seq_len,
+            rope_theta,
+            rms_norm_eps,
+        })
+    }
+
+    /// Read a single tensor's data from the file, dequantizing to f32.
+    pub fn read_tensor_data<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        tensor_info: &TensorInfo,
+    ) -> Result<Tensor, GgufError> {
+        let absolute_offset = self.tensor_data_offset + tensor_info.offset;
+        reader.seek(SeekFrom::Start(absolute_offset))?;
+
+        let byte_size = tensor_info.byte_size() as usize;
+        let mut raw = vec![0u8; byte_size];
+        reader.read_exact(&mut raw)?;
+
+        let numel = tensor_info.numel() as usize;
+        let f32_data = dequantize_tensor(&raw, tensor_info.dtype, numel)?;
+
+        let shape: Vec<usize> = tensor_info.dimensions.iter().map(|&d| d as usize).collect();
+        Tensor::from_vec(f32_data, &shape).map_err(|e| {
+            GgufError::Io(io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+        })
+    }
+
+    /// Load all tensor data from the file, returning a map of name → Tensor.
+    pub fn load_all_tensors<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+    ) -> Result<HashMap<String, Tensor>, GgufError> {
+        let mut tensors = HashMap::new();
+        for info in &self.tensors {
+            let tensor = self.read_tensor_data(reader, info)?;
+            tensors.insert(info.name.clone(), tensor);
+        }
+        Ok(tensors)
+    }
+}
+
+/// Dequantize raw bytes to f32 based on quantization format.
+fn dequantize_tensor(raw: &[u8], dtype: QuantFormat, numel: usize) -> Result<Vec<f32>, GgufError> {
+    match dtype {
+        QuantFormat::F32 => {
+            let mut data = vec![0.0f32; numel];
+            for (i, chunk) in raw.chunks_exact(4).enumerate() {
+                data[i] = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            }
+            Ok(data)
+        }
+        QuantFormat::F16 => {
+            let mut data = vec![0.0f32; numel];
+            for (i, chunk) in raw.chunks_exact(2).enumerate() {
+                let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
+                data[i] = quantize::f16_to_f32(bits);
+            }
+            Ok(data)
+        }
+        QuantFormat::Q8_0 => {
+            let block_size = 32;
+            let block_bytes = 34; // 2 (scale) + 32 (data)
+            let num_blocks = numel / block_size;
+            let mut data = vec![0.0f32; numel];
+            for b in 0..num_blocks {
+                let block = &raw[b * block_bytes..(b + 1) * block_bytes];
+                let mut out = [0.0f32; 32];
+                quantize::dequant_q8_0_block(block, &mut out);
+                data[b * block_size..(b + 1) * block_size].copy_from_slice(&out);
+            }
+            Ok(data)
+        }
+        QuantFormat::Q4_0 => {
+            let block_size = 32;
+            let block_bytes = 18; // 2 (scale) + 16 (data)
+            let num_blocks = numel / block_size;
+            let mut data = vec![0.0f32; numel];
+            for b in 0..num_blocks {
+                let block = &raw[b * block_bytes..(b + 1) * block_bytes];
+                let mut out = [0.0f32; 32];
+                quantize::dequant_q4_0_block(block, &mut out);
+                data[b * block_size..(b + 1) * block_size].copy_from_slice(&out);
+            }
+            Ok(data)
+        }
+        other => Err(GgufError::UnsupportedQuant(other)),
+    }
+}
+
+fn read_gguf_string<R: Read>(reader: &mut R) -> Result<String, GgufError> {
+    let len = reader.read_u64::<LittleEndian>()? as usize;
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf)?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+fn read_metadata_value<R: Read>(reader: &mut R) -> Result<MetadataValue, GgufError> {
+    let value_type = reader.read_u32::<LittleEndian>()?;
+    match value_type {
+        0 => Ok(MetadataValue::Uint8(reader.read_u8()?)),
+        1 => Ok(MetadataValue::Int8(reader.read_i8()?)),
+        2 => Ok(MetadataValue::Uint16(reader.read_u16::<LittleEndian>()?)),
+        3 => Ok(MetadataValue::Int16(reader.read_i16::<LittleEndian>()?)),
+        4 => Ok(MetadataValue::Uint32(reader.read_u32::<LittleEndian>()?)),
+        5 => Ok(MetadataValue::Int32(reader.read_i32::<LittleEndian>()?)),
+        6 => Ok(MetadataValue::Float32(reader.read_f32::<LittleEndian>()?)),
+        7 => Ok(MetadataValue::Bool(reader.read_u8()? != 0)),
+        8 => Ok(MetadataValue::String(read_gguf_string(reader)?)),
+        9 => {
+            // Array
+            let element_type = reader.read_u32::<LittleEndian>()?;
+            let count = reader.read_u64::<LittleEndian>()? as usize;
+            let mut values = Vec::with_capacity(count);
+            for _ in 0..count {
+                // Read raw values of the element type
+                let val = read_typed_value(reader, element_type)?;
+                values.push(val);
+            }
+            Ok(MetadataValue::Array(values))
+        }
+        10 => Ok(MetadataValue::Uint64(reader.read_u64::<LittleEndian>()?)),
+        11 => Ok(MetadataValue::Int64(reader.read_i64::<LittleEndian>()?)),
+        12 => Ok(MetadataValue::Float64(reader.read_f64::<LittleEndian>()?)),
+        _ => Err(GgufError::InvalidValueType(value_type)),
+    }
+}
+
+fn read_typed_value<R: Read>(reader: &mut R, type_id: u32) -> Result<MetadataValue, GgufError> {
+    match type_id {
+        0 => Ok(MetadataValue::Uint8(reader.read_u8()?)),
+        1 => Ok(MetadataValue::Int8(reader.read_i8()?)),
+        2 => Ok(MetadataValue::Uint16(reader.read_u16::<LittleEndian>()?)),
+        3 => Ok(MetadataValue::Int16(reader.read_i16::<LittleEndian>()?)),
+        4 => Ok(MetadataValue::Uint32(reader.read_u32::<LittleEndian>()?)),
+        5 => Ok(MetadataValue::Int32(reader.read_i32::<LittleEndian>()?)),
+        6 => Ok(MetadataValue::Float32(reader.read_f32::<LittleEndian>()?)),
+        7 => Ok(MetadataValue::Bool(reader.read_u8()? != 0)),
+        8 => Ok(MetadataValue::String(read_gguf_string(reader)?)),
+        10 => Ok(MetadataValue::Uint64(reader.read_u64::<LittleEndian>()?)),
+        11 => Ok(MetadataValue::Int64(reader.read_i64::<LittleEndian>()?)),
+        12 => Ok(MetadataValue::Float64(reader.read_f64::<LittleEndian>()?)),
+        _ => Err(GgufError::InvalidValueType(type_id)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn write_gguf_header(buf: &mut Vec<u8>, tensor_count: u64, metadata_count: u64) {
+        buf.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        buf.extend_from_slice(&3u32.to_le_bytes()); // version
+        buf.extend_from_slice(&tensor_count.to_le_bytes());
+        buf.extend_from_slice(&metadata_count.to_le_bytes());
+    }
+
+    fn write_gguf_string(buf: &mut Vec<u8>, s: &str) {
+        buf.extend_from_slice(&(s.len() as u64).to_le_bytes());
+        buf.extend_from_slice(s.as_bytes());
+    }
+
+    #[test]
+    fn test_parse_empty_gguf() {
+        let mut buf = Vec::new();
+        write_gguf_header(&mut buf, 0, 0);
+
+        let mut cursor = Cursor::new(buf);
+        let file = GgufFile::parse_header(&mut cursor).unwrap();
+        assert_eq!(file.version, 3);
+        assert!(file.metadata.is_empty());
+        assert!(file.tensors.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_magic() {
+        let buf = vec![0u8; 32];
+        let mut cursor = Cursor::new(buf);
+        let result = GgufFile::parse_header(&mut cursor);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_metadata() {
+        let mut buf = Vec::new();
+        write_gguf_header(&mut buf, 0, 1);
+
+        // Write one string metadata entry
+        write_gguf_string(&mut buf, "general.architecture");
+        buf.extend_from_slice(&8u32.to_le_bytes()); // type: string
+        write_gguf_string(&mut buf, "llama");
+
+        let mut cursor = Cursor::new(buf);
+        let file = GgufFile::parse_header(&mut cursor).unwrap();
+        assert_eq!(file.architecture(), Some("llama"));
+    }
+}

--- a/flare-loader/src/lib.rs
+++ b/flare-loader/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod gguf;
+pub mod quantize;
+pub mod safetensors;
+pub mod weights;
+
+pub use gguf::{GgufFile, GgufError};
+pub use quantize::QuantFormat;
+pub use safetensors::{SafeTensorsFile, SafeTensorsError};
+pub use weights::load_model_weights;

--- a/flare-loader/src/quantize.rs
+++ b/flare-loader/src/quantize.rs
@@ -1,0 +1,173 @@
+/// Quantization format identifiers matching GGUF type IDs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantFormat {
+    F32,
+    F16,
+    Q4_0,
+    Q4_1,
+    Q5_0,
+    Q5_1,
+    Q8_0,
+    Q8_1,
+    Q2K,
+    Q3K,
+    Q4K,
+    Q5K,
+    Q6K,
+    Unknown(u32),
+}
+
+impl QuantFormat {
+    pub fn from_gguf_type(type_id: u32) -> Self {
+        match type_id {
+            0 => QuantFormat::F32,
+            1 => QuantFormat::F16,
+            2 => QuantFormat::Q4_0,
+            3 => QuantFormat::Q4_1,
+            6 => QuantFormat::Q5_0,
+            7 => QuantFormat::Q5_1,
+            8 => QuantFormat::Q8_0,
+            9 => QuantFormat::Q8_1,
+            10 => QuantFormat::Q2K,
+            11 => QuantFormat::Q3K,
+            12 => QuantFormat::Q4K,
+            13 => QuantFormat::Q5K,
+            14 => QuantFormat::Q6K,
+            other => QuantFormat::Unknown(other),
+        }
+    }
+
+    /// Bits per weight for this format.
+    pub fn bits_per_weight(&self) -> f32 {
+        match self {
+            QuantFormat::F32 => 32.0,
+            QuantFormat::F16 => 16.0,
+            QuantFormat::Q4_0 | QuantFormat::Q4_1 | QuantFormat::Q4K => 4.5,
+            QuantFormat::Q5_0 | QuantFormat::Q5_1 | QuantFormat::Q5K => 5.5,
+            QuantFormat::Q8_0 | QuantFormat::Q8_1 => 8.5,
+            QuantFormat::Q2K => 2.6,
+            QuantFormat::Q3K => 3.4,
+            QuantFormat::Q6K => 6.6,
+            QuantFormat::Unknown(_) => 32.0, // assume worst case
+        }
+    }
+
+    /// Block size for quantized formats (number of weights per block).
+    pub fn block_size(&self) -> usize {
+        match self {
+            QuantFormat::F32 | QuantFormat::F16 => 1,
+            QuantFormat::Q4_0 | QuantFormat::Q4_1 => 32,
+            QuantFormat::Q5_0 | QuantFormat::Q5_1 => 32,
+            QuantFormat::Q8_0 | QuantFormat::Q8_1 => 32,
+            QuantFormat::Q2K | QuantFormat::Q3K | QuantFormat::Q4K
+            | QuantFormat::Q5K | QuantFormat::Q6K => 256,
+            QuantFormat::Unknown(_) => 1,
+        }
+    }
+
+    /// Bytes required for a given number of elements in this format.
+    pub fn bytes_for_elements(&self, elements: u64) -> u64 {
+        (elements as f64 * self.bits_per_weight() as f64 / 8.0).ceil() as u64
+    }
+}
+
+/// Dequantize a Q4_0 block: 32 weights packed as 16 bytes + 2 byte scale.
+pub fn dequant_q4_0_block(block: &[u8], output: &mut [f32; 32]) {
+    // Q4_0: 2 bytes scale (f16) + 16 bytes data (32 nibbles)
+    if block.len() < 18 {
+        return;
+    }
+    let scale = f16_to_f32(u16::from_le_bytes([block[0], block[1]]));
+    for i in 0..16 {
+        let byte = block[2 + i];
+        let lo = (byte & 0x0F) as i8 - 8;
+        let hi = ((byte >> 4) & 0x0F) as i8 - 8;
+        output[i * 2] = lo as f32 * scale;
+        output[i * 2 + 1] = hi as f32 * scale;
+    }
+}
+
+/// Dequantize a Q8_0 block: 32 weights as 32 int8 values + 2 byte scale.
+pub fn dequant_q8_0_block(block: &[u8], output: &mut [f32; 32]) {
+    if block.len() < 34 {
+        return;
+    }
+    let scale = f16_to_f32(u16::from_le_bytes([block[0], block[1]]));
+    for i in 0..32 {
+        output[i] = block[2 + i] as i8 as f32 * scale;
+    }
+}
+
+/// Convert f16 (as u16 bits) to f32.
+pub fn f16_to_f32(bits: u16) -> f32 {
+    let sign = ((bits >> 15) & 1) as u32;
+    let exp = ((bits >> 10) & 0x1F) as u32;
+    let mant = (bits & 0x3FF) as u32;
+
+    if exp == 0 {
+        if mant == 0 {
+            return f32::from_bits(sign << 31);
+        }
+        // Subnormal
+        let mut mant = mant;
+        let mut exp = exp;
+        while (mant & 0x400) == 0 {
+            mant <<= 1;
+            exp = exp.wrapping_sub(1);
+        }
+        let exp = (exp.wrapping_add(127).wrapping_sub(15).wrapping_add(1)) & 0xFF;
+        let mant = (mant & 0x3FF) << 13;
+        return f32::from_bits((sign << 31) | (exp << 23) | mant);
+    }
+
+    if exp == 31 {
+        let mant = mant << 13;
+        return f32::from_bits((sign << 31) | (0xFF << 23) | mant);
+    }
+
+    let exp = (exp + 127 - 15) & 0xFF;
+    let mant = mant << 13;
+    f32::from_bits((sign << 31) | (exp << 23) | mant)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_f16_to_f32() {
+        // f16 representation of 1.0: sign=0, exp=15, mant=0 => 0x3C00
+        let val = f16_to_f32(0x3C00);
+        assert!((val - 1.0).abs() < 1e-6);
+
+        // f16 representation of 0.0
+        let val = f16_to_f32(0x0000);
+        assert_eq!(val, 0.0);
+
+        // f16 representation of -1.0: 0xBC00
+        let val = f16_to_f32(0xBC00);
+        assert!((val - (-1.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_quant_format_from_gguf() {
+        assert_eq!(QuantFormat::from_gguf_type(0), QuantFormat::F32);
+        assert_eq!(QuantFormat::from_gguf_type(2), QuantFormat::Q4_0);
+        assert_eq!(QuantFormat::from_gguf_type(8), QuantFormat::Q8_0);
+        assert_eq!(QuantFormat::from_gguf_type(999), QuantFormat::Unknown(999));
+    }
+
+    #[test]
+    fn test_dequant_q8_0() {
+        // Build a simple Q8_0 block: scale=1.0 (f16: 0x3C00), values 0..31
+        let mut block = vec![0x00, 0x3C]; // f16 1.0
+        for i in 0..32u8 {
+            block.push(i);
+        }
+        let mut output = [0.0f32; 32];
+        dequant_q8_0_block(&block, &mut output);
+        for i in 0..32 {
+            assert!((output[i] - i as f32).abs() < 1e-3, "mismatch at {i}");
+        }
+    }
+}

--- a/flare-loader/src/safetensors.rs
+++ b/flare-loader/src/safetensors.rs
@@ -1,0 +1,562 @@
+use std::collections::HashMap;
+use std::io::{self, Read, Seek, SeekFrom};
+
+use byteorder::{LittleEndian, ReadBytesExt};
+use serde::Deserialize;
+use thiserror::Error;
+
+use flare_core::tensor::Tensor;
+
+use crate::quantize::QuantFormat;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum SafeTensorsError {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("JSON header parse error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("header size {0} exceeds sanity limit ({1} bytes)")]
+    HeaderTooLarge(u64, u64),
+    #[error("tensor not found: {0}")]
+    TensorNotFound(String),
+    #[error("unsupported dtype: {0}")]
+    UnsupportedDtype(String),
+    #[error("data size mismatch for tensor \"{name}\": expected {expected} bytes, got {got}")]
+    DataSizeMismatch {
+        name: String,
+        expected: usize,
+        got: usize,
+    },
+    #[error("tensor error: {0}")]
+    Tensor(#[from] flare_core::tensor::TensorError),
+}
+
+// ---------------------------------------------------------------------------
+// Dtype
+// ---------------------------------------------------------------------------
+
+/// Data types supported in SafeTensors files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Dtype {
+    F32,
+    F16,
+    BF16,
+}
+
+impl Dtype {
+    /// Size of a single element in bytes.
+    pub fn element_size(self) -> usize {
+        match self {
+            Dtype::F32 => 4,
+            Dtype::F16 => 2,
+            Dtype::BF16 => 2,
+        }
+    }
+
+    /// Map to the closest `QuantFormat`.
+    pub fn to_quant_format(self) -> QuantFormat {
+        match self {
+            Dtype::F32 => QuantFormat::F32,
+            Dtype::F16 | Dtype::BF16 => QuantFormat::F16,
+        }
+    }
+}
+
+impl std::fmt::Display for Dtype {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Dtype::F32 => write!(f, "F32"),
+            Dtype::F16 => write!(f, "F16"),
+            Dtype::BF16 => write!(f, "BF16"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON header schema
+// ---------------------------------------------------------------------------
+
+/// Raw JSON entry for a single tensor in the header.
+#[derive(Debug, Clone, Deserialize)]
+struct RawTensorEntry {
+    dtype: Dtype,
+    shape: Vec<usize>,
+    data_offsets: [usize; 2],
+}
+
+// ---------------------------------------------------------------------------
+// Parsed types
+// ---------------------------------------------------------------------------
+
+/// Metadata for a single tensor inside a SafeTensors file.
+#[derive(Debug, Clone)]
+pub struct SafeTensorInfo {
+    pub name: String,
+    pub dtype: Dtype,
+    pub shape: Vec<usize>,
+    /// Byte offset of the first data byte, relative to the start of the
+    /// tensor-data region (i.e. right after the JSON header).
+    pub start: usize,
+    /// Byte offset one past the last data byte (exclusive), relative to the
+    /// start of the tensor-data region.
+    pub end: usize,
+}
+
+impl SafeTensorInfo {
+    /// Total number of elements.
+    pub fn numel(&self) -> usize {
+        self.shape.iter().product::<usize>().max(1)
+    }
+
+    /// Expected byte length of the raw data.
+    pub fn byte_len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+/// A parsed SafeTensors file header.  Tensor data is read lazily via offsets.
+#[derive(Debug)]
+pub struct SafeTensorsFile {
+    /// Optional string-to-string metadata embedded in the header.
+    pub metadata: HashMap<String, String>,
+    /// Tensor descriptors, keyed by name.
+    pub tensors: HashMap<String, SafeTensorInfo>,
+    /// Absolute byte offset in the file where the tensor data region begins
+    /// (immediately after the JSON header).
+    pub data_offset: u64,
+}
+
+impl SafeTensorsFile {
+    // Maximum header size we are willing to allocate (256 MiB).
+    const MAX_HEADER_SIZE: u64 = 256 * 1024 * 1024;
+
+    /// Parse the SafeTensors header from a reader.
+    ///
+    /// This only reads the 8-byte length prefix and the JSON header; it does
+    /// NOT read any tensor data.
+    pub fn parse_header<R: Read + Seek>(reader: &mut R) -> Result<Self, SafeTensorsError> {
+        // 1. Read the 8-byte header size (u64 LE).
+        let header_size = reader.read_u64::<LittleEndian>()?;
+        if header_size > Self::MAX_HEADER_SIZE {
+            return Err(SafeTensorsError::HeaderTooLarge(
+                header_size,
+                Self::MAX_HEADER_SIZE,
+            ));
+        }
+
+        // 2. Read the JSON header bytes.
+        let mut header_buf = vec![0u8; header_size as usize];
+        reader.read_exact(&mut header_buf)?;
+
+        // The tensor data starts right after the header.
+        let data_offset = 8 + header_size;
+
+        // 3. Deserialize as a map of string → raw JSON value so we can
+        //    separate `__metadata__` from tensor entries.
+        let raw_map: HashMap<String, serde_json::Value> = serde_json::from_slice(&header_buf)?;
+
+        let mut metadata = HashMap::new();
+        let mut tensors = HashMap::new();
+
+        for (key, value) in raw_map {
+            if key == "__metadata__" {
+                // Parse the metadata object as string→string.
+                if let serde_json::Value::Object(map) = value {
+                    for (mk, mv) in map {
+                        if let serde_json::Value::String(s) = mv {
+                            metadata.insert(mk, s);
+                        }
+                    }
+                }
+            } else {
+                // Parse as a tensor entry.
+                let entry: RawTensorEntry = serde_json::from_value(value)?;
+                tensors.insert(
+                    key.clone(),
+                    SafeTensorInfo {
+                        name: key,
+                        dtype: entry.dtype,
+                        shape: entry.shape,
+                        start: entry.data_offsets[0],
+                        end: entry.data_offsets[1],
+                    },
+                );
+            }
+        }
+
+        Ok(Self {
+            metadata,
+            tensors,
+            data_offset,
+        })
+    }
+
+    /// Look up a tensor by name.
+    pub fn find_tensor(&self, name: &str) -> Option<&SafeTensorInfo> {
+        self.tensors.get(name)
+    }
+
+    /// Return an iterator over all tensor names.
+    pub fn tensor_names(&self) -> impl Iterator<Item = &str> {
+        self.tensors.keys().map(|s| s.as_str())
+    }
+
+    /// Read raw bytes for a specific tensor from the reader.
+    pub fn read_tensor_data<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        name: &str,
+    ) -> Result<Vec<u8>, SafeTensorsError> {
+        let info = self
+            .tensors
+            .get(name)
+            .ok_or_else(|| SafeTensorsError::TensorNotFound(name.to_owned()))?;
+
+        let abs_start = self.data_offset + info.start as u64;
+        reader.seek(SeekFrom::Start(abs_start))?;
+
+        let len = info.byte_len();
+        let mut buf = vec![0u8; len];
+        reader.read_exact(&mut buf)?;
+        Ok(buf)
+    }
+
+    /// Read a tensor and convert it to a `flare_core::tensor::Tensor` (f32).
+    ///
+    /// F16 and BF16 data are dequantized to f32 on the fly.
+    pub fn read_tensor<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        name: &str,
+    ) -> Result<Tensor, SafeTensorsError> {
+        let info = self
+            .tensors
+            .get(name)
+            .ok_or_else(|| SafeTensorsError::TensorNotFound(name.to_owned()))?;
+
+        let numel = info.numel();
+        let expected_bytes = numel * info.dtype.element_size();
+        if info.byte_len() != expected_bytes {
+            return Err(SafeTensorsError::DataSizeMismatch {
+                name: name.to_owned(),
+                expected: expected_bytes,
+                got: info.byte_len(),
+            });
+        }
+
+        let raw = self.read_tensor_data(reader, name)?;
+        let f32_data = decode_to_f32(&raw, info.dtype, numel)?;
+        let tensor = Tensor::from_vec(f32_data, &info.shape)?;
+        Ok(tensor)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decoding helpers
+// ---------------------------------------------------------------------------
+
+/// Decode raw bytes into a Vec<f32> according to `dtype`.
+fn decode_to_f32(
+    data: &[u8],
+    dtype: Dtype,
+    numel: usize,
+) -> Result<Vec<f32>, SafeTensorsError> {
+    match dtype {
+        Dtype::F32 => {
+            let mut out = vec![0f32; numel];
+            // Safe: we have verified that data.len() == numel * 4.
+            for (i, chunk) in data.chunks_exact(4).enumerate() {
+                out[i] = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            }
+            Ok(out)
+        }
+        Dtype::F16 => {
+            let mut out = Vec::with_capacity(numel);
+            for chunk in data.chunks_exact(2) {
+                let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
+                out.push(f16_to_f32(bits));
+            }
+            Ok(out)
+        }
+        Dtype::BF16 => {
+            let mut out = Vec::with_capacity(numel);
+            for chunk in data.chunks_exact(2) {
+                let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
+                out.push(bf16_to_f32(bits));
+            }
+            Ok(out)
+        }
+    }
+}
+
+/// Convert IEEE 754 half-precision (binary16) bits to f32.
+fn f16_to_f32(bits: u16) -> f32 {
+    let sign = ((bits >> 15) & 1) as u32;
+    let exp = ((bits >> 10) & 0x1F) as u32;
+    let mant = (bits & 0x3FF) as u32;
+
+    if exp == 0 {
+        if mant == 0 {
+            return f32::from_bits(sign << 31);
+        }
+        // Subnormal f16 → normalise.
+        let mut m = mant;
+        let mut e = 0u32;
+        while (m & 0x400) == 0 {
+            m <<= 1;
+            e = e.wrapping_add(1);
+        }
+        let exp32 = 127u32.wrapping_sub(15).wrapping_sub(e).wrapping_add(1);
+        let mant32 = (m & 0x3FF) << 13;
+        return f32::from_bits((sign << 31) | (exp32 << 23) | mant32);
+    }
+    if exp == 31 {
+        // Inf / NaN
+        return f32::from_bits((sign << 31) | (0xFF << 23) | (mant << 13));
+    }
+
+    let exp32 = exp + 127 - 15;
+    let mant32 = mant << 13;
+    f32::from_bits((sign << 31) | (exp32 << 23) | mant32)
+}
+
+/// Convert bfloat16 bits to f32.
+///
+/// bfloat16 is simply the upper 16 bits of an f32, so conversion is a
+/// left-shift by 16.
+fn bf16_to_f32(bits: u16) -> f32 {
+    f32::from_bits((bits as u32) << 16)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// Build a minimal SafeTensors file in memory and return the bytes.
+    fn build_safetensors(
+        tensors: &[(&str, Dtype, &[usize], &[u8])],
+        metadata: Option<&[(&str, &str)]>,
+    ) -> Vec<u8> {
+        // Compute data offsets and build the JSON header map.
+        let mut header_map = serde_json::Map::new();
+
+        if let Some(meta) = metadata {
+            let mut m = serde_json::Map::new();
+            for (k, v) in meta {
+                m.insert(k.to_string(), serde_json::Value::String(v.to_string()));
+            }
+            header_map.insert(
+                "__metadata__".to_string(),
+                serde_json::Value::Object(m),
+            );
+        }
+
+        let mut offset = 0usize;
+        let mut all_data: Vec<u8> = Vec::new();
+        for (name, dtype, shape, data) in tensors {
+            let start = offset;
+            let end = start + data.len();
+            offset = end;
+
+            let dtype_str = match dtype {
+                Dtype::F32 => "F32",
+                Dtype::F16 => "F16",
+                Dtype::BF16 => "BF16",
+            };
+
+            let entry = serde_json::json!({
+                "dtype": dtype_str,
+                "shape": shape,
+                "data_offsets": [start, end],
+            });
+            header_map.insert(name.to_string(), entry);
+            all_data.extend_from_slice(data);
+        }
+
+        let header_json = serde_json::to_string(&serde_json::Value::Object(header_map)).unwrap();
+        let header_bytes = header_json.as_bytes();
+        let header_len = header_bytes.len() as u64;
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&header_len.to_le_bytes());
+        buf.extend_from_slice(header_bytes);
+        buf.extend_from_slice(&all_data);
+        buf
+    }
+
+    #[test]
+    fn test_parse_empty() {
+        let file_bytes = build_safetensors(&[], None);
+        let mut cursor = Cursor::new(file_bytes);
+        let st = SafeTensorsFile::parse_header(&mut cursor).unwrap();
+        assert!(st.tensors.is_empty());
+        assert!(st.metadata.is_empty());
+    }
+
+    #[test]
+    fn test_parse_metadata() {
+        let file_bytes = build_safetensors(&[], Some(&[("format", "pt"), ("version", "1")]));
+        let mut cursor = Cursor::new(file_bytes);
+        let st = SafeTensorsFile::parse_header(&mut cursor).unwrap();
+        assert_eq!(st.metadata.get("format").unwrap(), "pt");
+        assert_eq!(st.metadata.get("version").unwrap(), "1");
+    }
+
+    #[test]
+    fn test_read_f32_tensor() {
+        let values: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let raw: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+
+        let file_bytes = build_safetensors(&[("weight", Dtype::F32, &[2, 3], &raw)], None);
+        let mut cursor = Cursor::new(file_bytes);
+        let st = SafeTensorsFile::parse_header(&mut cursor).unwrap();
+
+        assert!(st.find_tensor("weight").is_some());
+        let info = st.find_tensor("weight").unwrap();
+        assert_eq!(info.dtype, Dtype::F32);
+        assert_eq!(info.shape, vec![2, 3]);
+        assert_eq!(info.numel(), 6);
+
+        let tensor = st.read_tensor(&mut cursor, "weight").unwrap();
+        assert_eq!(tensor.shape(), &[2, 3]);
+        assert_eq!(tensor.data(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn test_read_f16_tensor() {
+        // f16 1.0 = 0x3C00
+        let raw: Vec<u8> = vec![0x00, 0x3C, 0x00, 0x40]; // [1.0, 2.0] in f16
+        let file_bytes = build_safetensors(&[("bias", Dtype::F16, &[2], &raw)], None);
+        let mut cursor = Cursor::new(file_bytes);
+        let st = SafeTensorsFile::parse_header(&mut cursor).unwrap();
+
+        let tensor = st.read_tensor(&mut cursor, "bias").unwrap();
+        assert_eq!(tensor.shape(), &[2]);
+        assert!((tensor.data()[0] - 1.0).abs() < 1e-3);
+        assert!((tensor.data()[1] - 2.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_read_bf16_tensor() {
+        // bf16 is upper 16 bits of f32.
+        // f32 1.0 = 0x3F80_0000 → bf16 = 0x3F80
+        // f32 -2.0 = 0xC000_0000 → bf16 = 0xC000
+        let raw: Vec<u8> = vec![0x80, 0x3F, 0x00, 0xC0];
+        let file_bytes = build_safetensors(&[("x", Dtype::BF16, &[2], &raw)], None);
+        let mut cursor = Cursor::new(file_bytes);
+        let st = SafeTensorsFile::parse_header(&mut cursor).unwrap();
+
+        let tensor = st.read_tensor(&mut cursor, "x").unwrap();
+        assert_eq!(tensor.shape(), &[2]);
+        assert!((tensor.data()[0] - 1.0).abs() < 1e-3);
+        assert!((tensor.data()[1] - (-2.0)).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_multiple_tensors() {
+        let w_data: Vec<u8> = vec![1.0f32, 2.0]
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
+        let b_data: Vec<u8> = vec![0.5f32]
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
+
+        let file_bytes = build_safetensors(
+            &[
+                ("weight", Dtype::F32, &[2], &w_data),
+                ("bias", Dtype::F32, &[1], &b_data),
+            ],
+            None,
+        );
+        let mut cursor = Cursor::new(file_bytes);
+        let st = SafeTensorsFile::parse_header(&mut cursor).unwrap();
+        assert_eq!(st.tensors.len(), 2);
+
+        let w = st.read_tensor(&mut cursor, "weight").unwrap();
+        assert_eq!(w.data(), &[1.0, 2.0]);
+
+        let b = st.read_tensor(&mut cursor, "bias").unwrap();
+        assert_eq!(b.data(), &[0.5]);
+    }
+
+    #[test]
+    fn test_tensor_not_found() {
+        let file_bytes = build_safetensors(&[], None);
+        let mut cursor = Cursor::new(file_bytes);
+        let st = SafeTensorsFile::parse_header(&mut cursor).unwrap();
+
+        let err = st.read_tensor(&mut cursor, "nope").unwrap_err();
+        assert!(matches!(err, SafeTensorsError::TensorNotFound(_)));
+    }
+
+    #[test]
+    fn test_header_too_large() {
+        // Write a header size that exceeds the limit.
+        let huge_size: u64 = 512 * 1024 * 1024;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&huge_size.to_le_bytes());
+        // Don't need actual data; parse should fail early.
+        buf.extend_from_slice(&[0u8; 64]);
+
+        let mut cursor = Cursor::new(buf);
+        let err = SafeTensorsFile::parse_header(&mut cursor).unwrap_err();
+        assert!(matches!(err, SafeTensorsError::HeaderTooLarge(_, _)));
+    }
+
+    #[test]
+    fn test_tensor_names() {
+        let data: Vec<u8> = 1.0f32.to_le_bytes().to_vec();
+        let file_bytes = build_safetensors(
+            &[
+                ("a", Dtype::F32, &[1], &data),
+                ("b", Dtype::F32, &[1], &data),
+            ],
+            None,
+        );
+        let mut cursor = Cursor::new(file_bytes);
+        let st = SafeTensorsFile::parse_header(&mut cursor).unwrap();
+
+        let mut names: Vec<&str> = st.tensor_names().collect();
+        names.sort();
+        assert_eq!(names, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_f16_conversion_roundtrip() {
+        assert!((f16_to_f32(0x3C00) - 1.0).abs() < 1e-6);
+        assert_eq!(f16_to_f32(0x0000), 0.0);
+        assert!((f16_to_f32(0xBC00) - (-1.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_bf16_conversion() {
+        assert!((bf16_to_f32(0x3F80) - 1.0).abs() < 1e-6);
+        assert_eq!(bf16_to_f32(0x0000), 0.0);
+        assert!((bf16_to_f32(0xBF80) - (-1.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_read_tensor_data_raw() {
+        let values: Vec<f32> = vec![42.0, 99.0];
+        let raw: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let file_bytes = build_safetensors(&[("t", Dtype::F32, &[2], &raw)], None);
+        let mut cursor = Cursor::new(file_bytes);
+        let st = SafeTensorsFile::parse_header(&mut cursor).unwrap();
+
+        let data = st.read_tensor_data(&mut cursor, "t").unwrap();
+        assert_eq!(data.len(), 8);
+        assert_eq!(data, raw);
+    }
+}

--- a/flare-loader/src/weights.rs
+++ b/flare-loader/src/weights.rs
@@ -1,0 +1,130 @@
+use std::collections::HashMap;
+use std::io::{Read, Seek};
+
+use flare_core::model::{LayerWeights, ModelWeights};
+use flare_core::tensor::Tensor;
+
+use crate::gguf::{GgufError, GgufFile};
+
+/// Load ModelWeights from a parsed GGUF file.
+///
+/// Maps GGUF tensor names (e.g., "blk.0.attn_q.weight") to the
+/// LayerWeights / ModelWeights structure expected by the model.
+pub fn load_model_weights<R: Read + Seek>(
+    gguf: &GgufFile,
+    reader: &mut R,
+) -> Result<ModelWeights, GgufError> {
+    let tensors = gguf.load_all_tensors(reader)?;
+    let config = gguf.to_model_config()?;
+
+    // Token embedding — try common name variants
+    let token_embedding = find_tensor(&tensors, &[
+        "token_embd.weight",
+        "model.embed_tokens.weight",
+    ])?;
+
+    // Output norm
+    let output_norm = find_tensor(&tensors, &[
+        "output_norm.weight",
+        "model.norm.weight",
+    ])?;
+
+    // Output projection — may share weights with embedding
+    let output_weight = find_tensor(&tensors, &[
+        "output.weight",
+        "lm_head.weight",
+    ]).unwrap_or_else(|_| token_embedding.clone());
+
+    // Load layer weights
+    let mut layers = Vec::with_capacity(config.num_layers);
+    for i in 0..config.num_layers {
+        let layer = load_layer_weights(&tensors, i)?;
+        layers.push(layer);
+    }
+
+    Ok(ModelWeights {
+        token_embedding,
+        layers,
+        output_norm,
+        output_weight,
+    })
+}
+
+fn load_layer_weights(
+    tensors: &HashMap<String, Tensor>,
+    layer_idx: usize,
+) -> Result<LayerWeights, GgufError> {
+    let i = layer_idx;
+
+    let attn_norm = find_tensor(tensors, &[
+        &format!("blk.{i}.attn_norm.weight"),
+        &format!("model.layers.{i}.input_layernorm.weight"),
+    ])?;
+
+    let wq = find_tensor(tensors, &[
+        &format!("blk.{i}.attn_q.weight"),
+        &format!("model.layers.{i}.self_attn.q_proj.weight"),
+    ])?;
+
+    let wk = find_tensor(tensors, &[
+        &format!("blk.{i}.attn_k.weight"),
+        &format!("model.layers.{i}.self_attn.k_proj.weight"),
+    ])?;
+
+    let wv = find_tensor(tensors, &[
+        &format!("blk.{i}.attn_v.weight"),
+        &format!("model.layers.{i}.self_attn.v_proj.weight"),
+    ])?;
+
+    let wo = find_tensor(tensors, &[
+        &format!("blk.{i}.attn_output.weight"),
+        &format!("model.layers.{i}.self_attn.o_proj.weight"),
+    ])?;
+
+    let ffn_norm = find_tensor(tensors, &[
+        &format!("blk.{i}.ffn_norm.weight"),
+        &format!("model.layers.{i}.post_attention_layernorm.weight"),
+    ])?;
+
+    let w_gate = find_tensor(tensors, &[
+        &format!("blk.{i}.ffn_gate.weight"),
+        &format!("model.layers.{i}.mlp.gate_proj.weight"),
+    ])?;
+
+    let w_up = find_tensor(tensors, &[
+        &format!("blk.{i}.ffn_up.weight"),
+        &format!("model.layers.{i}.mlp.up_proj.weight"),
+    ])?;
+
+    let w_down = find_tensor(tensors, &[
+        &format!("blk.{i}.ffn_down.weight"),
+        &format!("model.layers.{i}.mlp.down_proj.weight"),
+    ])?;
+
+    Ok(LayerWeights {
+        attn_norm,
+        wq,
+        wk,
+        wv,
+        wo,
+        ffn_norm,
+        w_gate,
+        w_up,
+        w_down,
+    })
+}
+
+/// Try multiple name variants and return the first matching tensor.
+fn find_tensor(
+    tensors: &HashMap<String, Tensor>,
+    names: &[&str],
+) -> Result<Tensor, GgufError> {
+    for name in names {
+        if let Some(t) = tensors.get(*name) {
+            return Ok(t.clone());
+        }
+    }
+    Err(GgufError::TensorNotFound(
+        names.iter().map(|s| s.to_string()).collect::<Vec<_>>().join(" | "),
+    ))
+}


### PR DESCRIPTION
## Summary
- **GGUF parser**: v2/v3 header parsing, full metadata extraction, tensor info with offsets
- **Config extraction**: GGUF metadata → `ModelConfig` for Llama, Qwen2, Mistral architectures
- **Tensor loading**: read tensor data with on-the-fly dequantization (F32, F16, Q4_0, Q8_0)
- **SafeTensors parser**: header parsing, F32/F16/BF16 tensor reading
- **Quantization**: block dequantization for Q4_0 and Q8_0, f16↔f32 conversion
- **Weight mapper**: maps GGUF tensor names (e.g. `blk.0.attn_q.weight`) to `ModelWeights`

## Test plan
- [x] 18 unit tests pass (`cargo test -p flare-loader`)
- [x] GGUF parsing with metadata and tensor info
- [x] SafeTensors F32/F16/BF16 roundtrip tests
- [x] Q8_0 dequantization accuracy
- [x] f16 conversion accuracy