### PR TITLE
Add minimal browser demo HTML page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +455,7 @@ dependencies = [
 name = "flarellm-web"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
  "flarellm-core",
  "flarellm-gpu",
  "flarellm-loader",

--- a/flare-web/Cargo.toml
+++ b/flare-web/Cargo.toml
@@ -40,3 +40,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
+console_error_panic_hook = "0.1"

--- a/flare-web/demo/README.md
+++ b/flare-web/demo/README.md
@@ -1,0 +1,40 @@
+# Flare Browser Demo
+
+A minimal HTML page that loads the WASM build and runs inference entirely in the browser.
+
+## Quick start
+
+```bash
+# 1. Build the WASM package
+wasm-pack build flare-web --target web
+
+# 2. Serve the demo (any HTTP server works)
+cd flare-web
+python3 -m http.server 8000
+
+# 3. Open http://localhost:8000/demo/
+```
+
+## What it does
+
+1. Loads the `flare_web` WASM module
+2. Detects WebGPU availability
+3. Lets you upload a GGUF file via `<input type="file">`
+4. Calls `FlareEngine.load(bytes)` to parse and load the model
+5. Calls `engine.generate_tokens(prompt, 30)` to generate from BOS
+
+## Limitations
+
+- The demo shows raw token IDs (no BPE detokenization in JS yet)
+- Loads the entire model into memory at once (no progressive loading yet)
+- CPU only (WebGPU compute path not yet wired through wasm-bindgen)
+
+## Try it with SmolLM2-135M Q8_0
+
+```bash
+# Download from HuggingFace (~138MB)
+curl -L "https://huggingface.co/bartowski/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-Q8_0.gguf" \
+  -o SmolLM2-135M-Instruct-Q8_0.gguf
+```
+
+Then drag the file into the demo page.

--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flare LLM Browser Demo</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    }
+    body {
+      max-width: 720px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      line-height: 1.5;
+    }
+    h1 { margin-bottom: 0.25rem; }
+    .subtitle { opacity: 0.7; margin-top: 0; }
+    .panel {
+      border: 1px solid #8884;
+      border-radius: 8px;
+      padding: 1rem;
+      margin: 1rem 0;
+    }
+    button {
+      font: inherit;
+      padding: 0.5rem 1rem;
+      border: 1px solid #8888;
+      border-radius: 4px;
+      background: #8881;
+      cursor: pointer;
+    }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    button:hover:not(:disabled) { background: #8882; }
+    pre {
+      background: #8881;
+      padding: 0.75rem;
+      border-radius: 4px;
+      overflow-x: auto;
+      font-size: 0.9rem;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .stats { font-size: 0.85rem; opacity: 0.8; }
+    .error { color: #d33; }
+    progress { width: 100%; }
+  </style>
+</head>
+<body>
+  <h1>Flare LLM</h1>
+  <p class="subtitle">WASM-first LLM inference, running entirely in your browser.</p>
+
+  <div class="panel">
+    <h3>Status</h3>
+    <p id="status">Initializing WASM module...</p>
+    <p class="stats" id="env"></p>
+  </div>
+
+  <div class="panel">
+    <h3>1. Load a model</h3>
+    <p>Drop a GGUF file here, or click to select. Try SmolLM2-135M Q8_0 (~138MB).</p>
+    <input type="file" id="file-input" accept=".gguf" disabled>
+    <progress id="load-progress" value="0" max="1" hidden></progress>
+    <p class="stats" id="model-info"></p>
+  </div>
+
+  <div class="panel">
+    <h3>2. Generate</h3>
+    <p>Click to generate 30 tokens starting from BOS (token 1).</p>
+    <button id="generate" disabled>Generate</button>
+    <pre id="output"></pre>
+    <p class="stats" id="gen-stats"></p>
+  </div>
+
+  <p class="subtitle" style="text-align:center; margin-top:2rem;">
+    <a href="https://github.com/sauravpanda/flarellm">github.com/sauravpanda/flarellm</a>
+  </p>
+
+  <script type="module">
+    import init, { FlareEngine, webgpu_available, device_info } from '../pkg/flare_web.js';
+
+    const $status = document.getElementById('status');
+    const $env = document.getElementById('env');
+    const $fileInput = document.getElementById('file-input');
+    const $progress = document.getElementById('load-progress');
+    const $modelInfo = document.getElementById('model-info');
+    const $generate = document.getElementById('generate');
+    const $output = document.getElementById('output');
+    const $genStats = document.getElementById('gen-stats');
+
+    let engine = null;
+
+    async function start() {
+      try {
+        await init();
+        $status.textContent = 'WASM module loaded. Ready.';
+        $env.textContent = `WebGPU: ${webgpu_available() ? 'yes' : 'no'}`;
+        $fileInput.disabled = false;
+      } catch (err) {
+        $status.textContent = 'Failed to load WASM: ' + err;
+        $status.classList.add('error');
+      }
+    }
+
+    $fileInput.addEventListener('change', async (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+
+      $progress.hidden = false;
+      $progress.value = 0;
+      $modelInfo.textContent = `Reading ${(file.size / 1e6).toFixed(1)}MB...`;
+
+      try {
+        const buffer = await file.arrayBuffer();
+        $progress.value = 0.5;
+        $modelInfo.textContent = 'Parsing GGUF and loading weights...';
+
+        // Yield to UI
+        await new Promise(r => setTimeout(r, 10));
+
+        const bytes = new Uint8Array(buffer);
+        const t0 = performance.now();
+        engine = FlareEngine.load(bytes);
+        const loadMs = performance.now() - t0;
+
+        $progress.value = 1;
+        $modelInfo.textContent = `Loaded in ${loadMs.toFixed(0)}ms. ` +
+          `Vocab: ${engine.vocab_size}, Layers: ${engine.num_layers}, Hidden: ${engine.hidden_dim}`;
+        $generate.disabled = false;
+        setTimeout(() => { $progress.hidden = true; }, 500);
+      } catch (err) {
+        $modelInfo.textContent = 'Error: ' + err;
+        $modelInfo.classList.add('error');
+      }
+    });
+
+    $generate.addEventListener('click', async () => {
+      if (!engine) return;
+      $generate.disabled = true;
+      $output.textContent = '...';
+      $genStats.textContent = '';
+
+      // Yield to UI
+      await new Promise(r => setTimeout(r, 10));
+
+      try {
+        engine.reset();
+        const t0 = performance.now();
+        const tokens = engine.generate_tokens(new Uint32Array([1]), 30);
+        const ms = performance.now() - t0;
+        const tokS = tokens.length / (ms / 1000);
+
+        $output.textContent = `Generated tokens (raw IDs): [${Array.from(tokens).join(', ')}]\n\n` +
+          'Note: this demo shows raw token IDs. A real app would decode them with the BPE vocab.';
+        $genStats.textContent = `${tokens.length} tokens in ${ms.toFixed(0)}ms = ${tokS.toFixed(1)} tok/s`;
+      } catch (err) {
+        $output.textContent = 'Error: ' + err;
+        $output.classList.add('error');
+      } finally {
+        $generate.disabled = false;
+      }
+    });
+
+    start();
+  </script>
+</body>
+</html>

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -1,9 +1,39 @@
 //! Browser integration for Flare LLM.
 //!
-//! Provides WASM-bindgen exports for WebGPU detection, device info,
-//! and engine initialization. Designed to be built with `wasm-pack`.
+//! Provides WASM-bindgen exports for loading GGUF models from JS, running
+//! inference, and detecting WebGPU. Designed to be built with `wasm-pack`.
+//!
+//! # Quick start (JS)
+//!
+//! ```javascript
+//! import init, { FlareEngine, webgpu_available } from './pkg/flare_web.js';
+//!
+//! await init();
+//! console.log('WebGPU:', webgpu_available());
+//!
+//! // Load model from a fetched ArrayBuffer
+//! const response = await fetch('model.gguf');
+//! const bytes = new Uint8Array(await response.arrayBuffer());
+//! const engine = FlareEngine.load(bytes);
+//!
+//! // Generate
+//! const tokens = engine.generate_tokens(new Uint32Array([1, 2, 3]), 50);
+//! ```
 
+use std::io::Cursor;
+
+use flare_core::generate::Generator;
+use flare_core::model::Model;
+use flare_core::sampling::SamplingParams;
+use flare_loader::gguf::GgufFile;
+use flare_loader::weights::load_model_weights;
 use wasm_bindgen::prelude::*;
+
+/// Set up better panic messages in the browser console.
+#[wasm_bindgen(start)]
+pub fn start() {
+    console_error_panic_hook::set_once();
+}
 
 /// Check if WebGPU is available in the current browser.
 #[wasm_bindgen]
@@ -13,14 +43,13 @@ pub fn webgpu_available() -> bool {
         None => return false,
     };
 
-    // Check if navigator.gpu exists
     let navigator: JsValue = window.navigator().into();
     js_sys::Reflect::get(&navigator, &JsValue::from_str("gpu"))
         .map(|v| !v.is_undefined() && !v.is_null())
         .unwrap_or(false)
 }
 
-/// Get basic device info for capability detection.
+/// Get basic device info as a JSON string.
 #[wasm_bindgen]
 pub fn device_info() -> String {
     let ua: String = web_sys::window()
@@ -35,12 +64,104 @@ pub fn device_info() -> String {
     )
 }
 
-/// Placeholder: initialize the Flare engine.
-/// Will set up WebGPU device, create compute pipelines, etc.
+/// Flare LLM inference engine, exported to JS.
+///
+/// Holds a loaded model and runs greedy/sampled token generation.
 #[wasm_bindgen]
-pub async fn init() -> Result<JsValue, JsValue> {
-    // Set up panic hook for better error messages in browser console
-    // TODO: add console_error_panic_hook feature for better WASM error messages
+pub struct FlareEngine {
+    model: Model,
+}
 
-    Ok(JsValue::from_str("flare initialized"))
+#[wasm_bindgen]
+impl FlareEngine {
+    /// Load a GGUF model from a Uint8Array of bytes (e.g. from `fetch`).
+    #[wasm_bindgen]
+    pub fn load(gguf_bytes: &[u8]) -> Result<FlareEngine, JsError> {
+        let mut reader = Cursor::new(gguf_bytes);
+        let gguf = GgufFile::parse_header(&mut reader)
+            .map_err(|e| JsError::new(&format!("GGUF parse error: {e}")))?;
+        let config = gguf
+            .to_model_config()
+            .map_err(|e| JsError::new(&format!("Model config error: {e}")))?;
+        let weights = load_model_weights(&gguf, &mut reader)
+            .map_err(|e| JsError::new(&format!("Weight load error: {e}")))?;
+
+        Ok(FlareEngine {
+            model: Model::new(config, weights),
+        })
+    }
+
+    /// Reset the KV cache (start a new conversation).
+    #[wasm_bindgen]
+    pub fn reset(&mut self) {
+        self.model.reset();
+    }
+
+    /// Get the vocabulary size of the loaded model.
+    #[wasm_bindgen(getter)]
+    pub fn vocab_size(&self) -> u32 {
+        self.model.config().vocab_size as u32
+    }
+
+    /// Get the number of layers.
+    #[wasm_bindgen(getter)]
+    pub fn num_layers(&self) -> u32 {
+        self.model.config().num_layers as u32
+    }
+
+    /// Get the hidden dimension.
+    #[wasm_bindgen(getter)]
+    pub fn hidden_dim(&self) -> u32 {
+        self.model.config().hidden_dim as u32
+    }
+
+    /// Generate `max_tokens` tokens starting from `prompt_tokens` (greedy).
+    /// Returns a Uint32Array of generated token IDs.
+    #[wasm_bindgen]
+    pub fn generate_tokens(&mut self, prompt_tokens: &[u32], max_tokens: u32) -> Vec<u32> {
+        let params = SamplingParams {
+            temperature: 0.0,
+            ..Default::default()
+        };
+        let mut gen = Generator::new(&mut self.model, params);
+        gen.generate(
+            prompt_tokens,
+            max_tokens as usize,
+            None,
+            || 0.5,
+            |_, _| true,
+        )
+    }
+
+    /// Generate with sampling parameters. Uses a fixed RNG seed for reproducibility
+    /// (browser apps should pass their own RNG via JS-side state).
+    #[wasm_bindgen]
+    pub fn generate_with_params(
+        &mut self,
+        prompt_tokens: &[u32],
+        max_tokens: u32,
+        temperature: f32,
+        top_p: f32,
+    ) -> Vec<u32> {
+        let params = SamplingParams {
+            temperature,
+            top_p,
+            top_k: 40,
+            repeat_penalty: 1.1,
+        };
+        let mut gen = Generator::new(&mut self.model, params);
+        // Simple LCG for browser-side RNG (deterministic per call)
+        let mut state: u32 = 0x12345678;
+        let mut rng = move || {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            (state as f32) / (u32::MAX as f32)
+        };
+        gen.generate(
+            prompt_tokens,
+            max_tokens as usize,
+            None,
+            &mut rng,
+            |_, _| true,
+        )
+    }
 }


### PR DESCRIPTION
A self-contained demo page that loads the WASM module, accepts a GGUF file via drag-and-drop, and runs inference. Builds on PR #81 (WASM bindings).