### PR TITLE
Add rayon parallel matvec — 1B model 13 → 23 tok/s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +342,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -344,6 +375,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "log",
+ "rayon",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1075,6 +1107,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/flare-core/Cargo.toml
+++ b/flare-core/Cargo.toml
@@ -18,3 +18,7 @@ byteorder = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+# Native multi-threading via rayon. Disabled on wasm32 (no threads).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rayon = "1.10"

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -358,59 +358,92 @@ pub fn matvec(mat: &[f32], vec: &[f32], rows: usize, cols: usize) -> Vec<f32> {
     }
 }
 
-/// ARM NEON SIMD matvec: 4 f32 lanes × 4 accumulators = 16 elements per iteration.
+/// Compute one row of NEON matvec. Used by both serial and parallel paths.
+///
+/// # Safety
+/// `row` and `vec` must both have length `cols`. NEON is always available on aarch64.
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+unsafe fn matvec_neon_row(row: &[f32], vec: &[f32], cols: usize) -> f32 {
+    use std::arch::aarch64::*;
+    let cols16 = cols & !15;
+
+    let mut acc0 = vdupq_n_f32(0.0);
+    let mut acc1 = vdupq_n_f32(0.0);
+    let mut acc2 = vdupq_n_f32(0.0);
+    let mut acc3 = vdupq_n_f32(0.0);
+
+    let mut j = 0usize;
+    while j < cols16 {
+        let r0 = vld1q_f32(row.as_ptr().add(j));
+        let v0 = vld1q_f32(vec.as_ptr().add(j));
+        acc0 = vfmaq_f32(acc0, r0, v0);
+
+        let r1 = vld1q_f32(row.as_ptr().add(j + 4));
+        let v1 = vld1q_f32(vec.as_ptr().add(j + 4));
+        acc1 = vfmaq_f32(acc1, r1, v1);
+
+        let r2 = vld1q_f32(row.as_ptr().add(j + 8));
+        let v2 = vld1q_f32(vec.as_ptr().add(j + 8));
+        acc2 = vfmaq_f32(acc2, r2, v2);
+
+        let r3 = vld1q_f32(row.as_ptr().add(j + 12));
+        let v3 = vld1q_f32(vec.as_ptr().add(j + 12));
+        acc3 = vfmaq_f32(acc3, r3, v3);
+
+        j += 16;
+    }
+
+    let sum01 = vaddq_f32(acc0, acc1);
+    let sum23 = vaddq_f32(acc2, acc3);
+    let sum = vaddq_f32(sum01, sum23);
+    let mut scalar = vaddvq_f32(sum);
+
+    while j < cols {
+        scalar += row[j] * vec[j];
+        j += 1;
+    }
+    scalar
+}
+
+/// ARM NEON SIMD matvec with rayon parallelism on native, serial on wasm32.
+///
+/// Parallelizes by chunking rows so each task handles many rows. The threshold
+/// is based on total work (rows * cols) to amortize rayon dispatch overhead.
 #[cfg(target_arch = "aarch64")]
 fn matvec_neon(mat: &[f32], vec: &[f32], rows: usize, cols: usize) -> Vec<f32> {
-    use std::arch::aarch64::*;
+    // Total FMAs above which parallelism wins. ~5M FMAs / ~50µs sequential break-even.
+    const PARALLEL_FMA_THRESHOLD: usize = 5_000_000;
+    // Chunk size: balance task granularity vs overhead
+    const CHUNK_ROWS: usize = 64;
 
+    let total_work = rows * cols;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    if total_work >= PARALLEL_FMA_THRESHOLD && rows >= CHUNK_ROWS * 2 {
+        use rayon::prelude::*;
+        let mut output = vec![0.0f32; rows];
+        output
+            .par_chunks_mut(CHUNK_ROWS)
+            .enumerate()
+            .for_each(|(chunk_idx, out_chunk)| {
+                let row_start = chunk_idx * CHUNK_ROWS;
+                for (local_i, out) in out_chunk.iter_mut().enumerate() {
+                    let i = row_start + local_i;
+                    let row = &mat[i * cols..i * cols + cols];
+                    // SAFETY: row.len() == cols, NEON always available on aarch64
+                    *out = unsafe { matvec_neon_row(row, vec, cols) };
+                }
+            });
+        return output;
+    }
+
+    // Sequential path
     let mut output = vec![0.0f32; rows];
-    let cols16 = cols & !15; // round down to 16
-
     for (i, out) in output.iter_mut().enumerate() {
         let row = &mat[i * cols..i * cols + cols];
-
-        // Safety: we stay within bounds (cols16 <= cols), and aarch64 NEON is always available.
-        unsafe {
-            let mut acc0 = vdupq_n_f32(0.0);
-            let mut acc1 = vdupq_n_f32(0.0);
-            let mut acc2 = vdupq_n_f32(0.0);
-            let mut acc3 = vdupq_n_f32(0.0);
-
-            let mut j = 0usize;
-            while j < cols16 {
-                let r0 = vld1q_f32(row.as_ptr().add(j));
-                let v0 = vld1q_f32(vec.as_ptr().add(j));
-                acc0 = vfmaq_f32(acc0, r0, v0);
-
-                let r1 = vld1q_f32(row.as_ptr().add(j + 4));
-                let v1 = vld1q_f32(vec.as_ptr().add(j + 4));
-                acc1 = vfmaq_f32(acc1, r1, v1);
-
-                let r2 = vld1q_f32(row.as_ptr().add(j + 8));
-                let v2 = vld1q_f32(vec.as_ptr().add(j + 8));
-                acc2 = vfmaq_f32(acc2, r2, v2);
-
-                let r3 = vld1q_f32(row.as_ptr().add(j + 12));
-                let v3 = vld1q_f32(vec.as_ptr().add(j + 12));
-                acc3 = vfmaq_f32(acc3, r3, v3);
-
-                j += 16;
-            }
-
-            // Reduce 4 accumulators → scalar
-            let sum01 = vaddq_f32(acc0, acc1);
-            let sum23 = vaddq_f32(acc2, acc3);
-            let sum = vaddq_f32(sum01, sum23);
-            let mut scalar = vaddvq_f32(sum);
-
-            // Handle remainder
-            while j < cols {
-                scalar += row[j] * vec[j];
-                j += 1;
-            }
-
-            *out = scalar;
-        }
+        // SAFETY: row.len() == cols, NEON always available on aarch64
+        *out = unsafe { matvec_neon_row(row, vec, cols) };
     }
     output
 }


### PR DESCRIPTION
## Summary
- Parallelizes matvec via rayon for large matrices (5M+ FMAs threshold)
- Chunks rows into groups of 64 to balance task granularity
- Sequential fallback for small matrices avoids rayon overhead
- WASM excluded (no threads)

## Results (M5 Pro)
| Model | Before | After | Change |
|---|---|---|---|
| SmolLM-135M Q8_0 | 95.3 tok/s | **101.4 tok/s** | +6% |
| Llama-3.2-1B Q8_0 | 13.0 tok/s | **23.2 tok/s** | **+78%** |

Phase 1 target for 1B (15 tok/s) now exceeded.

## Test plan
- [x] All 143 tests pass
- [x] cargo clippy clean