### PR TITLE
Add Q5_0 dequantization (partial fix for #39)

### DIFF
--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -368,6 +368,19 @@ fn dequantize_tensor(raw: &[u8], dtype: QuantFormat, numel: usize) -> Result<Vec
             }
             Ok(data)
         }
+        QuantFormat::Q5_0 => {
+            let block_size = 32;
+            let block_bytes = 22; // 2 (scale) + 4 (high bits) + 16 (nibbles)
+            let num_blocks = numel / block_size;
+            let mut data = vec![0.0f32; numel];
+            for b in 0..num_blocks {
+                let block = &raw[b * block_bytes..(b + 1) * block_bytes];
+                let mut out = [0.0f32; 32];
+                quantize::dequant_q5_0_block(block, &mut out);
+                data[b * block_size..(b + 1) * block_size].copy_from_slice(&out);
+            }
+            Ok(data)
+        }
         QuantFormat::Q6K => {
             let block_size = 256;
             let block_bytes = 210;

--- a/flare-loader/src/quantize.rs
+++ b/flare-loader/src/quantize.rs
@@ -101,6 +101,40 @@ pub fn dequant_q8_0_block(block: &[u8], output: &mut [f32; 32]) {
     }
 }
 
+/// Dequantize a Q5_0 block: 32 weights with 5 bits each.
+/// Layout: 2 bytes scale (f16) + 4 bytes high-bit mask + 16 bytes low nibbles
+/// Total: 22 bytes per block of 32 weights.
+///
+/// High bit layout matches llama.cpp: bits 0-15 are for weights 0-15 (low nibbles),
+/// bits 16-31 are for weights 16-31 (high nibbles).
+pub fn dequant_q5_0_block(block: &[u8], output: &mut [f32; 32]) {
+    if block.len() < 22 {
+        for v in output.iter_mut() {
+            *v = 0.0;
+        }
+        return;
+    }
+    let scale = f16_to_f32(u16::from_le_bytes([block[0], block[1]]));
+    let qh = u32::from_le_bytes([block[2], block[3], block[4], block[5]]);
+
+    for j in 0..16 {
+        let byte = block[6 + j];
+        let lo_nibble = byte & 0x0F;
+        let hi_nibble = (byte >> 4) & 0x0F;
+
+        // High bit for weight j (low nibble) is at qh bit j
+        let xh_0 = ((qh >> j) & 1) as u8;
+        // High bit for weight j+16 (high nibble) is at qh bit j+16
+        let xh_1 = ((qh >> (j + 16)) & 1) as u8;
+
+        let x0 = (lo_nibble | (xh_0 << 4)) as i32 - 16;
+        let x1 = (hi_nibble | (xh_1 << 4)) as i32 - 16;
+
+        output[j] = x0 as f32 * scale;
+        output[j + 16] = x1 as f32 * scale;
+    }
+}
+
 /// Dequantize a Q6_K block: 256 weights.
 /// Layout: quantized_data[128] + scales[8] (Q8) + d (f16)
 /// Each weight is 6 bits, packed in groups.


### PR DESCRIPTION
## Summary
Adds Q5_0 block dequantization with llama.cpp-compatible high-bit layout.

**Status:**
- Q8_0 models: ✅ work perfectly (\"The capital of France is Paris\")
- Q4_K_M models: ❌ load but produce garbage — Q5_0 dequant likely has a bit manipulation bug
- The remaining Q5_0 bug needs careful comparison against a reference implementation

This PR unblocks loading Q4_K_M files (previously errored with \"unsupported Q5_0\").

## Test plan
- [x] 136 tests pass
- [x] Clippy clean, fmt clean
- [x] Q4_K_M models load without errors