### PR TITLE
Add flare-gpu and flare-simd compute backends

### DIFF
--- a/flare-gpu/Cargo.toml
+++ b/flare-gpu/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "flare-gpu"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "WebGPU/wgpu compute backend for Flare LLM inference"
+
+[dependencies]
+flare-core = { path = "../flare-core" }
+wgpu = { workspace = true }
+thiserror = { workspace = true }
+log = { workspace = true }
+byteorder = { workspace = true }

--- a/flare-gpu/shaders/matmul.wgsl
+++ b/flare-gpu/shaders/matmul.wgsl
@@ -1,0 +1,58 @@
+// Tiled matrix multiply — the core LLM inference kernel.
+// Tile size chosen for WebGPU workgroup limits (256 max invocations).
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> result: array<f32>;
+
+struct Params {
+    M: u32,
+    N: u32,
+    K: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+const TILE_SIZE: u32 = 16u;
+var<workgroup> tile_a: array<array<f32, 16>, 16>;
+var<workgroup> tile_b: array<array<f32, 16>, 16>;
+
+@compute @workgroup_size(16, 16)
+fn matmul(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+    @builtin(local_invocation_id) lid: vec3<u32>,
+) {
+    let row = gid.x;
+    let col = gid.y;
+    var sum: f32 = 0.0;
+
+    let num_tiles = (params.K + TILE_SIZE - 1u) / TILE_SIZE;
+
+    for (var t: u32 = 0u; t < num_tiles; t = t + 1u) {
+        let a_col = t * TILE_SIZE + lid.y;
+        let b_row = t * TILE_SIZE + lid.x;
+
+        if (row < params.M && a_col < params.K) {
+            tile_a[lid.x][lid.y] = a[row * params.K + a_col];
+        } else {
+            tile_a[lid.x][lid.y] = 0.0;
+        }
+
+        if (b_row < params.K && col < params.N) {
+            tile_b[lid.x][lid.y] = b[b_row * params.N + col];
+        } else {
+            tile_b[lid.x][lid.y] = 0.0;
+        }
+
+        workgroupBarrier();
+
+        for (var k: u32 = 0u; k < TILE_SIZE; k = k + 1u) {
+            sum = sum + tile_a[lid.x][k] * tile_b[k][lid.y];
+        }
+
+        workgroupBarrier();
+    }
+
+    if (row < params.M && col < params.N) {
+        result[row * params.N + col] = sum;
+    }
+}

--- a/flare-gpu/shaders/rmsnorm.wgsl
+++ b/flare-gpu/shaders/rmsnorm.wgsl
@@ -1,0 +1,35 @@
+// Fused RMSNorm + residual add.
+// Each workgroup processes one row of the input.
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read> residual: array<f32>;
+@group(0) @binding(2) var<storage, read> weight: array<f32>;
+@group(0) @binding(3) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    hidden_dim: u32,
+    eps: f32,
+}
+@group(0) @binding(4) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn fused_rmsnorm_residual(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+    let row = gid.x;
+    let dim = params.hidden_dim;
+
+    // Compute sum of squares
+    var sum_sq: f32 = 0.0;
+    for (var i: u32 = 0u; i < dim; i = i + 1u) {
+        let val = input[row * dim + i] + residual[row * dim + i];
+        sum_sq = sum_sq + val * val;
+    }
+    let rms = sqrt(sum_sq / f32(dim) + params.eps);
+
+    // Normalize and scale
+    for (var i: u32 = 0u; i < dim; i = i + 1u) {
+        let val = input[row * dim + i] + residual[row * dim + i];
+        output[row * dim + i] = (val / rms) * weight[i];
+    }
+}

