### PR TITLE
Wire model loading and inference into API server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +227,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +275,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation"
@@ -279,6 +375,7 @@ name = "flare-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "clap",
  "flare-core",
  "flare-gpu",
  "flare-loader",
@@ -291,6 +388,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tower",
+ "tower-http",
 ]
 
 [[package]]
@@ -655,6 +753,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +965,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ordered-float"
@@ -1128,6 +1238,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1387,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "http",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1449,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,5 @@ tokio = { version = "1", features = ["full"] }
 # HTTP server
 axum = "0.8"
 tokio-stream = "0.1"
+tower-http = { version = "0.6", features = ["cors"] }
+clap = { version = "4", features = ["derive"] }

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -4,7 +4,7 @@ use crate::tensor::Tensor;
 
 /// Trait for compute backends (WebGPU, SIMD, native wgpu).
 /// Each backend implements these fundamental operations.
-pub trait ComputeBackend {
+pub trait ComputeBackend: Send + Sync {
     fn matmul(&self, a: &Tensor, b: &Tensor, output: &mut Tensor);
     fn rmsnorm(&self, input: &Tensor, weight: &Tensor, eps: f32, output: &mut Tensor);
     fn rope(&self, q: &mut Tensor, k: &mut Tensor, pos: usize, head_dim: usize, theta: f32);

--- a/flare-server/Cargo.toml
+++ b/flare-server/Cargo.toml
@@ -30,6 +30,8 @@ thiserror = { workspace = true }
 axum = { workspace = true }
 tokio-stream = { workspace = true }
 futures = { workspace = true }
+tower-http = { workspace = true }
+clap = { workspace = true }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/flare-server/src/main.rs
+++ b/flare-server/src/main.rs
@@ -9,37 +9,196 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use std::sync::Arc;
+use clap::Parser;
+use std::fs::File;
+use std::io::BufReader;
+use std::sync::{Arc, Mutex};
+use tower_http::cors::{Any, CorsLayer};
+
+use flare_core::chat::{ChatMessage, ChatTemplate, Role};
+use flare_core::generate::Generator;
+use flare_core::model::Model;
+use flare_core::sampling::SamplingParams;
+use flare_core::tokenizer::{BpeTokenizer, Tokenizer};
+use flare_loader::gguf::{GgufFile, MetadataValue};
+use flare_loader::tokenizer::GgufVocab;
+use flare_loader::weights::load_model_weights;
 
 use api::{ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse};
+
+/// CLI arguments for the Flare server.
+#[derive(Parser, Debug)]
+#[command(
+    name = "flare-server",
+    about = "Flare LLM inference server with OpenAI-compatible API"
+)]
+struct Args {
+    /// Path to GGUF model file
+    #[arg(long)]
+    model: Option<String>,
+
+    /// Path to tokenizer.json (optional, falls back to GGUF vocab)
+    #[arg(long)]
+    tokenizer: Option<String>,
+
+    /// Host to bind to
+    #[arg(long, default_value = "0.0.0.0")]
+    host: String,
+
+    /// Port to listen on
+    #[arg(long, default_value = "8080")]
+    port: u16,
+}
+
+/// Holds loaded tokenizer state (either BPE or GGUF vocab).
+enum TokenizerState {
+    Bpe(BpeTokenizer),
+    Gguf(GgufVocab),
+}
 
 /// Shared server state.
 struct AppState {
     model_name: String,
+    /// The model itself, behind a Mutex for exclusive mutable access during inference.
+    model: Option<Mutex<Model>>,
+    /// Tokenizer state, immutable after loading.
+    tokenizer: Option<TokenizerState>,
+    /// Chat template for formatting messages.
+    chat_template: Option<ChatTemplate>,
 }
 
 /// Build the application router. Extracted for testability.
 fn app(state: Arc<AppState>) -> Router {
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
     Router::new()
         .route("/v1/chat/completions", post(chat_completions))
         .route("/v1/models", get(list_models))
         .route("/health", get(health))
+        .layer(cors)
         .with_state(state)
 }
 
 #[tokio::main]
 async fn main() {
-    let port = std::env::var("PORT").unwrap_or_else(|_| "8080".into());
+    let args = Args::parse();
+
+    // Allow PORT env var to override the default
+    let port = match std::env::var("PORT") {
+        Ok(p) => p.parse::<u16>().unwrap_or(args.port),
+        Err(_) => args.port,
+    };
     let model_name = std::env::var("MODEL_NAME").unwrap_or_else(|_| "flare-local".into());
 
-    let state = Arc::new(AppState { model_name });
+    let (model, tokenizer, chat_template) = match args.model {
+        Some(ref model_path) => match load_model_from_path(model_path, args.tokenizer.as_deref()) {
+            Ok((m, t, c)) => {
+                eprintln!("Model loaded successfully");
+                (Some(Mutex::new(m)), Some(t), Some(c))
+            }
+            Err(e) => {
+                eprintln!("Failed to load model: {e}");
+                std::process::exit(1);
+            }
+        },
+        None => {
+            eprintln!("No --model specified, server will return errors for inference requests");
+            (None, None, None)
+        }
+    };
 
-    let addr = format!("0.0.0.0:{port}");
+    let state = Arc::new(AppState {
+        model_name,
+        model,
+        tokenizer,
+        chat_template,
+    });
+
+    let addr = format!("{}:{}", args.host, port);
     eprintln!("Flare server listening on {addr}");
     eprintln!("OpenAI-compatible API at http://localhost:{port}/v1/chat/completions");
 
-    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
-    axum::serve(listener, app(state)).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to bind to {addr}: {e}");
+            std::process::exit(1);
+        });
+    axum::serve(listener, app(state)).await.unwrap_or_else(|e| {
+        eprintln!("Server error: {e}");
+        std::process::exit(1);
+    });
+}
+
+/// Load a GGUF model and tokenizer from disk.
+/// Returns (Model, TokenizerState, ChatTemplate).
+fn load_model_from_path(
+    model_path: &str,
+    tokenizer_path: Option<&str>,
+) -> Result<(Model, TokenizerState, ChatTemplate), String> {
+    eprintln!("Loading model from {model_path}...");
+
+    let file = File::open(model_path).map_err(|e| format!("Error opening {model_path}: {e}"))?;
+    let mut reader = BufReader::new(file);
+
+    let gguf = GgufFile::parse_header(&mut reader)
+        .map_err(|e| format!("Error parsing GGUF header: {e}"))?;
+
+    let config = gguf
+        .to_model_config()
+        .map_err(|e| format!("Error extracting model config: {e}"))?;
+
+    eprintln!("Architecture: {:?}", config.architecture);
+    eprintln!(
+        "Parameters:   ~{}M",
+        config.estimate_param_count() / 1_000_000
+    );
+    eprintln!(
+        "Layers: {}, Hidden: {}",
+        config.num_layers, config.hidden_dim
+    );
+
+    eprintln!("Loading weights...");
+    let weights = load_model_weights(&gguf, &mut reader)
+        .map_err(|e| format!("Error loading weights: {e}"))?;
+
+    let model = Model::new(config, weights);
+
+    // Load tokenizer: prefer external tokenizer.json, fall back to GGUF vocab
+    let tokenizer = if let Some(path) = tokenizer_path {
+        eprintln!("Loading tokenizer from {path}...");
+        let bpe =
+            BpeTokenizer::from_file(path).map_err(|e| format!("Error loading tokenizer: {e}"))?;
+        TokenizerState::Bpe(bpe)
+    } else {
+        let vocab =
+            GgufVocab::from_gguf(&gguf).map_err(|e| format!("No tokenizer available: {e}"))?;
+        eprintln!(
+            "Using GGUF-embedded vocabulary ({} tokens, bos={:?}, eos={:?})",
+            vocab.vocab_size, vocab.bos_id, vocab.eos_id
+        );
+        TokenizerState::Gguf(vocab)
+    };
+
+    // Detect chat template
+    let arch = gguf.architecture().unwrap_or("llama");
+    let chat_template = match gguf.metadata.get("tokenizer.chat_template") {
+        Some(MetadataValue::String(tmpl)) => {
+            let detected = ChatTemplate::from_gguf_template(tmpl, arch);
+            eprintln!("Chat template: {detected:?} (from GGUF metadata)");
+            detected
+        }
+        _ => {
+            let detected = ChatTemplate::from_architecture(arch);
+            eprintln!("Chat template: {detected:?} (from architecture)");
+            detected
+        }
+    };
+
+    Ok((model, tokenizer, chat_template))
 }
 
 async fn health() -> &'static str {
