### PR TITLE
Rename workspace crates to flarellm-* for crates.io

### DIFF
--- a/BENCHMARK_HISTORY.md
+++ b/BENCHMARK_HISTORY.md
@@ -52,3 +52,16 @@ Baseline model: SmolLM2-135M-Instruct Q8_0 (138MB, 30 layers, dim=576).
 | Decode (256 tok) | 107.3 |
 | Sustained (512 tok) | **93.1** |
 
+### 2026-04-09 20:13 — `7c9cede Add benchmark history log with --log flag (#65)`
+
+**Hardware:** Apple M5 Pro, ARM64 (NEON SIMD)  
+**Model:** Llama, ~162M params, 30 layers, dim=576  
+**Load time:** 0.11s
+
+| Metric | tok/s |
+|---|---|
+| Decode (16 tok) | 123.6 |
+| Decode (64 tok) | 120.2 |
+| Decode (256 tok) | 106.8 |
+| Sustained (512 tok) | **78.9** |
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "flare-core"
+name = "flarellm"
+version = "0.0.1"
+
+[[package]]
+name = "flarellm-core"
 version = "0.1.0"
 dependencies = [
  "byteorder",
@@ -346,12 +350,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "flare-gpu"
+name = "flarellm-gpu"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
  "byteorder",
- "flare-core",
+ "flarellm-core",
  "log",
  "pollster",
  "thiserror 2.0.18",
@@ -359,11 +363,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "flare-loader"
+name = "flarellm-loader"
 version = "0.1.0"
 dependencies = [
  "byteorder",
- "flare-core",
+ "flarellm-core",
  "log",
  "serde",
  "serde_json",
@@ -371,14 +375,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "flare-server"
+name = "flarellm-server"
 version = "0.1.0"
 dependencies = [
  "axum",
  "clap",
- "flare-core",
- "flare-gpu",
- "flare-loader",
+ "flarellm-core",
+ "flarellm-gpu",
+ "flarellm-loader",
  "futures",
  "http-body-util",
  "log",
@@ -392,22 +396,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "flare-simd"
+name = "flarellm-simd"
 version = "0.1.0"
 dependencies = [
- "flare-core",
+ "flarellm-core",
  "log",
  "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "flare-web"
+name = "flarellm-web"
 version = "0.1.0"
 dependencies = [
- "flare-core",
- "flare-gpu",
- "flare-loader",
- "flare-simd",
+ "flarellm-core",
+ "flarellm-gpu",
+ "flarellm-loader",
+ "flarellm-simd",
  "js-sys",
  "log",
  "serde",
@@ -417,10 +421,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
-
-[[package]]
-name = "flarellm"
-version = "0.0.1"
 
 [[package]]
 name = "foldhash"

--- a/flare-core/Cargo.toml
+++ b/flare-core/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
-name = "flare-core"
+name = "flarellm-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Core inference engine for Flare LLM runtime"
+keywords = ["llm", "inference", "ai", "tensor"]
+categories = ["science", "no-std"]
+readme = "../README.md"
+
+[lib]
+name = "flare_core"
 
 [dependencies]
 thiserror = { workspace = true }

--- a/flare-gpu/Cargo.toml
+++ b/flare-gpu/Cargo.toml
@@ -1,13 +1,19 @@
 [package]
-name = "flare-gpu"
+name = "flarellm-gpu"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "WebGPU/wgpu compute backend for Flare LLM inference"
+keywords = ["webgpu", "wgpu", "llm", "gpu", "compute"]
+categories = ["graphics", "science"]
+readme = "../README.md"
+
+[lib]
+name = "flare_gpu"
 
 [dependencies]
-flare-core = { path = "../flare-core" }
+flare-core = { package = "flarellm-core", path = "../flare-core", version = "0.1.0" }
 wgpu = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }

--- a/flare-loader/Cargo.toml
+++ b/flare-loader/Cargo.toml
@@ -1,13 +1,19 @@
 [package]
-name = "flare-loader"
+name = "flarellm-loader"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Model weight loading for Flare (GGUF, SafeTensors, progressive streaming)"
+keywords = ["gguf", "llm", "safetensors", "loader"]
+categories = ["parser-implementations", "science"]
+readme = "../README.md"
+
+[lib]
+name = "flare_loader"
 
 [dependencies]
-flare-core = { path = "../flare-core" }
+flare-core = { package = "flarellm-core", path = "../flare-core", version = "0.1.0" }
 thiserror = { workspace = true }
 byteorder = { workspace = true }
 log = { workspace = true }

--- a/flare-server/Cargo.toml
+++ b/flare-server/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
-name = "flare-server"
+name = "flarellm-server"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Native server with OpenAI-compatible API for Flare LLM inference"
+keywords = ["llm", "server", "openai", "inference", "api"]
+categories = ["web-programming::http-server", "science"]
+readme = "../README.md"
 
 [[bin]]
 name = "flare-server"
@@ -19,9 +22,9 @@ name = "flare-info"
 path = "src/info.rs"
 
 [dependencies]
-flare-core = { path = "../flare-core" }
-flare-loader = { path = "../flare-loader" }
-flare-gpu = { path = "../flare-gpu" }
+flare-core = { package = "flarellm-core", path = "../flare-core", version = "0.1.0" }
+flare-loader = { package = "flarellm-loader", path = "../flare-loader", version = "0.1.0" }
+flare-gpu = { package = "flarellm-gpu", path = "../flare-gpu", version = "0.1.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/flare-simd/Cargo.toml
+++ b/flare-simd/Cargo.toml
@@ -1,16 +1,22 @@
 [package]
-name = "flare-simd"
+name = "flarellm-simd"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "WASM SIMD128 CPU fallback backend for Flare LLM inference"
+keywords = ["wasm", "simd", "llm", "cpu"]
+categories = ["wasm", "science"]
+readme = "../README.md"
+
+[lib]
+name = "flare_simd"
 
 [[bench]]
 name = "matmul_bench"
 harness = false
 
 [dependencies]
-flare-core = { path = "../flare-core" }
+flare-core = { package = "flarellm-core", path = "../flare-core", version = "0.1.0" }
 thiserror = { workspace = true }
 log = { workspace = true }

--- a/flare-web/Cargo.toml
+++ b/flare-web/Cargo.toml
@@ -1,19 +1,23 @@
 [package]
-name = "flare-web"
+name = "flarellm-web"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Browser integration for Flare LLM inference (WASM, Web Workers, Cache API)"
+keywords = ["wasm", "browser", "llm", "webgpu"]
+categories = ["wasm", "web-programming"]
+readme = "../README.md"
 
 [lib]
+name = "flare_web"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-flare-core = { path = "../flare-core" }
-flare-loader = { path = "../flare-loader" }
-flare-gpu = { path = "../flare-gpu" }
-flare-simd = { path = "../flare-simd" }
+flare-core = { package = "flarellm-core", path = "../flare-core", version = "0.1.0" }
+flare-loader = { package = "flarellm-loader", path = "../flare-loader", version = "0.1.0" }
+flare-gpu = { package = "flarellm-gpu", path = "../flare-gpu", version = "0.1.0" }
+flare-simd = { package = "flarellm-simd", path = "../flare-simd", version = "0.1.0" }
 wasm-bindgen = { workspace = true }
 web-sys = { workspace = true, features = [
     "console",


### PR DESCRIPTION
## Summary
- The crate name flare-core is taken by an unrelated WebSocket project on crates.io
- Renames all 6 workspace crates to flarellm-* namespace
- Source code unchanged: lib.name keeps imports as flare_core::*
- Internal deps use package = "flarellm-*" rename
- Adds keywords, categories, readme metadata
- All 143 tests pass, cargo package -p flarellm-core verifies cleanly

Closes #63