--- a/flare-gpu/shaders/rope.wgsl
+++ b/flare-gpu/shaders/rope.wgsl
@@ -1,0 +1,39 @@
+// Rotary Position Embedding (RoPE).
+
+@group(0) @binding(0) var<storage, read_write> q: array<f32>;
+@group(0) @binding(1) var<storage, read_write> k: array<f32>;
+
+struct Params {
+    head_dim: u32,
+    position: u32,
+    theta: f32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(64)
+fn rope_embedding(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+    let idx = gid.x;
+    let head_dim = params.head_dim;
+    let half = head_dim / 2u;
+    let pos = params.position;
+
+    let i = idx % half;
+    let freq = 1.0 / pow(params.theta, f32(2u * i) / f32(head_dim));
+    let angle = f32(pos) * freq;
+    let cos_val = cos(angle);
+    let sin_val = sin(angle);
+
+    // Apply to Q
+    let q0 = q[idx];
+    let q1 = q[idx + half];
+    q[idx]        = q0 * cos_val - q1 * sin_val;
+    q[idx + half] = q0 * sin_val + q1 * cos_val;
+
+    // Apply to K
+    let k0 = k[idx];
+    let k1 = k[idx + half];
+    k[idx]        = k0 * cos_val - k1 * sin_val;
+    k[idx + half] = k0 * sin_val + k1 * cos_val;
+}

--- a/flare-gpu/shaders/silu_mul.wgsl
+++ b/flare-gpu/shaders/silu_mul.wgsl
@@ -1,0 +1,25 @@
+// SiLU activation fused with element-wise multiply.
+// Used in the FFN: output = SiLU(gate) * up
+
+@group(0) @binding(0) var<storage, read> gate: array<f32>;
+@group(0) @binding(1) var<storage, read> up: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    size: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn silu_mul(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+    let idx = gid.x;
+    if (idx >= params.size) {
+        return;
+    }
+
+    let x = gate[idx];
+    let silu = x / (1.0 + exp(-x)); // SiLU(x) = x * sigmoid(x)
+    output[idx] = silu * up[idx];
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -1,0 +1,87 @@
+use flare_core::model::ComputeBackend;
+use flare_core::tensor::Tensor;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GpuError {
+    #[error("no suitable GPU adapter found")]
+    NoAdapter,
+    #[error("failed to request GPU device: {0}")]
+    DeviceRequest(String),
+    #[error("shader compilation error: {0}")]
+    ShaderError(String),
+    #[error("buffer operation error: {0}")]
+    BufferError(String),
+}
+
+/// WebGPU/wgpu compute backend.
+///
+/// On native, this uses Vulkan/Metal/DX12 via wgpu.
+/// In the browser (WASM), this uses WebGPU via wgpu's web backend.
+pub struct WebGpuBackend {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+}
+
+impl WebGpuBackend {
+    /// Create a new GPU backend. This is async because adapter/device
+    /// request is async on both native and web.
+    pub async fn new() -> Result<Self, GpuError> {
+        let instance = wgpu::Instance::default();
+
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter: false,
+            })
+            .await
+            .ok_or(GpuError::NoAdapter)?;
+
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("flare-gpu"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: wgpu::Limits::default(),
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .map_err(|e| GpuError::DeviceRequest(e.to_string()))?;
+
+        Ok(Self { device, queue })
+    }
+
+    pub fn device(&self) -> &wgpu::Device {
+        &self.device
+    }
+
+    pub fn queue(&self) -> &wgpu::Queue {
+        &self.queue
+    }
+}
+
+impl ComputeBackend for WebGpuBackend {
+    fn matmul(&self, _a: &Tensor, _b: &Tensor, _output: &mut Tensor) {
+        // TODO: dispatch matmul.wgsl compute shader
+        todo!("GPU matmul not yet implemented")
+    }
+
+    fn rmsnorm(&self, _input: &Tensor, _weight: &Tensor, _eps: f32, _output: &mut Tensor) {
+        todo!("GPU rmsnorm not yet implemented")
+    }
+
+    fn rope(&self, _q: &mut Tensor, _k: &mut Tensor, _pos: usize, _head_dim: usize, _theta: f32) {
+        todo!("GPU RoPE not yet implemented")
+    }
+
+    fn softmax(&self, _input: &mut Tensor) {
+        todo!("GPU softmax not yet implemented")
+    }
+
+    fn silu_mul(&self, _gate: &Tensor, _up: &Tensor, _output: &mut Tensor) {
+        todo!("GPU SiLU*mul not yet implemented")
+    }
+}

--- a/flare-gpu/src/buffers.rs
+++ b/flare-gpu/src/buffers.rs
@@ -1,0 +1,39 @@
+use wgpu::util::DeviceExt;
+
+/// Create a GPU storage buffer from CPU data.
+pub fn create_storage_buffer(device: &wgpu::Device, label: &str, data: &[u8]) -> wgpu::Buffer {
+    device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some(label),
+        contents: data,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+    })
+}
+
+/// Create an empty GPU storage buffer for output.
+pub fn create_output_buffer(device: &wgpu::Device, label: &str, size: u64) -> wgpu::Buffer {
+    device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        size,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    })
+}
+
+/// Create a uniform buffer for shader parameters.
+pub fn create_uniform_buffer(device: &wgpu::Device, label: &str, data: &[u8]) -> wgpu::Buffer {
+    device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some(label),
+        contents: data,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+    })
+}
+
+/// Create a staging buffer for reading back GPU results to CPU.
+pub fn create_staging_buffer(device: &wgpu::Device, label: &str, size: u64) -> wgpu::Buffer {
+    device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        size,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    })
+}

--- a/flare-gpu/src/lib.rs
+++ b/flare-gpu/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod backend;
+pub mod buffers;
+pub mod pipeline;
+
+pub use backend::WebGpuBackend;

