### PR TITLE
Add re-exports and feature flags to flarellm crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,12 @@ dependencies = [
 
 [[package]]
 name = "flarellm"
-version = "0.0.1"
+version = "0.1.0"
+dependencies = [
+ "flarellm-core",
+ "flarellm-gpu",
+ "flarellm-loader",
+]
 
 [[package]]
 name = "flarellm-core"

--- a/flarellm/Cargo.toml
+++ b/flarellm/Cargo.toml
@@ -1,9 +1,21 @@
 [package]
 name = "flarellm"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/sauravpanda/flarellm"
 description = "A WASM-first LLM inference engine with WebGPU acceleration"
 keywords = ["llm", "wasm", "webgpu", "inference", "ai"]
 categories = ["wasm", "science"]
+readme = "../README.md"
+
+[features]
+default = ["loader"]
+loader = ["dep:flarellm-loader"]
+gpu = ["dep:flarellm-gpu"]
+all = ["loader", "gpu"]
+
+[dependencies]
+flarellm-core = { path = "../flare-core", version = "0.1.0" }
+flarellm-loader = { path = "../flare-loader", version = "0.1.0", optional = true }
+flarellm-gpu = { path = "../flare-gpu", version = "0.1.0", optional = true }

--- a/flarellm/src/lib.rs
+++ b/flarellm/src/lib.rs
@@ -5,4 +5,43 @@
 //! Run large language models directly in the browser with zero server costs.
 //! Built in pure Rust, compiles to both native and WebAssembly.
 //!
-//! **Status**: Early development. See the [repository](https://github.com/sauravpanda/flarellm) for progress.
+//! See the [repository](https://github.com/sauravpanda/flarellm) for examples
+//! and architecture documentation.
+//!
+//! ## Crate organization
+//!
+//! - [`core`] — model, tensor, sampling, generation (always available)
+//! - [`loader`] — GGUF / SafeTensors loading (enabled by `loader` feature, default)
+//! - [`gpu`] — WebGPU compute backend (enabled by `gpu` feature)
+//!
+//! ## Quick start
+//!
+//! ```no_run
+//! use flarellm::core::generate::Generator;
+//! use flarellm::core::sampling::SamplingParams;
+//! use flarellm::loader::gguf::GgufFile;
+//! use flarellm::loader::weights::load_model_weights;
+//! use flarellm::core::model::Model;
+//! use std::fs::File;
+//! use std::io::BufReader;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut reader = BufReader::new(File::open("model.gguf")?);
+//! let gguf = GgufFile::parse_header(&mut reader)?;
+//! let config = gguf.to_model_config()?;
+//! let weights = load_model_weights(&gguf, &mut reader)?;
+//! let mut model = Model::new(config, weights);
+//!
+//! let mut gen = Generator::new(&mut model, SamplingParams::default());
+//! let tokens = gen.generate(&[1, 2, 3], 50, None, || 0.5, |_, _| true);
+//! # Ok(())
+//! # }
+//! ```
+
+pub use flare_core as core;
+
+#[cfg(feature = "loader")]
+pub use flare_loader as loader;
+
+#[cfg(feature = "gpu")]
+pub use flare_gpu as gpu;


### PR DESCRIPTION
## Summary
- Adds re-exports for core/loader/gpu through the flarellm umbrella crate
- Feature flags: `loader` (default), `gpu` (opt-in), `all`
- Users can `cargo add flarellm` and get the full stack
- Doc-test verifies the API surface

Builds on #66 (publish-setup branch).