### PR TITLE
Add GPU integration tests and wire compute backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "byteorder",
  "flare-core",
  "log",
+ "pollster",
  "thiserror 2.0.18",
  "wgpu",
 ]
@@ -916,6 +917,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "presser"

--- a/flare-core/src/lib.rs
+++ b/flare-core/src/lib.rs
@@ -30,4 +30,5 @@ pub mod tokenizer;
 pub use config::ModelConfig;
 pub use error::{FlareError, ModelError};
 pub use generate::Generator;
+pub use model::CpuBackend;
 pub use tensor::Tensor;

--- a/flare-core/src/memory.rs
+++ b/flare-core/src/memory.rs
@@ -37,9 +37,20 @@ impl MemoryBudget {
 
     /// Native budget: effectively unlimited for small models.
     pub fn native() -> Self {
+        // On wasm32, usize is 32-bit so we cap at safe values; native gets 16GB/8GB.
+        #[cfg(target_pointer_width = "64")]
+        const TOTAL: usize = 16 * 1024 * 1024 * 1024; // 16GB
+        #[cfg(not(target_pointer_width = "64"))]
+        const TOTAL: usize = 3500 * 1024 * 1024; // 3.5GB (max safe on 32-bit)
+
+        #[cfg(target_pointer_width = "64")]
+        const GPU: usize = 8 * 1024 * 1024 * 1024; // 8GB
+        #[cfg(not(target_pointer_width = "64"))]
+        const GPU: usize = 2 * 1024 * 1024 * 1024; // 2GB
+
         Self {
-            total_bytes: 16 * 1024 * 1024 * 1024, // 16GB
-            gpu_bytes: 8 * 1024 * 1024 * 1024,    // 8GB
+            total_bytes: TOTAL,
+            gpu_bytes: GPU,
             label: "Native".into(),
         }
     }

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -287,9 +287,9 @@ impl Model {
             let gate =
                 self.backend
                     .matvec(layer.w_gate.data(), &normed, config.intermediate_dim, dim);
-            let up =
-                self.backend
-                    .matvec(layer.w_up.data(), &normed, config.intermediate_dim, dim);
+            let up = self
+                .backend
+                .matvec(layer.w_up.data(), &normed, config.intermediate_dim, dim);
 
             // SiLU(gate) * up
             let ffn_hidden = self.backend.silu_mul_vec(&gate, &up);

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -10,6 +10,107 @@ pub trait ComputeBackend {
     fn rope(&self, q: &mut Tensor, k: &mut Tensor, pos: usize, head_dim: usize, theta: f32);
     fn softmax(&self, input: &mut Tensor);
     fn silu_mul(&self, gate: &Tensor, up: &Tensor, output: &mut Tensor);
+
+    /// Matrix-vector multiply: output[rows] = mat[rows, cols] * vec[cols].
+    /// Default implementation reshapes into matmul, but backends can override
+    /// with a more efficient kernel.
+    fn matvec(&self, mat: &[f32], vec: &[f32], rows: usize, cols: usize) -> Vec<f32> {
+        matvec(mat, vec, rows, cols)
+    }
+
+    /// RMSNorm on raw slices, returning a new Vec.
+    /// Default delegates to the CPU implementation.
+    fn rmsnorm_vec(&self, x: &[f32], weight: &[f32], eps: f32) -> Vec<f32> {
+        rmsnorm(x, weight, eps)
+    }
+
+    /// Apply RoPE to interleaved Q or K vectors (in-place on raw slices).
+    fn apply_rope_vec(
+        &self,
+        data: &mut [f32],
+        num_heads: usize,
+        head_dim: usize,
+        pos: usize,
+        theta: f32,
+    ) {
+        apply_rope(data, num_heads, head_dim, pos, theta);
+    }
+
+    /// SiLU(gate) * up, returning a new Vec.
+    fn silu_mul_vec(&self, gate: &[f32], up: &[f32]) -> Vec<f32> {
+        silu_mul_cpu(gate, up)
+    }
+}
+
+/// Default CPU compute backend. Uses optimized scalar loops.
+pub struct CpuBackend;
+
+impl ComputeBackend for CpuBackend {
+    fn matmul(&self, a: &Tensor, b: &Tensor, output: &mut Tensor) {
+        let a_shape = a.shape();
+        let b_shape = b.shape();
+        assert!(a_shape.len() == 2 && b_shape.len() == 2);
+        let m = a_shape[0];
+        let k = a_shape[1];
+        let n = b_shape[1];
+        assert_eq!(b_shape[0], k);
+        let out = output.data_mut();
+        let a_data = a.data();
+        let b_data = b.data();
+        for i in 0..m {
+            for j in 0..n {
+                let mut sum = 0.0f32;
+                for p in 0..k {
+                    sum += a_data[i * k + p] * b_data[p * n + j];
+                }
+                out[i * n + j] = sum;
+            }
+        }
+    }
+
+    fn rmsnorm(&self, input: &Tensor, weight: &Tensor, eps: f32, output: &mut Tensor) {
+        let data = input.data();
+        let w = weight.data();
+        let out = output.data_mut();
+        let dim = w.len();
+        let num_rows = data.len() / dim;
+        for row in 0..num_rows {
+            let offset = row * dim;
+            let row_data = &data[offset..offset + dim];
+            let sum_sq: f32 = row_data.iter().map(|x| x * x).sum();
+            let rms = (sum_sq / dim as f32 + eps).sqrt();
+            for i in 0..dim {
+                out[offset + i] = (row_data[i] / rms) * w[i];
+            }
+        }
+    }
+
+    fn rope(&self, q: &mut Tensor, k: &mut Tensor, pos: usize, head_dim: usize, theta: f32) {
+        let q_heads = q.numel() / head_dim;
+        let k_heads = k.numel() / head_dim;
+        apply_rope(q.data_mut(), q_heads, head_dim, pos, theta);
+        apply_rope(k.data_mut(), k_heads, head_dim, pos, theta);
+    }
+
+    fn softmax(&self, input: &mut Tensor) {
+        let data = input.data_mut();
+        let max = data.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let mut sum = 0.0f32;
+        for v in data.iter_mut() {
+            *v = (*v - max).exp();
+            sum += *v;
+        }
+        for v in data.iter_mut() {
+            *v /= sum;
+        }
+    }
+
+    fn silu_mul(&self, gate: &Tensor, up: &Tensor, output: &mut Tensor) {
+        let out = output.data_mut();
+        for (i, (g, u)) in gate.data().iter().zip(up.data().iter()).enumerate() {
+            out[i] = (g / (1.0 + (-g).exp())) * u;
+        }
+    }
 }
 
 /// Weights for a single transformer layer.
@@ -38,10 +139,14 @@ pub struct ModelWeights {
 }
 
 /// The core model that runs inference.
+///
+/// By default uses `CpuBackend` for all compute operations. Call
+/// `set_backend` to plug in a GPU or SIMD backend.
 pub struct Model {
     config: ModelConfig,
     weights: ModelWeights,
     kv_cache: KvCache,
+    backend: Box<dyn ComputeBackend>,
 }
 
 impl Model {
@@ -56,7 +161,14 @@ impl Model {
             config,
             weights,
             kv_cache,
+            backend: Box::new(CpuBackend),
         }
+    }
+
+    /// Replace the compute backend (e.g. with a GPU backend).
+    /// Returns the previous backend.
+    pub fn set_backend(&mut self, backend: Box<dyn ComputeBackend>) -> Box<dyn ComputeBackend> {
+        std::mem::replace(&mut self.backend, backend)
     }
 
     pub fn config(&self) -> &ModelConfig {
@@ -81,6 +193,10 @@ impl Model {
 
     /// Run a single forward pass for one token position.
     /// Returns logits over the vocabulary [vocab_size].
+    ///
+    /// Delegates heavy compute (matvec, rmsnorm, rope, silu_mul) to the
+    /// active `ComputeBackend`. By default this is `CpuBackend`; call
+    /// `set_backend` to use GPU acceleration.
     pub fn forward(&mut self, token_id: u32, pos: usize) -> Tensor {
         let config = &self.config;
         let dim = config.hidden_dim;
@@ -100,12 +216,16 @@ impl Model {
 
             // --- Attention block ---
             // RMSNorm
-            let normed = rmsnorm(x.data(), layer.attn_norm.data(), config.rms_norm_eps);
+            let normed =
+                self.backend
+                    .rmsnorm_vec(x.data(), layer.attn_norm.data(), config.rms_norm_eps);
 
             // QKV projections
-            let mut q_data = matvec(layer.wq.data(), &normed, num_heads * head_dim, dim);
-            let mut k_data = matvec(layer.wk.data(), &normed, kv_dim, dim);
-            let mut v_data = matvec(layer.wv.data(), &normed, kv_dim, dim);
+            let mut q_data =
+                self.backend
+                    .matvec(layer.wq.data(), &normed, num_heads * head_dim, dim);
+            let mut k_data = self.backend.matvec(layer.wk.data(), &normed, kv_dim, dim);
+            let mut v_data = self.backend.matvec(layer.wv.data(), &normed, kv_dim, dim);
 
             // Add attention biases if present (Qwen2)
             if let Some(bias) = &layer.attn_q_bias {
@@ -123,8 +243,15 @@ impl Model {
                     *v += b;
                 }
             }
-            apply_rope(&mut q_data, num_heads, head_dim, pos, config.rope_theta);
-            apply_rope(&mut k_data, num_kv_heads, head_dim, pos, config.rope_theta);
+            self.backend
+                .apply_rope_vec(&mut q_data, num_heads, head_dim, pos, config.rope_theta);
+            self.backend.apply_rope_vec(
+                &mut k_data,
+                num_kv_heads,
+                head_dim,
+                pos,
+                config.rope_theta,
+            );
 
             // Write K, V to cache
             self.kv_cache.write(layer_idx, &k_data, &v_data);
@@ -141,7 +268,9 @@ impl Model {
             );
 
             // Output projection
-            let attn_proj = matvec(layer.wo.data(), &attn_output, dim, num_heads * head_dim);
+            let attn_proj =
+                self.backend
+                    .matvec(layer.wo.data(), &attn_output, dim, num_heads * head_dim);
 
             // Residual connection
             let x_data = x.data_mut();
@@ -150,20 +279,23 @@ impl Model {
             }
 
             // --- FFN block ---
-            let normed = rmsnorm(x.data(), layer.ffn_norm.data(), config.rms_norm_eps);
+            let normed =
+                self.backend
+                    .rmsnorm_vec(x.data(), layer.ffn_norm.data(), config.rms_norm_eps);
 
             // Gate and up projections
-            let gate = matvec(layer.w_gate.data(), &normed, config.intermediate_dim, dim);
-            let up = matvec(layer.w_up.data(), &normed, config.intermediate_dim, dim);
+            let gate =
+                self.backend
+                    .matvec(layer.w_gate.data(), &normed, config.intermediate_dim, dim);
+            let up =
+                self.backend
+                    .matvec(layer.w_up.data(), &normed, config.intermediate_dim, dim);
 
-            // SiLU(gate) * up — reuse gate allocation
-            let mut ffn_hidden = gate;
-            for (g, &u) in ffn_hidden.iter_mut().zip(up.iter()) {
-                *g = (*g / (1.0 + (-*g).exp())) * u;
-            }
+            // SiLU(gate) * up
+            let ffn_hidden = self.backend.silu_mul_vec(&gate, &up);
 
             // Down projection
-            let ffn_out = matvec(
+            let ffn_out = self.backend.matvec(
                 layer.w_down.data(),
                 &ffn_hidden,
                 dim,
@@ -181,14 +313,14 @@ impl Model {
         self.kv_cache.advance();
 
         // Final RMSNorm
-        let normed = rmsnorm(
+        let normed = self.backend.rmsnorm_vec(
             x.data(),
             self.weights.output_norm.data(),
             config.rms_norm_eps,
         );
 
-        // Output logits: [vocab_size] = output_weight [vocab_size, dim] × normed [dim]
-        let logits = matvec(
+        // Output logits: [vocab_size] = output_weight [vocab_size, dim] x normed [dim]
+        let logits = self.backend.matvec(
             self.weights.output_weight.data(),
             &normed,
             config.vocab_size,
@@ -199,8 +331,8 @@ impl Model {
     }
 }
 
-/// RMSNorm: normalize and scale.
-fn rmsnorm(x: &[f32], weight: &[f32], eps: f32) -> Vec<f32> {
+/// RMSNorm: normalize and scale (CPU implementation).
+pub fn rmsnorm(x: &[f32], weight: &[f32], eps: f32) -> Vec<f32> {
     let dim = x.len();
     let sum_sq: f32 = x.iter().map(|v| v * v).sum();
     let rms = (sum_sq / dim as f32 + eps).sqrt();
@@ -210,11 +342,11 @@ fn rmsnorm(x: &[f32], weight: &[f32], eps: f32) -> Vec<f32> {
         .collect()
 }
 
-/// Matrix-vector multiply: output[rows] = mat[rows, cols] × vec[cols]
+/// Matrix-vector multiply: output[rows] = mat[rows, cols] * vec[cols] (CPU implementation).
 ///
 /// Uses 4-wide manual unrolling for better ILP and auto-vectorization.
 /// For a [576, 1536] matrix, this is ~2-3x faster than a naive loop.
-fn matvec(mat: &[f32], vec: &[f32], rows: usize, cols: usize) -> Vec<f32> {
+pub fn matvec(mat: &[f32], vec: &[f32], rows: usize, cols: usize) -> Vec<f32> {
     let mut output = vec![0.0f32; rows];
     let cols4 = cols & !3; // round down to multiple of 4
 
@@ -244,8 +376,16 @@ fn matvec(mat: &[f32], vec: &[f32], rows: usize, cols: usize) -> Vec<f32> {
     output
 }
 
-/// Apply RoPE to interleaved Q or K vectors.
-fn apply_rope(data: &mut [f32], num_heads: usize, head_dim: usize, pos: usize, theta: f32) {
+/// SiLU(gate) * up on raw slices, returning a new Vec (CPU implementation).
+pub fn silu_mul_cpu(gate: &[f32], up: &[f32]) -> Vec<f32> {
+    gate.iter()
+        .zip(up.iter())
+        .map(|(&g, &u)| (g / (1.0 + (-g).exp())) * u)
+        .collect()
+}
+
+/// Apply RoPE to interleaved Q or K vectors (CPU implementation).
+pub fn apply_rope(data: &mut [f32], num_heads: usize, head_dim: usize, pos: usize, theta: f32) {
     let half = head_dim / 2;
     for h in 0..num_heads {
         let offset = h * head_dim;

--- a/flare-gpu/Cargo.toml
+++ b/flare-gpu/Cargo.toml
@@ -13,3 +13,7 @@ thiserror = { workspace = true }
 log = { workspace = true }
 byteorder = { workspace = true }
 bytemuck = { workspace = true }
+pollster = "0.4"
+
+[dev-dependencies]
+pollster = "0.4"

--- a/flare-gpu/examples/gpu_bench.rs
+++ b/flare-gpu/examples/gpu_bench.rs
@@ -11,7 +11,10 @@ fn bench_matvec(gpu: &WebGpuBackend, label: &str, rows: usize, cols: usize, iter
     let mat_bytes = rows * cols * 4;
     // Skip if matrix exceeds GPU buffer limit (~256MB)
     if mat_bytes > 250_000_000 {
-        println!("{label:35} (skipped: {:.0}MB > GPU buffer limit)", mat_bytes as f64 / 1e6);
+        println!(
+            "{label:35} (skipped: {:.0}MB > GPU buffer limit)",
+            mat_bytes as f64 / 1e6
+        );
         return;
     }
 
@@ -38,9 +41,7 @@ fn bench_matvec(gpu: &WebGpuBackend, label: &str, rows: usize, cols: usize, iter
     let gpu_us = start.elapsed().as_micros() as f64 / iters as f64;
 
     let speedup = cpu_us / gpu_us;
-    println!(
-        "{label:35} CPU: {cpu_us:8.0}µs  GPU: {gpu_us:8.0}µs  speedup: {speedup:.2}x"
-    );
+    println!("{label:35} CPU: {cpu_us:8.0}µs  GPU: {gpu_us:8.0}µs  speedup: {speedup:.2}x");
 }
 
 fn main() {

--- a/flare-gpu/examples/gpu_bench.rs
+++ b/flare-gpu/examples/gpu_bench.rs
@@ -1,0 +1,74 @@
+//! Quick benchmark: CPU vs GPU matvec at inference-realistic sizes.
+//!
+//! Run with: cargo run -p flare-gpu --example gpu_bench --release
+
+use std::time::Instant;
+
+use flare_core::model::{matvec, ComputeBackend};
+use flare_gpu::WebGpuBackend;
+
+fn bench_matvec(gpu: &WebGpuBackend, label: &str, rows: usize, cols: usize, iters: usize) {
+    let mat_bytes = rows * cols * 4;
+    // Skip if matrix exceeds GPU buffer limit (~256MB)
+    if mat_bytes > 250_000_000 {
+        println!("{label:35} (skipped: {:.0}MB > GPU buffer limit)", mat_bytes as f64 / 1e6);
+        return;
+    }
+
+    let mat: Vec<f32> = (0..rows * cols)
+        .map(|i| ((i % 17) as f32 - 8.0) * 0.01)
+        .collect();
+    let v: Vec<f32> = (0..cols).map(|i| (i as f32 * 0.1).sin()).collect();
+
+    // CPU
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = matvec(&mat, &v, rows, cols);
+    }
+    let cpu_us = start.elapsed().as_micros() as f64 / iters as f64;
+
+    // GPU (warmup + bench)
+    for _ in 0..3 {
+        let _ = gpu.matvec(&mat, &v, rows, cols);
+    }
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = gpu.matvec(&mat, &v, rows, cols);
+    }
+    let gpu_us = start.elapsed().as_micros() as f64 / iters as f64;
+
+    let speedup = cpu_us / gpu_us;
+    println!(
+        "{label:35} CPU: {cpu_us:8.0}µs  GPU: {gpu_us:8.0}µs  speedup: {speedup:.2}x"
+    );
+}
+
+fn main() {
+    println!("Flare GPU Benchmark — CPU vs GPU matvec");
+    println!("========================================");
+    println!("NOTE: GPU is slow here due to per-call buffer allocation.");
+    println!("Real gains need persistent buffers (future work).\n");
+
+    let gpu = pollster::block_on(WebGpuBackend::new()).expect("No GPU adapter found");
+
+    // SmolLM2-135M sizes
+    bench_matvec(&gpu, "SmolLM: embed→Q (576x576)", 576, 576, 100);
+    bench_matvec(&gpu, "SmolLM: FFN gate (1536x576)", 1536, 576, 100);
+    bench_matvec(&gpu, "SmolLM: FFN down (576x1536)", 576, 1536, 100);
+    bench_matvec(&gpu, "SmolLM: logits (49152x576)", 49152, 576, 10);
+
+    println!();
+
+    // Qwen2.5-0.5B sizes
+    bench_matvec(&gpu, "Qwen: embed→Q (896x896)", 896, 896, 100);
+    bench_matvec(&gpu, "Qwen: FFN gate (4864x896)", 4864, 896, 50);
+    bench_matvec(&gpu, "Qwen: FFN down (896x4864)", 896, 4864, 50);
+    bench_matvec(&gpu, "Qwen: logits (151936x896)", 151936, 896, 5);
+
+    println!();
+
+    // Llama-3.2-1B sizes
+    bench_matvec(&gpu, "1B: embed→Q (2048x2048)", 2048, 2048, 50);
+    bench_matvec(&gpu, "1B: FFN gate (8192x2048)", 8192, 2048, 20);
+    bench_matvec(&gpu, "1B: logits (128256x2048)", 128256, 2048, 3);
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -122,16 +122,10 @@ impl ComputeBackend for WebGpuBackend {
         let k = cols as u32;
         let n = 1u32;
 
-        let a_buf = buffers::create_storage_buffer(
-            &self.device,
-            "matvec_mat",
-            bytemuck::cast_slice(mat),
-        );
-        let b_buf = buffers::create_storage_buffer(
-            &self.device,
-            "matvec_vec",
-            bytemuck::cast_slice(vec),
-        );
+        let a_buf =
+            buffers::create_storage_buffer(&self.device, "matvec_mat", bytemuck::cast_slice(mat));
+        let b_buf =
+            buffers::create_storage_buffer(&self.device, "matvec_vec", bytemuck::cast_slice(vec));
         let output_size = m as u64 * 4;
         let out_buf = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("matvec_out"),
@@ -231,11 +225,8 @@ impl ComputeBackend for WebGpuBackend {
             "silu_vec_gate",
             bytemuck::cast_slice(gate),
         );
-        let up_buf = buffers::create_storage_buffer(
-            &self.device,
-            "silu_vec_up",
-            bytemuck::cast_slice(up),
-        );
+        let up_buf =
+            buffers::create_storage_buffer(&self.device, "silu_vec_up", bytemuck::cast_slice(up));
         let output_size = size as u64 * 4;
         let out_buf = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("silu_vec_out"),

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -117,6 +117,215 @@ impl WebGpuBackend {
 }
 
 impl ComputeBackend for WebGpuBackend {
+    fn matvec(&self, mat: &[f32], vec: &[f32], rows: usize, cols: usize) -> Vec<f32> {
+        let m = rows as u32;
+        let k = cols as u32;
+        let n = 1u32;
+
+        let a_buf = buffers::create_storage_buffer(
+            &self.device,
+            "matvec_mat",
+            bytemuck::cast_slice(mat),
+        );
+        let b_buf = buffers::create_storage_buffer(
+            &self.device,
+            "matvec_vec",
+            bytemuck::cast_slice(vec),
+        );
+        let output_size = m as u64 * 4;
+        let out_buf = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("matvec_out"),
+            size: output_size,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let params: [u32; 3] = [m, n, k];
+        let params_buf = buffers::create_uniform_buffer(
+            &self.device,
+            "matvec_params",
+            bytemuck::cast_slice(&params),
+        );
+
+        let shader_module = self
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("matvec"),
+                source: wgpu::ShaderSource::Wgsl(MATMUL_SHADER.into()),
+            });
+
+        let bind_group_layout =
+            self.device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("matvec_bgl"),
+                    entries: &[
+                        storage_ro_entry(0),
+                        storage_ro_entry(1),
+                        storage_rw_entry(2),
+                        uniform_entry(3),
+                    ],
+                });
+
+        let pipeline_layout = self
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("matvec_layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+
+        let pipeline = self
+            .device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("matvec_pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader_module,
+                entry_point: Some("matmul"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+
+        let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("matvec_bg"),
+            layout: &bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: a_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: b_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: out_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: params_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        let tile = 16u32;
+        let dispatch_x = m.div_ceil(tile);
+        let dispatch_y = n.div_ceil(tile);
+
+        self.dispatch_and_readback(
+            &pipeline,
+            &bind_group,
+            [dispatch_x, dispatch_y, 1],
+            &out_buf,
+            output_size,
+        )
+    }
+
+    fn silu_mul_vec(&self, gate: &[f32], up: &[f32]) -> Vec<f32> {
+        let size = gate.len() as u32;
+
+        let gate_buf = buffers::create_storage_buffer(
+            &self.device,
+            "silu_vec_gate",
+            bytemuck::cast_slice(gate),
+        );
+        let up_buf = buffers::create_storage_buffer(
+            &self.device,
+            "silu_vec_up",
+            bytemuck::cast_slice(up),
+        );
+        let output_size = size as u64 * 4;
+        let out_buf = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("silu_vec_out"),
+            size: output_size,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let params: [u32; 1] = [size];
+        let params_buf = buffers::create_uniform_buffer(
+            &self.device,
+            "silu_vec_params",
+            bytemuck::cast_slice(&params),
+        );
+
+        let shader_module = self
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("silu_mul_vec"),
+                source: wgpu::ShaderSource::Wgsl(SILU_MUL_SHADER.into()),
+            });
+
+        let bind_group_layout =
+            self.device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("silu_vec_bgl"),
+                    entries: &[
+                        storage_ro_entry(0),
+                        storage_ro_entry(1),
+                        storage_rw_entry(2),
+                        uniform_entry(3),
+                    ],
+                });
+
+        let pipeline_layout = self
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("silu_vec_layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+
+        let pipeline = self
+            .device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("silu_vec_pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader_module,
+                entry_point: Some("silu_mul"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+
+        let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("silu_vec_bg"),
+            layout: &bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: gate_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: up_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: out_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: params_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        let workgroup_size = 256u32;
+        let dispatch_x = size.div_ceil(workgroup_size);
+
+        self.dispatch_and_readback(
+            &pipeline,
+            &bind_group,
+            [dispatch_x, 1, 1],
+            &out_buf,
+            output_size,
+        )
+    }
+
     fn matmul(&self, a: &Tensor, b: &Tensor, output: &mut Tensor) {
         let a_shape = a.shape();
         let b_shape = b.shape();

--- a/flare-gpu/tests/gpu_backend.rs
+++ b/flare-gpu/tests/gpu_backend.rs
@@ -1,0 +1,105 @@
+//! Integration tests for the GPU compute backend.
+//!
+//! These tests require a GPU adapter. They are ignored by default
+//! and run with `cargo test -- --ignored` or on CI with GPU support.
+
+use flare_core::model::ComputeBackend;
+use flare_gpu::WebGpuBackend;
+
+fn try_create_gpu() -> Option<WebGpuBackend> {
+    pollster::block_on(WebGpuBackend::new()).ok()
+}
+
+#[test]
+#[ignore] // requires GPU
+fn test_gpu_matvec_identity() {
+    let gpu = match try_create_gpu() {
+        Some(g) => g,
+        None => {
+            eprintln!("No GPU adapter found, skipping");
+            return;
+        }
+    };
+
+    // Identity-like: [[1,0,0],[0,1,0],[0,0,1]] * [3,5,7] = [3,5,7]
+    let mat = vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+    let vec_data = vec![3.0, 5.0, 7.0];
+    let result = gpu.matvec(&mat, &vec_data, 3, 3);
+
+    assert_eq!(result.len(), 3);
+    assert!((result[0] - 3.0).abs() < 1e-3, "got {}", result[0]);
+    assert!((result[1] - 5.0).abs() < 1e-3, "got {}", result[1]);
+    assert!((result[2] - 7.0).abs() < 1e-3, "got {}", result[2]);
+}
+
+#[test]
+#[ignore] // requires GPU
+fn test_gpu_matvec_basic() {
+    let gpu = match try_create_gpu() {
+        Some(g) => g,
+        None => return,
+    };
+
+    // [[1,2],[3,4]] * [1,1] = [3, 7]
+    let mat = vec![1.0, 2.0, 3.0, 4.0];
+    let v = vec![1.0, 1.0];
+    let result = gpu.matvec(&mat, &v, 2, 2);
+
+    assert_eq!(result.len(), 2);
+    assert!((result[0] - 3.0).abs() < 1e-3, "got {}", result[0]);
+    assert!((result[1] - 7.0).abs() < 1e-3, "got {}", result[1]);
+}
+
+#[test]
+#[ignore] // requires GPU
+fn test_gpu_matvec_large() {
+    let gpu = match try_create_gpu() {
+        Some(g) => g,
+        None => return,
+    };
+
+    // 256x512 matrix * 512 vector — realistic size
+    let rows = 256;
+    let cols = 512;
+    let mat: Vec<f32> = (0..rows * cols)
+        .map(|i| ((i % 17) as f32 - 8.0) * 0.01)
+        .collect();
+    let v: Vec<f32> = (0..cols).map(|i| (i as f32 * 0.1).sin()).collect();
+
+    let gpu_result = gpu.matvec(&mat, &v, rows, cols);
+    let cpu_result = flare_core::model::matvec(&mat, &v, rows, cols);
+
+    assert_eq!(gpu_result.len(), rows);
+    for i in 0..rows {
+        assert!(
+            (gpu_result[i] - cpu_result[i]).abs() < 0.1,
+            "row {i}: gpu={} cpu={}",
+            gpu_result[i],
+            cpu_result[i]
+        );
+    }
+}
+
+#[test]
+#[ignore] // requires GPU
+fn test_gpu_silu_mul_vec() {
+    let gpu = match try_create_gpu() {
+        Some(g) => g,
+        None => return,
+    };
+
+    let gate = vec![0.0, 1.0, -1.0, 10.0];
+    let up = vec![1.0, 1.0, 1.0, 1.0];
+    let result = gpu.silu_mul_vec(&gate, &up);
+    let cpu = flare_core::model::silu_mul_cpu(&gate, &up);
+
+    assert_eq!(result.len(), 4);
+    for i in 0..4 {
+        assert!(
+            (result[i] - cpu[i]).abs() < 1e-3,
+            "silu_mul[{i}]: gpu={} cpu={}",
+            result[i],
+            cpu[i]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Wires the `ComputeBackend` trait into `Model.forward()` so all heavy compute (matvec, rmsnorm, rope, silu_mul) goes through a pluggable backend
- `CpuBackend` is the default; call `model.set_backend()` to switch to GPU at runtime
- Implements GPU-accelerated `matvec` and `silu_mul_vec` on `WebGpuBackend` using WGSL compute shaders
- Fixes `usize` overflow in `memory.rs` for wasm32 targets (32-bit pointer width)
- Adds 4 GPU integration tests (ignored by default, run with `--ignored`)
- Adds `gpu_bench` example for CPU vs GPU comparison at realistic matrix sizes

Closes #47, closes #48

## Benchmark findings
GPU path currently slower than CPU for single-token matvec due to per-call buffer allocation overhead. Next step: persistent buffer pool for amortized GPU dispatch.

## Test plan
- [x] All 142 existing tests pass
- [x] GPU tests pass on Metal (`cargo test -p flare-gpu -- --ignored`)
- [x] WASM compilation verified (`wasm-pack build flare-web --target web`)
- [x] Native compilation verified (`cargo check --workspace --all-targets`)