### PR TITLE
Add multi-model benchmark script and regression CI workflow (#54)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,76 @@
+name: Benchmark
+
+# This workflow runs the full e2e benchmark against the baseline model and
+# checks for performance regressions.
+#
+# It does NOT run on every push (models are large). Trigger manually via
+# workflow_dispatch, or on a nightly schedule.
+#
+# To compare two PRs, run the workflow on each branch and compare the JSON
+# artefacts.
+
+on:
+  workflow_dispatch:
+    inputs:
+      threshold_tok_s:
+        description: "Minimum acceptable sustained decode speed (tok/s)"
+        default: "60"
+        required: false
+      log_results:
+        description: "Append results to BENCHMARK_HISTORY.md and open a PR"
+        type: boolean
+        default: false
+  schedule:
+    # Nightly at 02:00 UTC — catches regressions merged during the day
+    - cron: "0 2 * * *"
+
+jobs:
+  bench:
+    name: E2E benchmark — SmolLM2-135M Q8_0
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artefacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Download baseline model
+        run: ./scripts/download_baseline_model.sh
+
+      - name: Run regression check
+        env:
+          THRESHOLD_TOK_S: ${{ github.event.inputs.threshold_tok_s || '60' }}
+        run: |
+          chmod +x ./scripts/check_perf_regression.sh
+          ./scripts/check_perf_regression.sh | tee bench_result.json
+
+      - name: Upload benchmark JSON
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-${{ github.sha }}
+          path: bench_result.json
+          retention-days: 90
+
+      - name: Append to history and open PR
+        if: ${{ github.event.inputs.log_results == 'true' }}
+        run: |
+          chmod +x ./scripts/bench_multi.sh
+          ./scripts/bench_multi.sh --log
+          git config user.name  "sauravpanda"
+          git config user.email "sgp65@cornell.edu"
+          BRANCH="chore/benchmark-update-$(date +%Y%m%d-%H%M)"
+          git checkout -b "$BRANCH"
+          git add BENCHMARK_HISTORY.md || true
+          git diff --staged --quiet || git commit -m "Update benchmark history $(date +%Y-%m-%d)"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: update benchmark history $(date +%Y-%m-%d)" \
+            --body "Automated benchmark run. See attached artefact for full JSON." \
+            --head "$BRANCH" --base main \
+            --label "benchmark" || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -92,18 +92,69 @@ Real measurements using `e2e_bench` with SmolLM2-135M-Instruct Q8_0 (138MB, 30 l
 
 ## How to Run
 
+### Single-model benchmark
+
 ```bash
-# End-to-end benchmark (requires model file)
-# Download: huggingface-cli download bartowski/SmolLM2-135M-Instruct-GGUF \
-#   SmolLM2-135M-Instruct-Q8_0.gguf --local-dir models
-cargo run -p flare-server --example e2e_bench --release
+# Download the baseline model (~138 MB)
+./scripts/download_baseline_model.sh
 
-# CPU matvec benchmark (no model needed)
-cargo run -p flare-core --example matvec_bench --release
+# Run e2e benchmark (human-readable)
+cargo run -p flarellm-server --example e2e_bench --release
 
-# GPU vs CPU comparison (no model needed)
-cargo run -p flare-gpu --example gpu_bench --release
+# Append result to BENCHMARK_HISTORY.md
+cargo run -p flarellm-server --example e2e_bench --release -- --log
+
+# Machine-readable JSON output
+cargo run -p flarellm-server --example e2e_bench --release -- --json
+```
+
+### Multi-model benchmark
+
+Place one or more `.gguf` files under `models/`, then:
+
+```bash
+# Benchmark all models (human-readable summary table)
+./scripts/bench_multi.sh
+
+# JSON output — one object per model per line
+./scripts/bench_multi.sh --json
+
+# JSON output + append each result to BENCHMARK_HISTORY.md
+./scripts/bench_multi.sh --json --log
+```
+
+### Performance regression check
+
+```bash
+# Pass/fail check against a 60 tok/s floor (uses baseline model)
+./scripts/check_perf_regression.sh
+
+# Custom threshold
+THRESHOLD_TOK_S=40 ./scripts/check_perf_regression.sh
+
+# Custom model
+MODEL_PATH=models/my-model.gguf THRESHOLD_TOK_S=20 ./scripts/check_perf_regression.sh
+```
+
+### Automated benchmarks (CI)
+
+The `benchmark` GitHub Actions workflow runs nightly and on `workflow_dispatch`.
+It downloads the baseline model, runs the regression check, and uploads the JSON
+result as a build artefact. To trigger manually:
+
+```
+GitHub → Actions → Benchmark → Run workflow
+```
+
+### CPU / GPU microbenchmarks (no model needed)
+
+```bash
+# CPU matvec benchmark
+cargo run -p flarellm-core --example matvec_bench --release
+
+# GPU vs CPU comparison
+cargo run -p flarellm-gpu --example gpu_bench --release
 
 # Full matmul + sampling benchmarks
-cargo bench -p flare-simd
+cargo bench -p flarellm-simd
 ```

--- a/scripts/bench_multi.sh
+++ b/scripts/bench_multi.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Run the Flare e2e benchmark against every GGUF model found in models/.
+#
+# Usage:
+#   ./scripts/bench_multi.sh              # human-readable table
+#   ./scripts/bench_multi.sh --json       # one JSON object per line (machine-readable)
+#   ./scripts/bench_multi.sh --log        # append results to BENCHMARK_HISTORY.md
+#   MODEL_DIR=path/to/models ./scripts/bench_multi.sh
+#
+# Exit code: 0 if at least one model was benchmarked, 1 otherwise.
+
+set -euo pipefail
+
+MODEL_DIR="${MODEL_DIR:-models}"
+BENCH_BIN="cargo run -p flarellm-server --example e2e_bench --release --quiet"
+JSON_MODE=false
+LOG_MODE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON_MODE=true ;;
+    --log)  LOG_MODE=true  ;;
+  esac
+done
+
+# Build once so the per-model runs are fast
+echo "Building e2e_bench (release)..." >&2
+cargo build -p flarellm-server --example e2e_bench --release --quiet 2>&1 | grep -v "^$" >&2 || true
+BENCH_BIN_PATH="$(cargo metadata --format-version 1 --no-deps 2>/dev/null | \
+  python3 -c "import sys,json; d=json.load(sys.stdin); print(d['target_directory'])" \
+  2>/dev/null || echo "target")/release/examples/e2e_bench"
+
+if [ ! -x "$BENCH_BIN_PATH" ]; then
+  # Fallback: use cargo run each time (slower first run, cached after)
+  BENCH_BIN_PATH=""
+fi
+
+# Discover models
+mapfile -t MODELS < <(find "$MODEL_DIR" -maxdepth 2 -name "*.gguf" 2>/dev/null | sort)
+
+if [ ${#MODELS[@]} -eq 0 ]; then
+  echo "No .gguf models found in $MODEL_DIR/" >&2
+  echo "Run ./scripts/download_baseline_model.sh to download the baseline model." >&2
+  exit 1
+fi
+
+echo "Found ${#MODELS[@]} model(s) in $MODEL_DIR/" >&2
+echo "" >&2
+
+# Header for human-readable mode
+if ! $JSON_MODE; then
+  printf "%-45s  %8s  %8s  %8s\n" "Model" "Load(s)" "Prefill" "Decode" >&2
+  printf "%-45s  %8s  %8s  %8s\n" "-----" "-------" "-------" "------" >&2
+fi
+
+BENCH_ARGS=""
+$LOG_MODE  && BENCH_ARGS="$BENCH_ARGS --log"
+$JSON_MODE && BENCH_ARGS="$BENCH_ARGS --json"
+
+EXIT_CODE=0
+for MODEL_PATH in "${MODELS[@]}"; do
+  MODEL_NAME="$(basename "$MODEL_PATH")"
+  echo "Benchmarking: $MODEL_NAME" >&2
+
+  if [ -n "$BENCH_BIN_PATH" ]; then
+    OUTPUT=$(MODEL_PATH="$MODEL_PATH" "$BENCH_BIN_PATH" $BENCH_ARGS 2>/dev/null) || {
+      echo "  FAILED — skipping $MODEL_NAME" >&2
+      EXIT_CODE=1
+      continue
+    }
+  else
+    OUTPUT=$(MODEL_PATH="$MODEL_PATH" cargo run -p flarellm-server \
+      --example e2e_bench --release --quiet -- $BENCH_ARGS 2>/dev/null) || {
+      echo "  FAILED — skipping $MODEL_NAME" >&2
+      EXIT_CODE=1
+      continue
+    }
+  fi
+
+  if $JSON_MODE; then
+    echo "$OUTPUT"
+  else
+    # Extract key numbers from human-readable output for summary line
+    LOAD=$(echo "$OUTPUT"  | grep "^Load:"     | awk '{print $2}')
+    DECODE=$(echo "$OUTPUT" | grep "Sustained" | grep -oE '[0-9]+\.[0-9]+')
+    PREFILL=$(echo "$OUTPUT" | grep "gen= *16" | awk '{print $3}')
+    printf "%-45s  %8s  %8s  %8s\n" "$MODEL_NAME" "$LOAD" "${PREFILL:-N/A}" "${DECODE:-N/A}"
+    echo ""
+    echo "$OUTPUT"
+    echo ""
+  fi
+done
+
+exit $EXIT_CODE

--- a/scripts/check_perf_regression.sh
+++ b/scripts/check_perf_regression.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Regression guard: run e2e_bench --json and fail if sustained decode speed
+# drops below THRESHOLD_TOK_S (default: 60 tok/s for SmolLM2-135M on any CI).
+#
+# Usage:
+#   ./scripts/check_perf_regression.sh
+#   THRESHOLD_TOK_S=40 ./scripts/check_perf_regression.sh
+#   MODEL_PATH=path/to/model.gguf THRESHOLD_TOK_S=20 ./scripts/check_perf_regression.sh
+#
+# Outputs JSON benchmark result on stdout.
+# Exits 0 if performance is above threshold, 1 if below or if model is missing.
+
+set -euo pipefail
+
+MODEL_DIR="${MODEL_DIR:-models}"
+MODEL_NAME="${MODEL_NAME:-smollm2-135m-instruct-q8_0.gguf}"
+MODEL_PATH="${MODEL_PATH:-$MODEL_DIR/$MODEL_NAME}"
+THRESHOLD_TOK_S="${THRESHOLD_TOK_S:-60}"
+
+if [ ! -f "$MODEL_PATH" ]; then
+  echo "Benchmark model not found at: $MODEL_PATH" >&2
+  echo "Run ./scripts/download_baseline_model.sh first." >&2
+  exit 1
+fi
+
+echo "Running e2e_bench (this takes ~30s)..." >&2
+
+JSON=$(MODEL_PATH="$MODEL_PATH" cargo run -p flarellm-server \
+  --example e2e_bench --release --quiet -- --json 2>/dev/null)
+
+echo "$JSON"
+
+# Extract sustained decode speed using Python (available on all CI runners)
+ACTUAL_TOK_S=$(python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+print(d['sustained_512_tok_s'])
+" <<< "$JSON")
+
+echo "" >&2
+echo "Sustained decode: ${ACTUAL_TOK_S} tok/s  (threshold: ${THRESHOLD_TOK_S} tok/s)" >&2
+
+# Compare floats: fail if actual < threshold
+PASSED=$(python3 -c "
+import sys
+print('yes' if float('$ACTUAL_TOK_S') >= float('$THRESHOLD_TOK_S') else 'no')
+")
+
+if [ "$PASSED" = "yes" ]; then
+  echo "PASS: performance is above threshold." >&2
+  exit 0
+else
+  echo "FAIL: ${ACTUAL_TOK_S} tok/s is below the ${THRESHOLD_TOK_S} tok/s threshold." >&2
+  echo "Check recent commits for regressions." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **`scripts/bench_multi.sh`**: discovers all `.gguf` files under `models/`, runs `e2e_bench` for each, and prints a summary table (or `--json` + `--log` modes for CI/history)
- **`scripts/check_perf_regression.sh`**: runs `e2e_bench --json`, extracts `sustained_512_tok_s`, and fails with exit code 1 if below `THRESHOLD_TOK_S` (default 60 tok/s); suitable as a CI gate
- **`.github/workflows/benchmark.yml`**: nightly (02:00 UTC) + `workflow_dispatch` workflow — downloads baseline model, runs regression check, uploads JSON artefact; optionally opens a PR with updated `BENCHMARK_HISTORY.md`
- **`BENCHMARKS.md`**: expanded "How to Run" section documenting all new scripts and the CI workflow

## Test plan

- [ ] CI passes on this PR (Format, Check, Test, Clippy, WASM, Doc)
- [ ] Trigger the `Benchmark` workflow manually with default inputs — should download model, run bench, upload artefact
- [ ] Run `./scripts/bench_multi.sh` locally after downloading baseline model — expect summary table
- [ ] Run `./scripts/check_perf_regression.sh` locally — expect PASS (>60 tok/s on recent hardware)

Closes #54