### PR TITLE
Add download_baseline_model.sh helper script

### DIFF
--- a/flare-server/examples/e2e_bench.rs
+++ b/flare-server/examples/e2e_bench.rs
@@ -35,12 +35,14 @@ fn main() {
     if !Path::new(&model_path).exists() {
         eprintln!("Model not found at: {model_path}");
         eprintln!();
-        eprintln!("Download SmolLM2-135M Q8_0:");
-        eprintln!("  mkdir -p models");
-        eprintln!("  huggingface-cli download bartowski/SmolLM2-135M-Instruct-GGUF \\");
-        eprintln!("    SmolLM2-135M-Instruct-Q8_0.gguf --local-dir models");
+        eprintln!("Quick setup (downloads ~138MB):");
+        eprintln!("  ./scripts/download_baseline_model.sh");
         eprintln!();
-        eprintln!("Or set MODEL_PATH to your GGUF file.");
+        eprintln!("Or manually:");
+        eprintln!("  curl -L \"https://huggingface.co/bartowski/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-Q8_0.gguf\" \\");
+        eprintln!("    -o models/smollm2-135m-instruct-q8_0.gguf");
+        eprintln!();
+        eprintln!("Or set MODEL_PATH to point to your own GGUF file.");
         std::process::exit(1);
     }
 

--- a/scripts/download_baseline_model.sh
+++ b/scripts/download_baseline_model.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Download the baseline benchmark model: SmolLM2-135M-Instruct Q8_0 (~138MB)
+#
+# Usage: ./scripts/download_baseline_model.sh
+
+set -e
+
+MODEL_DIR="${MODEL_DIR:-models}"
+MODEL_NAME="smollm2-135m-instruct-q8_0.gguf"
+MODEL_URL="https://huggingface.co/bartowski/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-Q8_0.gguf"
+
+mkdir -p "$MODEL_DIR"
+
+if [ -f "$MODEL_DIR/$MODEL_NAME" ]; then
+    echo "Model already exists at $MODEL_DIR/$MODEL_NAME"
+    exit 0
+fi
+
+echo "Downloading SmolLM2-135M-Instruct Q8_0 (~138MB)..."
+curl -L "$MODEL_URL" -o "$MODEL_DIR/$MODEL_NAME" --progress-bar
+
+if [ -f "$MODEL_DIR/$MODEL_NAME" ]; then
+    SIZE=$(du -h "$MODEL_DIR/$MODEL_NAME" | cut -f1)
+    echo "Downloaded $MODEL_DIR/$MODEL_NAME ($SIZE)"
+else
+    echo "Download failed" >&2
+    exit 1
+fi


### PR DESCRIPTION
One-command setup for the baseline benchmark model. Improves the missing-model error to point users to the script.