### PR TITLE
Fix GGUF magic number (byte-swap bug)

### DIFF
--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -7,7 +7,7 @@ use crate::quantize::{self, QuantFormat};
 use flare_core::config::{Architecture, ModelConfig};
 use flare_core::tensor::Tensor;
 
-const GGUF_MAGIC: u32 = 0x46475547; // "GGUF" in little-endian
+const GGUF_MAGIC: u32 = 0x46554747; // "GGUF" as little-endian u32 (bytes: 47 47 55 46)
 
 #[derive(Debug, Error)]
 pub enum GgufError {


### PR DESCRIPTION
## Summary
The GGUF magic constant was byte-swapped: `0x46475547` should be `0x46554747`.

Found by testing with a real model file (SmolLM2-135M-Instruct Q8_0 GGUF). After fix:
- `flare-info` correctly parses model metadata (30 layers, 576 hidden, 49K vocab)
- `flare-cli` loads weights in 0.1s and runs inference at 18.8 tok/s on CPU
- 272 tensors loaded and dequantized from Q8_0 format

## Test plan
- [x] 136 tests pass (existing tests use the constant, so they pass both before and after)
- [x] Verified with real SmolLM2-135M GGUF file
- [x] Clippy clean, fmt clean