### PR TITLE
Add Qwen2 attention bias support (fixes #56)

### DIFF
--- a/flare-core/src/generate.rs
+++ b/flare-core/src/generate.rs
@@ -158,6 +158,9 @@ mod tests {
             w_gate: make_tensor(inter * dim),
             w_up: make_tensor(inter * dim),
             w_down: make_tensor(dim * inter),
+            attn_q_bias: None,
+            attn_k_bias: None,
+            attn_v_bias: None,
         };
 
         let weights = ModelWeights {

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -23,6 +23,10 @@ pub struct LayerWeights {
     pub w_gate: Tensor,
     pub w_up: Tensor,
     pub w_down: Tensor,
+    // Optional attention biases (Qwen2 uses these, Llama does not)
+    pub attn_q_bias: Option<Tensor>,
+    pub attn_k_bias: Option<Tensor>,
+    pub attn_v_bias: Option<Tensor>,
 }
 
 /// Complete model weights.
@@ -99,13 +103,26 @@ impl Model {
             let normed = rmsnorm(x.data(), layer.attn_norm.data(), config.rms_norm_eps);
 
             // QKV projections
-            let q_data = matvec(layer.wq.data(), &normed, num_heads * head_dim, dim);
-            let k_data = matvec(layer.wk.data(), &normed, kv_dim, dim);
-            let v_data = matvec(layer.wv.data(), &normed, kv_dim, dim);
+            let mut q_data = matvec(layer.wq.data(), &normed, num_heads * head_dim, dim);
+            let mut k_data = matvec(layer.wk.data(), &normed, kv_dim, dim);
+            let mut v_data = matvec(layer.wv.data(), &normed, kv_dim, dim);
 
-            // Apply RoPE to Q and K
-            let mut q_data = q_data;
-            let mut k_data = k_data;
+            // Add attention biases if present (Qwen2)
+            if let Some(bias) = &layer.attn_q_bias {
+                for (q, &b) in q_data.iter_mut().zip(bias.data().iter()) {
+                    *q += b;
+                }
+            }
+            if let Some(bias) = &layer.attn_k_bias {
+                for (k, &b) in k_data.iter_mut().zip(bias.data().iter()) {
+                    *k += b;
+                }
+            }
+            if let Some(bias) = &layer.attn_v_bias {
+                for (v, &b) in v_data.iter_mut().zip(bias.data().iter()) {
+                    *v += b;
+                }
+            }
             apply_rope(&mut q_data, num_heads, head_dim, pos, config.rope_theta);
             apply_rope(&mut k_data, num_kv_heads, head_dim, pos, config.rope_theta);
 
@@ -391,6 +408,9 @@ mod tests {
             w_gate: Tensor::from_vec(make_weights(inter * dim), &[inter * dim]).unwrap(),
             w_up: Tensor::from_vec(make_weights(inter * dim), &[inter * dim]).unwrap(),
             w_down: Tensor::from_vec(make_weights(dim * inter), &[dim * inter]).unwrap(),
+            attn_q_bias: None,
+            attn_k_bias: None,
+            attn_v_bias: None,
         };
 
         let weights = ModelWeights {
@@ -494,6 +514,9 @@ mod tests {
             w_gate: Tensor::from_vec(zero_4x4.clone(), &[16]).unwrap(),
             w_up: Tensor::from_vec(zero_4x4.clone(), &[16]).unwrap(),
             w_down: Tensor::from_vec(zero_4x4, &[16]).unwrap(),
+            attn_q_bias: None,
+            attn_k_bias: None,
+            attn_v_bias: None,
         };
 
         // Embedding: token 0 = [1, 2, 3, 4]
@@ -571,6 +594,9 @@ mod tests {
             w_gate: Tensor::from_vec(make_w(inter * dim), &[inter * dim]).unwrap(),
             w_up: Tensor::from_vec(make_w(inter * dim), &[inter * dim]).unwrap(),
             w_down: Tensor::from_vec(make_w(dim * inter), &[dim * inter]).unwrap(),
+            attn_q_bias: None,
+            attn_k_bias: None,
+            attn_v_bias: None,
         };
 
         let weights = ModelWeights {
@@ -621,6 +647,9 @@ mod tests {
             w_gate: Tensor::from_vec(make_weights(inter * dim), &[inter * dim]).unwrap(),
             w_up: Tensor::from_vec(make_weights(inter * dim), &[inter * dim]).unwrap(),
             w_down: Tensor::from_vec(make_weights(dim * inter), &[dim * inter]).unwrap(),
+            attn_q_bias: None,
+            attn_k_bias: None,
+            attn_v_bias: None,
         };
 
         let weights = ModelWeights {

--- a/flare-loader/src/weights.rs
+++ b/flare-loader/src/weights.rs
@@ -123,6 +123,32 @@ fn load_layer_weights(
         ],
     )?;
 
+    // Optional attention biases (Qwen2 has these, Llama does not)
+    let attn_q_bias = find_tensor(
+        tensors,
+        &[
+            &format!("blk.{i}.attn_q.bias"),
+            &format!("model.layers.{i}.self_attn.q_proj.bias"),
+        ],
+    )
+    .ok();
+    let attn_k_bias = find_tensor(
+        tensors,
+        &[
+            &format!("blk.{i}.attn_k.bias"),
+            &format!("model.layers.{i}.self_attn.k_proj.bias"),
+        ],
+    )
+    .ok();
+    let attn_v_bias = find_tensor(
+        tensors,
+        &[
+            &format!("blk.{i}.attn_v.bias"),
+            &format!("model.layers.{i}.self_attn.v_proj.bias"),
+        ],
+    )
+    .ok();
+
     Ok(LayerWeights {
         attn_norm,
         wq,
@@ -133,6 +159,9 @@ fn load_layer_weights(
         w_gate,
         w_up,
         w_down,
+        attn_q_bias,
+        attn_k_bias,
+        attn_v_bias,
     })
 }
 


### PR DESCRIPTION
## Summary
Closes #56

Qwen2 models use Q/K/V attention biases (72 tensors) that our Llama-only forward pass didn't handle. Added optional bias fields to LayerWeights and apply them after QKV projection.

**Before:** Qwen2.5-0.5B → total garbage
**After:** Qwen2.5-0.5B → correct, coherent output

Verified prompts:
- \`"The capital of France is"\` → \`"located in the center of the country...called Paris"\`
- Chat mode: correctly describes Rust programming language features
- Story completion: coherent narrative

Performance: 6-7 tok/s for 0.5B (630M params) Q8_0 on M5 Pro

## Test plan
- [x] 142 tests pass
- [x] SmolLM2-135M (Llama) still works correctly
- [x] Qwen2.5-0.5B (Qwen2) now produces correct output
- [x] Clippy clean, fmt clean