### PR TITLE
Add doc CI job and fix broken intra-doc links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,14 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build flare-web for WASM
         run: wasm-pack build flare-web --target web
+
+  doc:
+    name: Doc build
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --workspace --no-deps --all-features

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -11,7 +11,7 @@ pub trait ComputeBackend: Send + Sync {
     fn softmax(&self, input: &mut Tensor);
     fn silu_mul(&self, gate: &Tensor, up: &Tensor, output: &mut Tensor);
 
-    /// Matrix-vector multiply: output[rows] = mat[rows, cols] * vec[cols].
+    /// Matrix-vector multiply: `output[rows]` = `mat[rows, cols]` * `vec[cols]`.
     /// Default implementation reshapes into matmul, but backends can override
     /// with a more efficient kernel.
     fn matvec(&self, mat: &[f32], vec: &[f32], rows: usize, cols: usize) -> Vec<f32> {
@@ -192,7 +192,7 @@ impl Model {
     }
 
     /// Run a single forward pass for one token position.
-    /// Returns logits over the vocabulary [vocab_size].
+    /// Returns logits over the vocabulary `[vocab_size]`.
     ///
     /// Delegates heavy compute (matvec, rmsnorm, rope, silu_mul) to the
     /// active `ComputeBackend`. By default this is `CpuBackend`; call
@@ -424,7 +424,7 @@ unsafe fn rmsnorm_neon(x: &[f32], weight: &[f32], eps: f32) -> Vec<f32> {
     output
 }
 
-/// Matrix-vector multiply: output[rows] = mat[rows, cols] * vec[cols] (CPU implementation).
+/// Matrix-vector multiply: `output[rows]` = `mat[rows, cols]` * `vec[cols]` (CPU implementation).
 ///
 /// Dispatches to platform-specific SIMD implementations:
 /// - ARM NEON (aarch64): 4-wide f32 SIMD, 4 accumulators (16 elements/iter), compile-time

--- a/flare-loader/src/quantize.rs
+++ b/flare-loader/src/quantize.rs
@@ -163,7 +163,7 @@ pub fn dequant_q5_0_block(block: &[u8], output: &mut [f32; 32]) {
 }
 
 /// Dequantize a Q6_K block: 256 weights.
-/// Layout: ql[128] + qh[64] + scales[16] + d[2] = 210 bytes.
+/// Layout: `ql[128]` + `qh[64]` + `scales[16]` + `d[2]` = 210 bytes.
 ///
 /// Follows llama.cpp dequant_row_q6_K exactly: processes two halves of 128
 /// elements each, with interleaved ql/qh access in groups of 32.
@@ -209,7 +209,7 @@ pub fn dequant_q6k_block(block: &[u8], output: &mut [f32; 256]) {
 }
 
 /// Dequantize a Q4_K block: 256 weights.
-/// Layout: d (f16) + dmin (f16) + scales[12] + qs[128]
+/// Layout: d (f16) + dmin (f16) + `scales[12]` + `qs[128]`
 pub fn dequant_q4k_block(block: &[u8], output: &mut [f32; 256]) {
     // Q4_K_M: 2 (d) + 2 (dmin) + 12 (scales) + 128 (qs) = 144 bytes
     if block.len() < 144 {
@@ -248,7 +248,7 @@ pub fn dequant_q4k_block(block: &[u8], output: &mut [f32; 256]) {
 }
 
 /// Dequantize a Q5_K block: 256 weights.
-/// Layout: d (f16) + dmin (f16) + scales[12] + qh[32] + ql[128]
+/// Layout: d (f16) + dmin (f16) + `scales[12]` + `qh[32]` + `ql[128]`
 /// Each weight is 5 bits: 4 from ql + 1 from qh.
 pub fn dequant_q5k_block(block: &[u8], output: &mut [f32; 256]) {
     // Q5_K: 2 (d) + 2 (dmin) + 12 (scales) + 32 (qh) + 128 (ql) = 176 bytes


### PR DESCRIPTION
Adds cargo doc check with -D warnings to catch broken links. Fixes existing broken links in quantize.rs and model.rs (bracketed identifiers needed escaping).