--- a/flare-gpu/src/pipeline.rs
+++ b/flare-gpu/src/pipeline.rs
@@ -1,0 +1,49 @@
+use std::collections::HashMap;
+
+/// Cache for compiled compute pipelines to avoid recompilation.
+pub struct PipelineCache {
+    pipelines: HashMap<String, wgpu::ComputePipeline>,
+}
+
+impl PipelineCache {
+    pub fn new() -> Self {
+        Self {
+            pipelines: HashMap::new(),
+        }
+    }
+
+    /// Get or create a compute pipeline from WGSL source.
+    pub fn get_or_create(
+        &mut self,
+        device: &wgpu::Device,
+        name: &str,
+        shader_source: &str,
+        entry_point: &str,
+    ) -> &wgpu::ComputePipeline {
+        if !self.pipelines.contains_key(name) {
+            let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(name),
+                source: wgpu::ShaderSource::Wgsl(shader_source.into()),
+            });
+
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some(&format!("{name}_layout")),
+                bind_group_layouts: &[],
+                push_constant_ranges: &[],
+            });
+
+            let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some(name),
+                layout: Some(&pipeline_layout),
+                module: &shader_module,
+                entry_point: Some(entry_point),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+
+            self.pipelines.insert(name.to_string(), pipeline);
+        }
+
+        &self.pipelines[name]
+    }
+}

--- a/flare-simd/Cargo.toml
+++ b/flare-simd/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "flare-simd"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "WASM SIMD128 CPU fallback backend for Flare LLM inference"
+
+[dependencies]
+flare-core = { path = "../flare-core" }
+thiserror = { workspace = true }
+log = { workspace = true }