@@ -47,48 +206,186 @@ async fn health() -> &'static str {
 }
 
 async fn list_models(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let ready = state.model.is_some();
     Json(serde_json::json!({
         "object": "list",
         "data": [{
             "id": state.model_name,
             "object": "model",
             "owned_by": "local",
+            "ready": ready,
         }]
     }))
+}
+
+fn model_not_loaded_error() -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": {
+                "message": "No model loaded. Start the server with --model <path>",
+                "type": "server_error",
+                "code": "model_not_loaded"
+            }
+        })),
+    )
+        .into_response()
 }
 
 async fn chat_completions(
     State(state): State<Arc<AppState>>,
     Json(req): Json<ChatCompletionRequest>,
 ) -> Response {
-    let prompt_tokens = req
-        .messages
-        .iter()
-        .map(|m| m.content.len() / 4)
-        .sum::<usize>();
+    let model_mutex = match &state.model {
+        Some(m) => m,
+        None => return model_not_loaded_error(),
+    };
+    let tokenizer = match &state.tokenizer {
+        Some(t) => t,
+        None => return model_not_loaded_error(),
+    };
+    let template = match &state.chat_template {
+        Some(t) => t,
+        None => return model_not_loaded_error(),
+    };
 
     if req.stream {
-        stream_response(&state.model_name, &req, prompt_tokens)
+        stream_response(&state.model_name, &req, model_mutex, tokenizer, template)
     } else {
-        non_stream_response(&state.model_name, &req, prompt_tokens)
+        non_stream_response(&state.model_name, &req, model_mutex, tokenizer, template)
     }
+}
+
+/// Convert OpenAI-style messages to chat messages and format with template.
+fn format_prompt(messages: &[api::Message], template: &ChatTemplate) -> String {
+    let chat_messages: Vec<ChatMessage> = messages
+        .iter()
+        .map(|m| ChatMessage {
+            role: match m.role.as_str() {
+                "system" => Role::System,
+                "assistant" => Role::Assistant,
+                _ => Role::User,
+            },
+            content: m.content.clone(),
+        })
+        .collect();
+    template.apply(&chat_messages)
+}
+
+/// Encode text to tokens using the loaded tokenizer.
+fn encode_prompt(text: &str, tokenizer: &TokenizerState) -> Vec<u32> {
+    match tokenizer {
+        TokenizerState::Bpe(bpe) => match bpe.encode(text) {
+            Ok(tokens) => tokens,
+            Err(e) => {
+                eprintln!("BPE tokenization error: {e}");
+                text.bytes().map(|b| b as u32).collect()
+            }
+        },
+        TokenizerState::Gguf(vocab) => {
+            // Byte-level fallback: look up each byte in GGUF vocab
+            text.bytes()
+                .map(|b| {
+                    let byte_token = format!("<0x{b:02X}>");
+                    vocab.encode_token(&byte_token).unwrap_or(b as u32)
+                })
+                .collect()
+        }
+    }
+}
+
+/// Decode a single token ID to text.
+fn decode_token(token_id: u32, tokenizer: &TokenizerState) -> Option<String> {
+    match tokenizer {
+        TokenizerState::Bpe(bpe) => bpe.decode(&[token_id]).ok(),
+        TokenizerState::Gguf(vocab) => Some(vocab.decode(&[token_id])),
+    }
+}
+
+/// Get the EOS token ID.
+fn get_eos(tokenizer: &TokenizerState) -> Option<u32> {
+    match tokenizer {
+        TokenizerState::Bpe(bpe) => bpe.eos_token_id(),
+        TokenizerState::Gguf(vocab) => vocab.eos_id,
+    }
+}
+
+/// Simple xorshift32 RNG.
+fn make_rng() -> impl FnMut() -> f32 {
+    let mut state: u32 = 0xDEADBEEF
+        ^ (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos());
+    move || {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        (state as f32) / (u32::MAX as f32)
+    }
+}
+
+fn lock_error_response(err: &str) -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({
+            "error": {
+                "message": format!("Model lock error: {err}"),
+                "type": "server_error",
+            }
+        })),
+    )
+        .into_response()
 }
 
 fn non_stream_response(
     model_name: &str,
     req: &ChatCompletionRequest,
-    prompt_tokens: usize,
+    model_mutex: &Mutex<Model>,
+    tokenizer: &TokenizerState,
+    template: &ChatTemplate,
 ) -> Response {
-    let content = format!(
-        "Flare server received {} message(s). Model inference not yet wired up.",
-        req.messages.len()
+    let mut model = match model_mutex.lock() {
+        Ok(guard) => guard,
+        Err(e) => return lock_error_response(&e.to_string()),
+    };
+
+    let prompt = format_prompt(&req.messages, template);
+    let prompt_tokens = encode_prompt(&prompt, tokenizer);
+    let prompt_token_count = prompt_tokens.len();
+    let eos_token = get_eos(tokenizer);
+
+    let params = SamplingParams {
+        temperature: req.temperature,
+        top_p: req.top_p,
+        top_k: 40,
+        repeat_penalty: req.repeat_penalty,
+    };
+
+    model.reset();
+    let mut rng = make_rng();
+    let mut gen = Generator::new(&mut model, params);
+
+    let mut collected = String::new();
+    let generated = gen.generate(
+        &prompt_tokens,
+        req.max_tokens,
+        eos_token,
+        &mut rng,
+        |token_id, _step| {
+            if let Some(text) = decode_token(token_id, tokenizer) {
+                collected.push_str(&text);
+            }
+            true
+        },
     );
-    let completion_tokens = content.len() / 4;
+
+    let completion_tokens = generated.len();
 
     Json(ChatCompletionResponse::new(
         model_name,
-        content,
-        prompt_tokens,
+        collected,
+        prompt_token_count,
         completion_tokens,
     ))
     .into_response()
@@ -97,49 +394,72 @@ fn non_stream_response(
 fn stream_response(
     model_name: &str,
     req: &ChatCompletionRequest,
-    _prompt_tokens: usize,
+    model_mutex: &Mutex<Model>,
+    tokenizer: &TokenizerState,
+    template: &ChatTemplate,
 ) -> Response {
-    let model = model_name.to_string();
-    let id = format!("chatcmpl-stream-{}", rand_id());
-    let num_messages = req.messages.len();
+    let mut model = match model_mutex.lock() {
+        Ok(guard) => guard,
+        Err(e) => return lock_error_response(&e.to_string()),
+    };
 
+    let model_name_owned = model_name.to_string();
+    let id = format!("chatcmpl-stream-{}", rand_id());
+
+    let prompt = format_prompt(&req.messages, template);
+    let prompt_tokens = encode_prompt(&prompt, tokenizer);
+    let eos_token = get_eos(tokenizer);
+
+    let params = SamplingParams {
+        temperature: req.temperature,
+        top_p: req.top_p,
+        top_k: 40,
+        repeat_penalty: req.repeat_penalty,
+    };
+
+    let max_tokens = req.max_tokens;
+
+    // Run generation synchronously while we hold the lock, sending chunks via channel.
     let (tx, rx) = tokio::sync::mpsc::channel::<String>(32);
 
-    tokio::spawn(async move {
-        let role_chunk = ChatCompletionChunk::new_role(&model, &id);
-        let _ = tx
-            .send(format!(
-                "data: {}\n\n",
-                serde_json::to_string(&role_chunk).unwrap_or_default()
-            ))
-            .await;
+    // Send role chunk
+    let role_chunk = ChatCompletionChunk::new_role(&model_name_owned, &id);
+    if let Ok(json) = serde_json::to_string(&role_chunk) {
+        let _ = tx.try_send(format!("data: {json}\n\n"));
+    }
 
-        let placeholder = format!(
-            "Flare server received {} message(s). Streaming mode active.",
-            num_messages
-        );
-        for word in placeholder.split_inclusive(' ') {
-            let chunk = ChatCompletionChunk::new_delta(&model, &id, Some(word.to_string()), None);
-            let _ = tx
-                .send(format!(
-                    "data: {}\n\n",
-                    serde_json::to_string(&chunk).unwrap_or_default()
-                ))
-                .await;
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
+    // Run the actual generation
+    model.reset();
+    let mut rng = make_rng();
+    let mut gen = Generator::new(&mut model, params);
 
-        let done_chunk =
-            ChatCompletionChunk::new_delta(&model, &id, None, Some("stop".to_string()));
-        let _ = tx
-            .send(format!(
-                "data: {}\n\n",
-                serde_json::to_string(&done_chunk).unwrap_or_default()
-            ))
-            .await;
+    gen.generate(
+        &prompt_tokens,
+        max_tokens,
+        eos_token,
+        &mut rng,
+        |token_id, _step| {
+            if let Some(text) = decode_token(token_id, tokenizer) {
+                let chunk =
+                    ChatCompletionChunk::new_delta(&model_name_owned, &id, Some(text), None);
+                if let Ok(json) = serde_json::to_string(&chunk) {
+                    let _ = tx.try_send(format!("data: {json}\n\n"));
+                }
+            }
+            true
+        },
+    );
 
-        let _ = tx.send("data: [DONE]\n\n".to_string()).await;
-    });
+    // Send finish chunk
+    let done_chunk =
+        ChatCompletionChunk::new_delta(&model_name_owned, &id, None, Some("stop".to_string()));
+    if let Ok(json) = serde_json::to_string(&done_chunk) {
+        let _ = tx.try_send(format!("data: {json}\n\n"));
+    }
+    let _ = tx.try_send("data: [DONE]\n\n".to_string());
+
+    // Drop the sender so the stream finishes
+    drop(tx);
 
     let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
     let body = Body::from_stream(futures::stream::StreamExt::map(stream, |chunk| {
@@ -152,7 +472,13 @@ fn stream_response(
         .header(header::CACHE_CONTROL, "no-cache")
         .header(header::CONNECTION, "keep-alive")
         .body(body)
-        .unwrap()
+        .unwrap_or_else(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to build response",
+            )
+                .into_response()
+        })
 }
 
 fn rand_id() -> String {
@@ -174,6 +500,9 @@ mod tests {
     fn test_state() -> Arc<AppState> {
         Arc::new(AppState {
             model_name: "test-model".into(),
+            model: None,
+            tokenizer: None,
+            chat_template: None,
         })
     }
 
@@ -206,7 +535,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_chat_completions_non_streaming() {
+    async fn test_chat_completions_no_model_returns_error() {
         let app = app(test_state());
         let req_body = serde_json::json!({
             "messages": [{"role": "user", "content": "Hello"}],
@@ -223,22 +552,14 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-
-        assert_eq!(json["object"], "chat.completion");
-        assert_eq!(json["model"], "test-model");
-        assert_eq!(json["choices"][0]["finish_reason"], "stop");
-        assert!(json["choices"][0]["message"]["content"]
-            .as_str()
-            .unwrap()
-            .contains("1 message(s)"));
-        assert!(json["usage"]["total_tokens"].as_u64().unwrap() > 0);
+        assert_eq!(json["error"]["code"], "model_not_loaded");
     }
 
     #[tokio::test]
-    async fn test_chat_completions_streaming() {
+    async fn test_chat_completions_streaming_no_model_returns_error() {
         let app = app(test_state());
         let req_body = serde_json::json!({
             "messages": [{"role": "user", "content": "Hi"}],
@@ -255,51 +576,23 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(
-            resp.headers().get("content-type").unwrap(),
-            "text/event-stream"
-        );
-
-        let body = resp.into_body().collect().await.unwrap().to_bytes();
-        let body_str = String::from_utf8_lossy(&body);
-
-        // Should contain SSE data lines
-        assert!(body_str.contains("data: "));
-        // Should end with [DONE]
-        assert!(body_str.contains("data: [DONE]"));
-        // Should contain chat.completion.chunk
-        assert!(body_str.contains("chat.completion.chunk"));
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]
-    async fn test_chat_completions_multiple_messages() {
+    async fn test_cors_headers_present() {
         let app = app(test_state());
-        let req_body = serde_json::json!({
-            "messages": [
-                {"role": "system", "content": "You are helpful."},
-                {"role": "user", "content": "Hello"},
-                {"role": "assistant", "content": "Hi!"},
-                {"role": "user", "content": "How are you?"}
-            ]
-        });
-
         let resp = app
             .oneshot(
-                Request::post("/v1/chat/completions")
-                    .header("content-type", "application/json")
-                    .body(Body::from(serde_json::to_string(&req_body).unwrap()))
+                Request::get("/health")
+                    .header("Origin", "http://localhost:3000")
+                    .body(Body::empty())
                     .unwrap(),
             )
             .await
             .unwrap();
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let body = resp.into_body().collect().await.unwrap().to_bytes();
-        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(json["choices"][0]["message"]["content"]
-            .as_str()
-            .unwrap()
-            .contains("4 message(s)"));
+        assert!(resp.headers().contains_key("access-control-allow-origin"));
     }
 }


### PR DESCRIPTION
## Summary
- Loads GGUF model at startup via `--model <path>` flag
- `/v1/chat/completions` now runs actual inference with the loaded model
- Supports both streaming (SSE) and non-streaming responses
- Chat template auto-detection from GGUF metadata
- CORS headers via tower-http for browser clients
- Returns 503 JSON error when no model is loaded
- Makes `ComputeBackend: Send + Sync` for `Arc<Mutex<Model>>` thread sharing

Closes #53

## Usage
```bash
cargo run -p flare-server --release -- --model path/to/model.gguf --port 8080

# Test with curl
curl http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"messages":[{"role":"user","content":"Hello"}],"max_tokens":50}'
```

## Test plan
- [x] All 142 tests pass
- [x] New tests: model-not-loaded returns 503, CORS headers present
- [x] `cargo check --workspace --all-targets`