### PR TITLE
Wire GPU compute shaders into WebGpuBackend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
 name = "flare-gpu"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "byteorder",
  "flare-core",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ log = "0.4"
 
 # GPU
 wgpu = "24"
+bytemuck = { version = "1", features = ["derive"] }
 
 # WASM
 wasm-bindgen = "0.2"

--- a/flare-gpu/Cargo.toml
+++ b/flare-gpu/Cargo.toml
@@ -12,3 +12,4 @@ wgpu = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 byteorder = { workspace = true }
+bytemuck = { workspace = true }

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -2,6 +2,8 @@ use flare_core::model::ComputeBackend;
 use flare_core::tensor::Tensor;
 use thiserror::Error;
 
+use crate::buffers;
+
 #[derive(Debug, Error)]
 pub enum GpuError {
     #[error("no suitable GPU adapter found")]
@@ -13,6 +15,9 @@ pub enum GpuError {
     #[error("buffer operation error: {0}")]
     BufferError(String),
 }
+
+const MATMUL_SHADER: &str = include_str!("../shaders/matmul.wgsl");
+const SILU_MUL_SHADER: &str = include_str!("../shaders/silu_mul.wgsl");
 
 /// WebGPU/wgpu compute backend.
 ///
@@ -61,27 +66,376 @@ impl WebGpuBackend {
     pub fn queue(&self) -> &wgpu::Queue {
         &self.queue
     }
+
+    /// Run a compute shader with the given bind group and dispatch dimensions,
+    /// then read back the output buffer to CPU.
+    fn dispatch_and_readback(
+        &self,
+        pipeline: &wgpu::ComputePipeline,
+        bind_group: &wgpu::BindGroup,
+        dispatch: [u32; 3],
+        output_buf: &wgpu::Buffer,
+        output_size: u64,
+    ) -> Vec<f32> {
+        let staging = buffers::create_staging_buffer(&self.device, "staging", output_size);
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: None,
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, bind_group, &[]);
+            pass.dispatch_workgroups(dispatch[0], dispatch[1], dispatch[2]);
+        }
+
+        encoder.copy_buffer_to_buffer(output_buf, 0, &staging, 0, output_size);
+        self.queue.submit(Some(encoder.finish()));
+
+        // Map and read back
+        let slice = staging.slice(..);
+        let (sender, receiver) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            sender.send(result).ok();
+        });
+        self.device.poll(wgpu::Maintain::Wait);
+        receiver
+            .recv()
+            .expect("GPU readback channel closed")
+            .expect("GPU readback failed");
+
+        let data = slice.get_mapped_range();
+        let result: Vec<f32> = bytemuck::cast_slice(&data).to_vec();
+        drop(data);
+        staging.unmap();
+        result
+    }
 }
 
 impl ComputeBackend for WebGpuBackend {
-    fn matmul(&self, _a: &Tensor, _b: &Tensor, _output: &mut Tensor) {
-        // TODO: dispatch matmul.wgsl compute shader
-        todo!("GPU matmul not yet implemented")
+    fn matmul(&self, a: &Tensor, b: &Tensor, output: &mut Tensor) {
+        let a_shape = a.shape();
+        let b_shape = b.shape();
+        assert!(a_shape.len() == 2 && b_shape.len() == 2);
+        let m = a_shape[0] as u32;
+        let k = a_shape[1] as u32;
+        let n = b_shape[1] as u32;
+
+        let a_buf = buffers::create_storage_buffer(
+            &self.device,
+            "matmul_a",
+            bytemuck::cast_slice(a.data()),
+        );
+        let b_buf = buffers::create_storage_buffer(
+            &self.device,
+            "matmul_b",
+            bytemuck::cast_slice(b.data()),
+        );
+        let output_size = (m * n) as u64 * 4;
+        let out_buf = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("matmul_out"),
+            size: output_size,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let params: [u32; 3] = [m, n, k];
+        let params_buf = buffers::create_uniform_buffer(
+            &self.device,
+            "matmul_params",
+            bytemuck::cast_slice(&params),
+        );
+
+        // We need to create pipeline with proper bind group layout
+        let shader_module = self
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("matmul"),
+                source: wgpu::ShaderSource::Wgsl(MATMUL_SHADER.into()),
+            });
+
+        let bind_group_layout =
+            self.device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("matmul_bgl"),
+                    entries: &[
+                        storage_ro_entry(0),
+                        storage_ro_entry(1),
+                        storage_rw_entry(2),
+                        uniform_entry(3),
+                    ],
+                });
+
+        let pipeline_layout = self
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("matmul_layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+
+        let pipeline = self
+            .device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("matmul_pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader_module,
+                entry_point: Some("matmul"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+
+        let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("matmul_bg"),
+            layout: &bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: a_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: b_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: out_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: params_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        let tile = 16u32;
+        let dispatch_x = m.div_ceil(tile);
+        let dispatch_y = n.div_ceil(tile);
+
+        let result = self.dispatch_and_readback(
+            &pipeline,
+            &bind_group,
+            [dispatch_x, dispatch_y, 1],
+            &out_buf,
+            output_size,
+        );
+
+        output.data_mut()[..result.len()].copy_from_slice(&result);
     }
 
-    fn rmsnorm(&self, _input: &Tensor, _weight: &Tensor, _eps: f32, _output: &mut Tensor) {
-        todo!("GPU rmsnorm not yet implemented")
+    fn rmsnorm(&self, input: &Tensor, weight: &Tensor, eps: f32, output: &mut Tensor) {
+        // CPU fallback for now — RMSNorm is memory-bound and fast on CPU
+        let data = input.data();
+        let w = weight.data();
+        let out = output.data_mut();
+        let dim = w.len();
+        let num_rows = data.len() / dim;
+        for row in 0..num_rows {
+            let offset = row * dim;
+            let row_data = &data[offset..offset + dim];
+            let sum_sq: f32 = row_data.iter().map(|x| x * x).sum();
+            let rms = (sum_sq / dim as f32 + eps).sqrt();
+            for i in 0..dim {
+                out[offset + i] = (row_data[i] / rms) * w[i];
+            }
+        }
     }
 
-    fn rope(&self, _q: &mut Tensor, _k: &mut Tensor, _pos: usize, _head_dim: usize, _theta: f32) {
-        todo!("GPU RoPE not yet implemented")
+    fn rope(&self, q: &mut Tensor, k: &mut Tensor, pos: usize, head_dim: usize, theta: f32) {
+        // CPU fallback — RoPE is a lightweight per-element operation
+        let half = head_dim / 2;
+        let num_q_heads = q.numel() / head_dim;
+        for h in 0..num_q_heads {
+            let offset = h * head_dim;
+            for i in 0..half {
+                let freq = 1.0 / theta.powf(2.0 * i as f32 / head_dim as f32);
+                let angle = pos as f32 * freq;
+                let (sin_val, cos_val) = angle.sin_cos();
+                let q_data = q.data_mut();
+                let q0 = q_data[offset + i];
+                let q1 = q_data[offset + i + half];
+                q_data[offset + i] = q0 * cos_val - q1 * sin_val;
+                q_data[offset + i + half] = q0 * sin_val + q1 * cos_val;
+            }
+        }
+        let num_k_heads = k.numel() / head_dim;
+        for h in 0..num_k_heads {
+            let offset = h * head_dim;
+            for i in 0..half {
+                let freq = 1.0 / theta.powf(2.0 * i as f32 / head_dim as f32);
+                let angle = pos as f32 * freq;
+                let (sin_val, cos_val) = angle.sin_cos();
+                let k_data = k.data_mut();
+                let k0 = k_data[offset + i];
+                let k1 = k_data[offset + i + half];
+                k_data[offset + i] = k0 * cos_val - k1 * sin_val;
+                k_data[offset + i + half] = k0 * sin_val + k1 * cos_val;
+            }
+        }
     }
 
-    fn softmax(&self, _input: &mut Tensor) {
-        todo!("GPU softmax not yet implemented")
+    fn softmax(&self, input: &mut Tensor) {
+        // CPU fallback — softmax over a single vector is fast
+        let data = input.data_mut();
+        let max = data.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let mut sum = 0.0f32;
+        for v in data.iter_mut() {
+            *v = (*v - max).exp();
+            sum += *v;
+        }
+        for v in data.iter_mut() {
+            *v /= sum;
+        }
     }
 
-    fn silu_mul(&self, _gate: &Tensor, _up: &Tensor, _output: &mut Tensor) {
-        todo!("GPU SiLU*mul not yet implemented")
+    fn silu_mul(&self, gate: &Tensor, up: &Tensor, output: &mut Tensor) {
+        let size = gate.numel() as u32;
+
+        let gate_buf = buffers::create_storage_buffer(
+            &self.device,
+            "silu_gate",
+            bytemuck::cast_slice(gate.data()),
+        );
+        let up_buf = buffers::create_storage_buffer(
+            &self.device,
+            "silu_up",
+            bytemuck::cast_slice(up.data()),
+        );
+        let output_size = size as u64 * 4;
+        let out_buf = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("silu_out"),
+            size: output_size,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let params: [u32; 1] = [size];
+        let params_buf = buffers::create_uniform_buffer(
+            &self.device,
+            "silu_params",
+            bytemuck::cast_slice(&params),
+        );
+
+        let shader_module = self
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("silu_mul"),
+                source: wgpu::ShaderSource::Wgsl(SILU_MUL_SHADER.into()),
+            });
+
+        let bind_group_layout =
+            self.device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("silu_bgl"),
+                    entries: &[
+                        storage_ro_entry(0),
+                        storage_ro_entry(1),
+                        storage_rw_entry(2),
+                        uniform_entry(3),
+                    ],
+                });
+
+        let pipeline_layout = self
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("silu_layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+
+        let pipeline = self
+            .device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("silu_pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader_module,
+                entry_point: Some("silu_mul"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+
+        let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("silu_bg"),
+            layout: &bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: gate_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: up_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: out_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: params_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        let workgroup_size = 256u32;
+        let dispatch_x = size.div_ceil(workgroup_size);
+
+        let result = self.dispatch_and_readback(
+            &pipeline,
+            &bind_group,
+            [dispatch_x, 1, 1],
+            &out_buf,
+            output_size,
+        );
+
+        output.data_mut()[..result.len()].copy_from_slice(&result);
+    }
+}
+
+// Helper functions for bind group layout entries
+fn storage_ro_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only: true },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+fn storage_rw_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only: false },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+fn uniform_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
     }
 }


### PR DESCRIPTION
## Summary
- Implement real GPU dispatch for `matmul` and `silu_mul` via WGSL compute shaders
- Buffer creation, bind group layout, pipeline compilation, dispatch, and CPU readback
- CPU fallback for RMSNorm, RoPE, softmax (lightweight ops not worth GPU roundtrip)
- Add `bytemuck` for safe f32/u8 casting

## Test plan
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --workspace` — 56 tests pass