### PR TITLE
Wire chat template rendering into browser demo (#92)

### DIFF
--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -44,6 +44,9 @@
     }
     .badge.ok   { background: #22aa4422; border-color: #22aa4444; color: #4a4; }
     .badge.warn { background: #ffaa0022; border-color: #ffaa0044; color: #a80; }
+    .badge.info { background: #4488ff22; border-color: #4488ff44; color: #48f; }
+    label.checkbox { display: flex; align-items: center; gap: 0.4rem; font-size: 0.9rem; cursor: pointer; }
+    .field-label { font-size: 0.85rem; opacity: 0.8; margin-bottom: 0.25rem; }
   </style>
 </head>
 <body>
@@ -96,7 +99,29 @@
 
   <div class="panel">
     <h3>3. Generate</h3>
-    <textarea id="prompt-input" placeholder="Once upon a time" disabled rows="2"></textarea>
+
+    <div style="margin-bottom:0.75rem;">
+      <label class="checkbox">
+        <input type="checkbox" id="chat-mode" checked>
+        Apply chat template
+        <span class="badge info" id="template-badge" style="display:none"></span>
+      </label>
+      <p class="stats" style="margin:0.2rem 0 0 1.4rem;">
+        Wraps your prompt in the model's instruction format (ChatML, Llama3, etc.).
+        Disable for raw completion.
+      </p>
+    </div>
+
+    <div id="system-prompt-row" style="margin-bottom:0.5rem;">
+      <div class="field-label">System prompt (optional)</div>
+      <textarea id="system-input" placeholder="You are a helpful assistant." disabled rows="2"></textarea>
+    </div>
+
+    <div>
+      <div class="field-label">User message</div>
+      <textarea id="prompt-input" placeholder="Once upon a time" disabled rows="2"></textarea>
+    </div>
+
     <div style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;">
       <button id="generate" disabled>Generate</button>
       <label style="font-size:0.85rem;">
@@ -132,6 +157,10 @@
     const $tokUrlIn    = $('tok-url-input');
     const $tokUrlLoad  = $('tok-url-load');
     const $tokInfo     = $('tok-info');
+    const $chatMode    = $('chat-mode');
+    const $tmplBadge   = $('template-badge');
+    const $systemRow   = $('system-prompt-row');
+    const $systemIn    = $('system-input');
     const $promptIn    = $('prompt-input');
     const $generate    = $('generate');
     const $maxTokens   = $('max-tokens');
@@ -140,6 +169,11 @@
 
     let engine    = null;
     let tokenizer = null;
+
+    // Show/hide system prompt row based on chat-mode checkbox
+    $chatMode.addEventListener('change', () => {
+      $systemRow.style.display = $chatMode.checked ? '' : 'none';
+    });
 
     // Tab switching: each panel has its own set of .tab-btn / .tab-panel pairs
     document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -181,11 +215,17 @@
 
     function onModelLoaded(eng, ms) {
       engine = eng;
+      const tmplName = eng.chat_template_name;
       $modelInfo.textContent =
         `Loaded in ${ms.toFixed(0)} ms — Vocab: ${eng.vocab_size}, ` +
-        `Layers: ${eng.num_layers}, Hidden: ${eng.hidden_dim}`;
+        `Layers: ${eng.num_layers}, Hidden: ${eng.hidden_dim}, ` +
+        `Template: ${tmplName}`;
       $generate.disabled = false;
       $promptIn.disabled = false;
+      $systemIn.disabled = false;
+      // Update template badge
+      $tmplBadge.textContent = tmplName;
+      $tmplBadge.style.display = '';
       hideProgress();
     }
 
@@ -280,19 +320,27 @@
       if (!engine) return;
       $generate.disabled = true;
       $output.textContent = '';
+      $output.classList.remove('error');
       $genStats.textContent = '';
       await new Promise(r => setTimeout(r, 10));
 
       const maxToks = parseInt($maxTokens.value, 10) || 64;
-      const promptText = $promptIn.value.trim() || 'Once upon a time';
+      const userText  = $promptIn.value.trim() || 'Once upon a time';
+      const sysText   = $systemIn.value.trim();
+      const chatMode  = $chatMode.checked;
 
       try {
         engine.reset();
         const t0 = performance.now();
 
-        // Encode prompt (or use BOS fallback)
+        // Format the input: apply chat template when enabled, or pass raw text
+        const inputText = chatMode
+          ? engine.apply_chat_template(userText, sysText)
+          : userText;
+
+        // Encode prompt (or use BOS fallback when no tokenizer)
         const promptIds = tokenizer
-          ? tokenizer.encode(promptText)
+          ? tokenizer.encode(inputText)
           : new Uint32Array([1]);
 
         const outputIds = engine.generate_tokens(promptIds, maxToks);
@@ -308,7 +356,8 @@
         }
 
         $genStats.textContent =
-          `${outputIds.length} tokens in ${ms.toFixed(0)} ms = ${tokS.toFixed(1)} tok/s`;
+          `${outputIds.length} tokens in ${ms.toFixed(0)} ms = ${tokS.toFixed(1)} tok/s` +
+          (chatMode ? ` · template: ${engine.chat_template_name}` : '');
       } catch (err) {
         $output.textContent = 'Error: ' + err;
         $output.classList.add('error');

--- a/flare-web/js/types.ts
+++ b/flare-web/js/types.ts
@@ -16,13 +16,52 @@ export declare function init(): Promise<string>;
 export type ProgressCallback = (loaded: number, total: number) => void;
 
 /**
+ * The Flare inference engine.
+ * Load a GGUF model, then call generate_tokens or generate_with_params.
+ * Use apply_chat_template to format prompts for instruction-tuned models.
+ */
+export declare class FlareEngine {
+  /** Load a GGUF model from raw bytes. */
+  static load(ggufBytes: Uint8Array): FlareEngine;
+  /** Reset the KV cache (start a new conversation). */
+  reset(): void;
+  /** Vocabulary size. */
+  readonly vocab_size: number;
+  /** Number of transformer layers. */
+  readonly num_layers: number;
+  /** Hidden dimension. */
+  readonly hidden_dim: number;
+  /**
+   * Auto-detected chat template name: "ChatML", "Llama3", "Alpaca", or "Raw".
+   * Detected from the GGUF tokenizer.chat_template metadata, falling back to
+   * architecture-based detection.
+   */
+  readonly chat_template_name: string;
+  /**
+   * Format a user message and optional system prompt using the model's chat
+   * template.  Pass the result to FlareTokenizer.encode() before generating.
+   * Pass an empty string for systemMessage to omit the system turn.
+   */
+  apply_chat_template(userMessage: string, systemMessage: string): string;
+  /** Generate tokens (greedy, temperature=0). Returns token ID array. */
+  generate_tokens(promptTokens: Uint32Array, maxTokens: number): Uint32Array;
+  /** Generate tokens with sampling parameters. */
+  generate_with_params(
+    promptTokens: Uint32Array,
+    maxTokens: number,
+    temperature: number,
+    topP: number
+  ): Uint32Array;
+}
+
+/**
  * Progressive loader: fetches a GGUF model from a URL with streaming download
  * progress, then parses and returns a FlareEngine.
  */
 export declare class FlareProgressiveLoader {
   constructor(url: string);
   /** Fetch, stream, and parse the model. Calls onProgress as chunks arrive. */
-  load(onProgress: ProgressCallback): Promise<import('../pkg/flare_web').FlareEngine>;
+  load(onProgress: ProgressCallback): Promise<FlareEngine>;
 }
 
 /**

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -16,12 +16,15 @@
 //! const bytes = new Uint8Array(await response.arrayBuffer());
 //! const engine = FlareEngine.load(bytes);
 //!
-//! // Generate
-//! const tokens = engine.generate_tokens(new Uint32Array([1, 2, 3]), 50);
+//! // Apply chat template then generate
+//! const prompt = engine.apply_chat_template('What is Rust?', '');
+//! const ids = tokenizer.encode(prompt);
+//! const tokens = engine.generate_tokens(ids, 50);
 //! ```
 
 use std::io::Cursor;
 
+use flare_core::chat::{ChatMessage, ChatTemplate, Role};
 use flare_core::generate::Generator;
 use flare_core::model::Model;
 use flare_core::sampling::SamplingParams;
@@ -66,12 +69,32 @@ pub fn device_info() -> String {
     )
 }
 
+/// Detect chat template from GGUF metadata.
+/// Prefers the `tokenizer.chat_template` Jinja string when present; falls back
+/// to architecture-based detection.
+fn detect_chat_template(gguf: &GgufFile) -> ChatTemplate {
+    let arch = gguf.architecture().unwrap_or("unknown");
+    if let Some(tmpl_str) = gguf
+        .metadata
+        .get("tokenizer.chat_template")
+        .and_then(|v| v.as_str())
+    {
+        ChatTemplate::from_gguf_template(tmpl_str, arch)
+    } else {
+        ChatTemplate::from_architecture(arch)
+    }
+}
+
 /// Flare LLM inference engine, exported to JS.
 ///
 /// Holds a loaded model and runs greedy/sampled token generation.
+/// The detected chat template is available via `chat_template_name` and
+/// `apply_chat_template` so the browser demo can format prompts correctly
+/// for instruction-tuned models.
 #[wasm_bindgen]
 pub struct FlareEngine {
     model: Model,
+    chat_template: ChatTemplate,
 }
 
 #[wasm_bindgen]
@@ -82,6 +105,7 @@ impl FlareEngine {
         let mut reader = Cursor::new(gguf_bytes);
         let gguf = GgufFile::parse_header(&mut reader)
             .map_err(|e| JsError::new(&format!("GGUF parse error: {e}")))?;
+        let chat_template = detect_chat_template(&gguf);
         let config = gguf
             .to_model_config()
             .map_err(|e| JsError::new(&format!("Model config error: {e}")))?;
@@ -90,6 +114,7 @@ impl FlareEngine {
 
         Ok(FlareEngine {
             model: Model::new(config, weights),
+            chat_template,
         })
     }
 
@@ -115,6 +140,50 @@ impl FlareEngine {
     #[wasm_bindgen(getter)]
     pub fn hidden_dim(&self) -> u32 {
         self.model.config().hidden_dim as u32
+    }
+
+    /// Name of the auto-detected chat template (e.g. `"ChatML"`, `"Llama3"`,
+    /// `"Alpaca"`, `"Raw"`).  Use this to display the template in the UI and
+    /// decide whether to call `apply_chat_template` before encoding.
+    #[wasm_bindgen(getter)]
+    pub fn chat_template_name(&self) -> String {
+        match self.chat_template {
+            ChatTemplate::Llama3 => "Llama3".to_string(),
+            ChatTemplate::ChatML => "ChatML".to_string(),
+            ChatTemplate::Alpaca => "Alpaca".to_string(),
+            ChatTemplate::Raw => "Raw".to_string(),
+        }
+    }
+
+    /// Format a user message (and optional system prompt) using the model's
+    /// auto-detected chat template.  Returns the formatted prompt string ready
+    /// to be passed to `FlareTokenizer.encode()`.
+    ///
+    /// Pass an empty string for `system_message` to omit the system turn.
+    ///
+    /// # JS example
+    /// ```javascript
+    /// const prompt = engine.apply_chat_template(
+    ///   'Explain quantum computing in simple terms.',
+    ///   'You are a helpful assistant.'
+    /// );
+    /// const ids = tokenizer.encode(prompt);
+    /// const output = engine.generate_tokens(ids, 128);
+    /// ```
+    #[wasm_bindgen]
+    pub fn apply_chat_template(&self, user_message: &str, system_message: &str) -> String {
+        let mut messages = Vec::new();
+        if !system_message.is_empty() {
+            messages.push(ChatMessage {
+                role: Role::System,
+                content: system_message.to_string(),
+            });
+        }
+        messages.push(ChatMessage {
+            role: Role::User,
+            content: user_message.to_string(),
+        });
+        self.chat_template.apply(&messages)
     }
 
     /// Generate `max_tokens` tokens starting from `prompt_tokens` (greedy).
@@ -292,6 +361,7 @@ impl FlareProgressiveLoader {
         let mut cursor = Cursor::new(bytes);
         let gguf = GgufFile::parse_header(&mut cursor)
             .map_err(|e| JsError::new(&format!("GGUF parse error: {e}")))?;
+        let chat_template = detect_chat_template(&gguf);
         let config = gguf
             .to_model_config()
             .map_err(|e| JsError::new(&format!("model config error: {e}")))?;
@@ -306,6 +376,7 @@ impl FlareProgressiveLoader {
 
         Ok(FlareEngine {
             model: Model::new(config, weights),
+            chat_template,
         })
     }
 }


### PR DESCRIPTION
## Summary

- Auto-detects chat template from GGUF `tokenizer.chat_template` metadata (falls back to architecture: Llama→Llama3, Qwen2/Mistral→ChatML)
- Exposes `chat_template_name` getter and `apply_chat_template(userMessage, systemMessage)` on `FlareEngine` WASM export
- Browser demo now has an "Apply chat template" checkbox (default on), an optional system prompt field, and shows the detected template name in the model info line and generation stats
- Fixes poor output from instruction-tuned models that never saw the special role tokens

## Test plan

- [ ] `cargo check --workspace` passes native
- [ ] `cargo check --workspace --target wasm32-unknown-unknown` passes WASM
- [ ] `cargo test --workspace` all green
- [ ] CI passes (Format, Check, Test, Clippy, WASM build, Doc build)

Closes #92