--- a/flare-simd/src/backend.rs
+++ b/flare-simd/src/backend.rs
@@ -1,0 +1,91 @@
+use flare_core::model::ComputeBackend;
+use flare_core::tensor::Tensor;
+
+/// WASM SIMD128 CPU fallback backend.
+/// Used when WebGPU is not available.
+pub struct SimdBackend;
+
+impl SimdBackend {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SimdBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ComputeBackend for SimdBackend {
+    fn matmul(&self, a: &Tensor, b: &Tensor, output: &mut Tensor) {
+        crate::matmul::matmul_cpu(a, b, output);
+    }
+
+    fn rmsnorm(&self, input: &Tensor, weight: &Tensor, eps: f32, output: &mut Tensor) {
+        let data = input.data();
+        let w = weight.data();
+        let out = output.data_mut();
+        let dim = w.len();
+
+        // Process each row
+        let num_rows = data.len() / dim;
+        for row in 0..num_rows {
+            let offset = row * dim;
+            let row_data = &data[offset..offset + dim];
+
+            let sum_sq: f32 = row_data.iter().map(|x| x * x).sum();
+            let rms = (sum_sq / dim as f32 + eps).sqrt();
+
+            for i in 0..dim {
+                out[offset + i] = (row_data[i] / rms) * w[i];
+            }
+        }
+    }
+
+    fn rope(&self, q: &mut Tensor, k: &mut Tensor, pos: usize, head_dim: usize, theta: f32) {
+        let half = head_dim / 2;
+
+        for i in 0..half {
+            let freq = 1.0 / theta.powf(2.0 * i as f32 / head_dim as f32);
+            let angle = pos as f32 * freq;
+            let cos_val = angle.cos();
+            let sin_val = angle.sin();
+
+            let q_data = q.data_mut();
+            let q0 = q_data[i];
+            let q1 = q_data[i + half];
+            q_data[i] = q0 * cos_val - q1 * sin_val;
+            q_data[i + half] = q0 * sin_val + q1 * cos_val;
+
+            let k_data = k.data_mut();
+            let k0 = k_data[i];
+            let k1 = k_data[i + half];
+            k_data[i] = k0 * cos_val - k1 * sin_val;
+            k_data[i + half] = k0 * sin_val + k1 * cos_val;
+        }
+    }
+
+    fn softmax(&self, input: &mut Tensor) {
+        let data = input.data_mut();
+        let max = data.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let mut sum = 0.0f32;
+        for v in data.iter_mut() {
+            *v = (*v - max).exp();
+            sum += *v;
+        }
+        for v in data.iter_mut() {
+            *v /= sum;
+        }
+    }
+
+    fn silu_mul(&self, gate: &Tensor, up: &Tensor, output: &mut Tensor) {
+        let g = gate.data();
+        let u = up.data();
+        let o = output.data_mut();
+        for i in 0..g.len() {
+            let silu = g[i] / (1.0 + (-g[i]).exp());
+            o[i] = silu * u[i];
+        }
+    }
+}

--- a/flare-simd/src/lib.rs
+++ b/flare-simd/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod backend;
+pub mod matmul;
+
+pub use backend::SimdBackend;

--- a/flare-simd/src/matmul.rs
+++ b/flare-simd/src/matmul.rs
@@ -1,0 +1,91 @@
+use flare_core::tensor::Tensor;
+
+/// CPU matrix multiply: C = A × B
+/// A is [M, K], B is [K, N], C is [M, N]
+///
+/// Uses a simple tiled approach for cache locality.
+/// On WASM targets with SIMD, the compiler auto-vectorizes the inner loop.
+pub fn matmul_cpu(a: &Tensor, b: &Tensor, output: &mut Tensor) {
+    let a_shape = a.shape();
+    let b_shape = b.shape();
+
+    assert!(a_shape.len() == 2 && b_shape.len() == 2, "matmul requires 2D tensors");
+    assert_eq!(a_shape[1], b_shape[0], "inner dimensions must match");
+
+    let m = a_shape[0];
+    let k = a_shape[1];
+    let n = b_shape[1];
+
+    let a_data = a.data();
+    let b_data = b.data();
+    let c_data = output.data_mut();
+
+    // Zero output
+    for v in c_data.iter_mut() {
+        *v = 0.0;
+    }
+
+    // Tiled multiply for cache locality
+    const TILE: usize = 32;
+
+    for i0 in (0..m).step_by(TILE) {
+        for j0 in (0..n).step_by(TILE) {
+            for k0 in (0..k).step_by(TILE) {
+                let i_end = (i0 + TILE).min(m);
+                let j_end = (j0 + TILE).min(n);
+                let k_end = (k0 + TILE).min(k);
+
+                for i in i0..i_end {
+                    for kk in k0..k_end {
+                        let a_val = a_data[i * k + kk];
+                        for j in j0..j_end {
+                            c_data[i * n + j] += a_val * b_data[kk * n + j];
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flare_core::tensor::Tensor;
+
+    #[test]
+    fn test_matmul_identity() {
+        // A = [[1,0],[0,1]], B = [[3,4],[5,6]]
+        let a = Tensor::from_vec(vec![1.0, 0.0, 0.0, 1.0], &[2, 2]).unwrap();
+        let b = Tensor::from_vec(vec![3.0, 4.0, 5.0, 6.0], &[2, 2]).unwrap();
+        let mut c = Tensor::zeros(&[2, 2]);
+        matmul_cpu(&a, &b, &mut c);
+        assert_eq!(c.data(), &[3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn test_matmul_basic() {
+        // [1,2,3] x [4,5,6,7,8,9] (1x3 * 3x2 = 1x2)
+        let a = Tensor::from_vec(vec![1.0, 2.0, 3.0], &[1, 3]).unwrap();
+        let b = Tensor::from_vec(vec![4.0, 5.0, 6.0, 7.0, 8.0, 9.0], &[3, 2]).unwrap();
+        let mut c = Tensor::zeros(&[1, 2]);
+        matmul_cpu(&a, &b, &mut c);
+        // [1*4+2*6+3*8, 1*5+2*7+3*9] = [40, 46]
+        assert_eq!(c.data(), &[40.0, 46.0]);
+    }
+
+    #[test]
+    fn test_matmul_larger() {
+        // 4x3 * 3x4
+        let a = Tensor::from_vec((0..12).map(|i| i as f32).collect(), &[4, 3]).unwrap();
+        let b = Tensor::from_vec((0..12).map(|i| i as f32).collect(), &[3, 4]).unwrap();
+        let mut c = Tensor::zeros(&[4, 4]);
+        matmul_cpu(&a, &b, &mut c);
+
+        // Verify dimensions
+        assert_eq!(c.shape(), &[4, 4]);
+
+        // Spot check: C[0,0] = 0*0 + 1*4 + 2*8 = 20
+        assert!((c.data()[0] - 20.0).abs() < 1e-5);
+    }
+}


### PR DESCRIPTION
## Summary
- **flare-gpu**: wgpu-based WebGPU/native GPU backend
  - Pipeline cache for compiled compute shaders
  - GPU buffer helpers (storage, uniform, staging, output)
  - WGSL shaders: tiled GEMM (16x16), fused RMSNorm+residual, RoPE, SiLU*mul
  - Implements `ComputeBackend` trait (stubs for GPU dispatch, to be wired up)
- **flare-simd**: CPU fallback backend
  - Tiled matrix multiply (32x32 tiles for cache locality)
  - Full `ComputeBackend` implementation: matmul, RMSNorm, RoPE, softmax, SiLU
  - Auto-vectorizes on WASM SIMD128 targets

## Test plan
- [x] 3 CPU matmul tests (identity, basic, larger matrices)
- [x] `cargo check -p flare-gpu` compiles with wgpu
- [x] All workspace tests pass