### PR TITLE
Add real WASM bindings to flare-web (FlareEngine class)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +455,7 @@ dependencies = [
 name = "flarellm-web"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
  "flarellm-core",
  "flarellm-gpu",
  "flarellm-loader",

--- a/flare-web/Cargo.toml
+++ b/flare-web/Cargo.toml
@@ -40,3 +40,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
+console_error_panic_hook = "0.1"

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -1,9 +1,39 @@
 //! Browser integration for Flare LLM.
 //!
-//! Provides WASM-bindgen exports for WebGPU detection, device info,
-//! and engine initialization. Designed to be built with `wasm-pack`.
+//! Provides WASM-bindgen exports for loading GGUF models from JS, running
+//! inference, and detecting WebGPU. Designed to be built with `wasm-pack`.
+//!
+//! # Quick start (JS)
+//!
+//! ```javascript
+//! import init, { FlareEngine, webgpu_available } from './pkg/flare_web.js';
+//!
+//! await init();
+//! console.log('WebGPU:', webgpu_available());
+//!
+//! // Load model from a fetched ArrayBuffer
+//! const response = await fetch('model.gguf');
+//! const bytes = new Uint8Array(await response.arrayBuffer());
+//! const engine = FlareEngine.load(bytes);
+//!
+//! // Generate
+//! const tokens = engine.generate_tokens(new Uint32Array([1, 2, 3]), 50);
+//! ```
 
+use std::io::Cursor;
+
+use flare_core::generate::Generator;
+use flare_core::model::Model;
+use flare_core::sampling::SamplingParams;
+use flare_loader::gguf::GgufFile;
+use flare_loader::weights::load_model_weights;
 use wasm_bindgen::prelude::*;
+
+/// Set up better panic messages in the browser console.
+#[wasm_bindgen(start)]
+pub fn start() {
+    console_error_panic_hook::set_once();
+}
 
 /// Check if WebGPU is available in the current browser.
 #[wasm_bindgen]
@@ -13,14 +43,13 @@ pub fn webgpu_available() -> bool {
         None => return false,
     };
 
-    // Check if navigator.gpu exists
     let navigator: JsValue = window.navigator().into();
     js_sys::Reflect::get(&navigator, &JsValue::from_str("gpu"))
         .map(|v| !v.is_undefined() && !v.is_null())
         .unwrap_or(false)
 }
 
-/// Get basic device info for capability detection.
+/// Get basic device info as a JSON string.
 #[wasm_bindgen]
 pub fn device_info() -> String {
     let ua: String = web_sys::window()
@@ -35,12 +64,104 @@ pub fn device_info() -> String {
     )
 }
 
-/// Placeholder: initialize the Flare engine.
-/// Will set up WebGPU device, create compute pipelines, etc.
+/// Flare LLM inference engine, exported to JS.
+///
+/// Holds a loaded model and runs greedy/sampled token generation.
 #[wasm_bindgen]
-pub async fn init() -> Result<JsValue, JsValue> {
-    // Set up panic hook for better error messages in browser console
-    // TODO: add console_error_panic_hook feature for better WASM error messages
+pub struct FlareEngine {
+    model: Model,
+}
 
-    Ok(JsValue::from_str("flare initialized"))
+#[wasm_bindgen]
+impl FlareEngine {
+    /// Load a GGUF model from a Uint8Array of bytes (e.g. from `fetch`).
+    #[wasm_bindgen]
+    pub fn load(gguf_bytes: &[u8]) -> Result<FlareEngine, JsError> {
+        let mut reader = Cursor::new(gguf_bytes);
+        let gguf = GgufFile::parse_header(&mut reader)
+            .map_err(|e| JsError::new(&format!("GGUF parse error: {e}")))?;
+        let config = gguf
+            .to_model_config()
+            .map_err(|e| JsError::new(&format!("Model config error: {e}")))?;
+        let weights = load_model_weights(&gguf, &mut reader)
+            .map_err(|e| JsError::new(&format!("Weight load error: {e}")))?;
+
+        Ok(FlareEngine {
+            model: Model::new(config, weights),
+        })
+    }
+
+    /// Reset the KV cache (start a new conversation).
+    #[wasm_bindgen]
+    pub fn reset(&mut self) {
+        self.model.reset();
+    }
+
+    /// Get the vocabulary size of the loaded model.
+    #[wasm_bindgen(getter)]
+    pub fn vocab_size(&self) -> u32 {
+        self.model.config().vocab_size as u32
+    }
+
+    /// Get the number of layers.
+    #[wasm_bindgen(getter)]
+    pub fn num_layers(&self) -> u32 {
+        self.model.config().num_layers as u32
+    }
+
+    /// Get the hidden dimension.
+    #[wasm_bindgen(getter)]
+    pub fn hidden_dim(&self) -> u32 {
+        self.model.config().hidden_dim as u32
+    }
+
+    /// Generate `max_tokens` tokens starting from `prompt_tokens` (greedy).
+    /// Returns a Uint32Array of generated token IDs.
+    #[wasm_bindgen]
+    pub fn generate_tokens(&mut self, prompt_tokens: &[u32], max_tokens: u32) -> Vec<u32> {
+        let params = SamplingParams {
+            temperature: 0.0,
+            ..Default::default()
+        };
+        let mut gen = Generator::new(&mut self.model, params);
+        gen.generate(
+            prompt_tokens,
+            max_tokens as usize,
+            None,
+            || 0.5,
+            |_, _| true,
+        )
+    }
+
+    /// Generate with sampling parameters. Uses a fixed RNG seed for reproducibility
+    /// (browser apps should pass their own RNG via JS-side state).
+    #[wasm_bindgen]
+    pub fn generate_with_params(
+        &mut self,
+        prompt_tokens: &[u32],
+        max_tokens: u32,
+        temperature: f32,
+        top_p: f32,
+    ) -> Vec<u32> {
+        let params = SamplingParams {
+            temperature,
+            top_p,
+            top_k: 40,
+            repeat_penalty: 1.1,
+        };
+        let mut gen = Generator::new(&mut self.model, params);
+        // Simple LCG for browser-side RNG (deterministic per call)
+        let mut state: u32 = 0x12345678;
+        let mut rng = move || {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            (state as f32) / (u32::MAX as f32)
+        };
+        gen.generate(
+            prompt_tokens,
+            max_tokens as usize,
+            None,
+            &mut rng,
+            |_, _| true,
+        )
+    }
 }


### PR DESCRIPTION
## Summary
Replaces the placeholder lib.rs with a proper FlareEngine class exposed via wasm-bindgen.

## API
```javascript
import init, { FlareEngine, webgpu_available } from './pkg/flare_web.js';

await init();
const response = await fetch('model.gguf');
const bytes = new Uint8Array(await response.arrayBuffer());
const engine = FlareEngine.load(bytes);

console.log('Vocab:', engine.vocab_size);
console.log('Layers:', engine.num_layers);

const tokens = engine.generate_tokens(new Uint32Array([1, 2, 3]), 50);
```

## Test plan
- [x] All 143 tests pass
- [x] cargo check + clippy clean
- [x] wasm-pack build succeeds, exports verified in flare_web.d.ts