### PR TITLE
Add Phi-3 and Gemma 2 architecture support (#100)

### DIFF
--- a/flare-core/src/chat.rs
+++ b/flare-core/src/chat.rs
@@ -28,6 +28,10 @@ pub enum ChatTemplate {
     Llama3,
     /// ChatML format (Qwen, Mistral, many others)
     ChatML,
+    /// Phi-3 / Phi-3.5 instruct format (`<|user|>...<|end|>`)
+    Phi3,
+    /// Gemma 2 instruct format (`<start_of_turn>...<end_of_turn>`)
+    Gemma,
     /// Alpaca-style format
     Alpaca,
     /// Raw — no formatting, just concatenate content
@@ -41,6 +45,8 @@ impl ChatTemplate {
         match arch.to_lowercase().as_str() {
             "llama" => ChatTemplate::Llama3,
             "qwen2" | "mistral" => ChatTemplate::ChatML,
+            "phi3" => ChatTemplate::Phi3,
+            "gemma2" => ChatTemplate::Gemma,
             _ => ChatTemplate::ChatML,
         }
     }
@@ -52,6 +58,10 @@ impl ChatTemplate {
             ChatTemplate::ChatML
         } else if template_str.contains("<|start_header_id|>") {
             ChatTemplate::Llama3
+        } else if template_str.contains("<|user|>") || template_str.contains("<|end|>") {
+            ChatTemplate::Phi3
+        } else if template_str.contains("<start_of_turn>") {
+            ChatTemplate::Gemma
         } else if template_str.contains("### Instruction") {
             ChatTemplate::Alpaca
         } else {
@@ -65,6 +75,8 @@ impl ChatTemplate {
         match self {
             ChatTemplate::Llama3 => format_llama3(messages),
             ChatTemplate::ChatML => format_chatml(messages),
+            ChatTemplate::Phi3 => format_phi3(messages),
+            ChatTemplate::Gemma => format_gemma(messages),
             ChatTemplate::Alpaca => format_alpaca(messages),
             ChatTemplate::Raw => format_raw(messages),
         }
@@ -151,6 +163,52 @@ fn format_alpaca(messages: &[ChatMessage]) -> String {
     out
 }
 
+/// Phi-3 / Phi-3.5 instruct format:
+/// ```text
+/// <|system|>
+/// {system}<|end|>
+/// <|user|>
+/// {user}<|end|>
+/// <|assistant|>
+/// ```
+fn format_phi3(messages: &[ChatMessage]) -> String {
+    let mut out = String::new();
+    for msg in messages {
+        let role_tag = match msg.role {
+            Role::System => "<|system|>",
+            Role::User => "<|user|>",
+            Role::Assistant => "<|assistant|>",
+        };
+        out.push_str(&format!("{role_tag}\n{}<|end|>\n", msg.content));
+    }
+    out.push_str("<|assistant|>\n");
+    out
+}
+
+/// Gemma 2 instruct format:
+/// ```text
+/// <start_of_turn>user
+/// {user}<end_of_turn>
+/// <start_of_turn>model
+/// {assistant}<end_of_turn>
+/// <start_of_turn>model
+/// ```
+fn format_gemma(messages: &[ChatMessage]) -> String {
+    let mut out = String::new();
+    for msg in messages {
+        let role_tag = match msg.role {
+            Role::System | Role::User => "user",
+            Role::Assistant => "model",
+        };
+        out.push_str(&format!(
+            "<start_of_turn>{role_tag}\n{}<end_of_turn>\n",
+            msg.content
+        ));
+    }
+    out.push_str("<start_of_turn>model\n");
+    out
+}
+
 /// Raw format — just concatenate all content.
 fn format_raw(messages: &[ChatMessage]) -> String {
     messages
@@ -217,6 +275,49 @@ mod tests {
         assert_eq!(
             ChatTemplate::from_architecture("mistral"),
             ChatTemplate::ChatML
+        );
+        assert_eq!(ChatTemplate::from_architecture("phi3"), ChatTemplate::Phi3);
+        assert_eq!(
+            ChatTemplate::from_architecture("gemma2"),
+            ChatTemplate::Gemma
+        );
+    }
+
+    #[test]
+    fn test_phi3_format() {
+        let result = ChatTemplate::Phi3.apply(&sample_messages());
+        assert!(result.contains("<|system|>"));
+        assert!(result.contains("You are a helpful assistant."));
+        assert!(result.contains("<|end|>"));
+        assert!(result.contains("<|user|>"));
+        assert!(result.contains("What is Rust?"));
+        assert!(result.ends_with("<|assistant|>\n"));
+    }
+
+    #[test]
+    fn test_gemma_format() {
+        let result = ChatTemplate::Gemma.apply(&sample_messages());
+        assert!(result.contains("<start_of_turn>user\n"));
+        assert!(result.contains("<end_of_turn>"));
+        assert!(result.contains("What is Rust?"));
+        assert!(result.ends_with("<start_of_turn>model\n"));
+    }
+
+    #[test]
+    fn test_from_gguf_template_phi3() {
+        let jinja = "{% for msg in messages %}{{ '<|' + msg['role'] + '|>' }}\n{{ msg['content'] }}<|end|>\n{% endfor %}<|assistant|>";
+        assert_eq!(
+            ChatTemplate::from_gguf_template(jinja, "phi3"),
+            ChatTemplate::Phi3
+        );
+    }
+
+    #[test]
+    fn test_from_gguf_template_gemma() {
+        let jinja = "{% for message in messages %}<start_of_turn>{{ message.role }}\n{{ message.content }}<end_of_turn>\n{% endfor %}";
+        assert_eq!(
+            ChatTemplate::from_gguf_template(jinja, "gemma2"),
+            ChatTemplate::Gemma
         );
     }
 

--- a/flare-core/src/config.rs
+++ b/flare-core/src/config.rs
@@ -14,6 +14,14 @@ pub struct ModelConfig {
     pub max_seq_len: usize,
     pub rope_theta: f32,
     pub rms_norm_eps: f32,
+    /// Attention logit soft-cap for Gemma 2 (`tanh(score / cap) * cap`).
+    /// Zero means no capping (Llama, Qwen, Mistral, Phi-3).
+    #[serde(default)]
+    pub attn_logit_softcap: f32,
+    /// Final logit soft-cap for Gemma 2.
+    /// Zero means no capping.
+    #[serde(default)]
+    pub final_logit_softcap: f32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -21,6 +29,10 @@ pub enum Architecture {
     Llama,
     Qwen2,
     Mistral,
+    /// Phi-3 / Phi-3.5 mini — forward pass identical to Llama, different chat template.
+    Phi3,
+    /// Gemma 2 — post-norms, logit soft-capping, GELU activation, alternating attention.
+    Gemma2,
 }
 
 impl ModelConfig {
@@ -68,6 +80,8 @@ impl Default for ModelConfig {
             max_seq_len: 2048,
             rope_theta: 500000.0,
             rms_norm_eps: 1e-5,
+            attn_logit_softcap: 0.0,
+            final_logit_softcap: 0.0,
         }
     }
 }

--- a/flare-core/src/generate.rs
+++ b/flare-core/src/generate.rs
@@ -161,6 +161,8 @@ mod tests {
             attn_q_bias: None,
             attn_k_bias: None,
             attn_v_bias: None,
+            post_attn_norm: None,
+            post_ffn_norm: None,
         };
 
         let weights = ModelWeights {

--- a/flare-core/src/memory.rs
+++ b/flare-core/src/memory.rs
@@ -192,6 +192,8 @@ mod tests {
             max_seq_len: 2048,
             rope_theta: 10000.0,
             rms_norm_eps: 1e-5,
+            attn_logit_softcap: 0.0,
+            final_logit_softcap: 0.0,
         }
     }
 

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -1,4 +1,4 @@
-use crate::config::ModelConfig;
+use crate::config::{Architecture, ModelConfig};
 use crate::kv_cache::KvCache;
 use crate::tensor::Tensor;
 
@@ -128,6 +128,9 @@ pub struct LayerWeights {
     pub attn_q_bias: Option<Tensor>,
     pub attn_k_bias: Option<Tensor>,
     pub attn_v_bias: Option<Tensor>,
+    // Post-norms for Gemma 2 (applied after attention output / FFN output)
+    pub post_attn_norm: Option<Tensor>,
+    pub post_ffn_norm: Option<Tensor>,
 }
 
 /// Complete model weights.
@@ -265,6 +268,7 @@ impl Model {
                 num_kv_heads,
                 head_dim,
                 self.kv_cache.len() + 1, // include current position
+                config.attn_logit_softcap,
             );
 
             // Output projection
@@ -272,10 +276,18 @@ impl Model {
                 self.backend
                     .matvec(layer.wo.data(), &attn_output, dim, num_heads * head_dim);
 
+            // Gemma 2: apply post-attention RMSNorm before the residual add
+            let attn_contrib = if let Some(ref post_norm) = layer.post_attn_norm {
+                self.backend
+                    .rmsnorm_vec(&attn_proj, post_norm.data(), config.rms_norm_eps)
+            } else {
+                attn_proj
+            };
+
             // Residual connection
             let x_data = x.data_mut();
             for i in 0..dim {
-                x_data[i] += attn_proj[i];
+                x_data[i] += attn_contrib[i];
             }
 
             // --- FFN block ---
@@ -291,8 +303,12 @@ impl Model {
                 .backend
                 .matvec(layer.w_up.data(), &normed, config.intermediate_dim, dim);
 
-            // SiLU(gate) * up
-            let ffn_hidden = self.backend.silu_mul_vec(&gate, &up);
+            // Gemma 2 uses GELU activation; Llama / Phi-3 use SiLU
+            let ffn_hidden = if config.architecture == Architecture::Gemma2 {
+                gelu_mul_cpu(&gate, &up)
+            } else {
+                self.backend.silu_mul_vec(&gate, &up)
+            };
 
             // Down projection
             let ffn_out = self.backend.matvec(
@@ -302,10 +318,18 @@ impl Model {
                 config.intermediate_dim,
             );
 
+            // Gemma 2: apply post-FFN RMSNorm before the residual add
+            let ffn_contrib = if let Some(ref post_norm) = layer.post_ffn_norm {
+                self.backend
+                    .rmsnorm_vec(&ffn_out, post_norm.data(), config.rms_norm_eps)
+            } else {
+                ffn_out
+            };
+
             // Residual connection
             let x_data = x.data_mut();
             for i in 0..dim {
-                x_data[i] += ffn_out[i];
+                x_data[i] += ffn_contrib[i];
             }
         }
 
@@ -320,12 +344,20 @@ impl Model {
         );
 
         // Output logits: [vocab_size] = output_weight [vocab_size, dim] x normed [dim]
-        let logits = self.backend.matvec(
+        let mut logits = self.backend.matvec(
             self.weights.output_weight.data(),
             &normed,
             config.vocab_size,
             dim,
         );
+
+        // Gemma 2: apply final logit soft-cap (tanh(x / cap) * cap)
+        if config.final_logit_softcap > 0.0 {
+            let cap = config.final_logit_softcap;
+            for l in &mut logits {
+                *l = (*l / cap).tanh() * cap;
+            }
+        }
 
         Tensor::from_vec(logits, &[config.vocab_size]).unwrap()
     }
@@ -674,6 +706,19 @@ pub fn silu_mul_cpu(gate: &[f32], up: &[f32]) -> Vec<f32> {
         .collect()
 }
 
+/// GELU(gate) * up — used by Gemma 2 FFN (tanh approximation).
+pub fn gelu_mul_cpu(gate: &[f32], up: &[f32]) -> Vec<f32> {
+    gate.iter()
+        .zip(up.iter())
+        .map(|(&g, &u)| {
+            // tanh-approximated GELU: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+            let c = 0.797_884_56_f32; // sqrt(2/pi)
+            let gelu = 0.5 * g * (1.0 + (c * (g + 0.044715 * g * g * g)).tanh());
+            gelu * u
+        })
+        .collect()
+}
+
 /// Apply RoPE to interleaved Q or K vectors (CPU implementation).
 ///
 /// Pre-computes (cos, sin) per dimension index once for the given pos/theta/head_dim,
@@ -715,7 +760,8 @@ fn grouped_query_attention(
     num_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
-    seq_len: usize, // number of valid KV entries
+    seq_len: usize,    // number of valid KV entries
+    attn_softcap: f32, // 0.0 = no capping (Llama etc); non-zero for Gemma 2
 ) -> Vec<f32> {
     let heads_per_kv = num_heads / num_kv_heads;
     let mut output = vec![0.0f32; num_heads * head_dim];
@@ -739,6 +785,13 @@ fn grouped_query_attention(
                 dot += q[q_offset + d] * k_cache[k_offset + d];
             }
             *score = dot * scale;
+        }
+
+        // Gemma 2: tanh soft-cap on attention logits before softmax
+        if attn_softcap > 0.0 {
+            for s in &mut scores {
+                *s = (*s / attn_softcap).tanh() * attn_softcap;
+            }
         }
 
         // Softmax
@@ -938,6 +991,8 @@ mod tests {
             max_seq_len: 16,
             rope_theta: 10000.0,
             rms_norm_eps: 1e-5,
+            attn_logit_softcap: 0.0,
+            final_logit_softcap: 0.0,
         };
 
         // Deterministic weight init: w[i] = (i % 7 - 3) * 0.1
@@ -964,6 +1019,8 @@ mod tests {
             attn_q_bias: None,
             attn_k_bias: None,
             attn_v_bias: None,
+            post_attn_norm: None,
+            post_ffn_norm: None,
         };
 
         let weights = ModelWeights {
@@ -1052,6 +1109,8 @@ mod tests {
             max_seq_len: 8,
             rope_theta: 10000.0,
             rms_norm_eps: 1e-5,
+            attn_logit_softcap: 0.0,
+            final_logit_softcap: 0.0,
         };
 
         let dim = 4;
@@ -1070,6 +1129,8 @@ mod tests {
             attn_q_bias: None,
             attn_k_bias: None,
             attn_v_bias: None,
+            post_attn_norm: None,
+            post_ffn_norm: None,
         };
 
         // Embedding: token 0 = [1, 2, 3, 4]
@@ -1126,6 +1187,8 @@ mod tests {
             max_seq_len: 8,
             rope_theta: 10000.0,
             rms_norm_eps: 1e-5,
+            attn_logit_softcap: 0.0,
+            final_logit_softcap: 0.0,
         };
 
         let make_w =
@@ -1150,6 +1213,8 @@ mod tests {
             attn_q_bias: None,
             attn_k_bias: None,
             attn_v_bias: None,
+            post_attn_norm: None,
+            post_ffn_norm: None,
         };
 
         let weights = ModelWeights {
@@ -1203,6 +1268,8 @@ mod tests {
             attn_q_bias: None,
             attn_k_bias: None,
             attn_v_bias: None,
+            post_attn_norm: None,
+            post_ffn_norm: None,
         };
 
         let weights = ModelWeights {

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -226,6 +226,8 @@ impl GgufFile {
             "llama" => Architecture::Llama,
             "qwen2" => Architecture::Qwen2,
             "mistral" => Architecture::Mistral,
+            "phi3" => Architecture::Phi3,
+            "gemma2" => Architecture::Gemma2,
             other => return Err(GgufError::UnsupportedArchitecture(other.to_string())),
         };
 
@@ -270,6 +272,14 @@ impl GgufFile {
             .meta_f32(&format!("{prefix}.attention.layer_norm_rms_epsilon"))
             .unwrap_or(1e-5);
 
+        // Gemma 2 logit soft-capping parameters (absent for other architectures)
+        let attn_logit_softcap = self
+            .meta_f32(&format!("{prefix}.attn_logit_softcapping"))
+            .unwrap_or(0.0);
+        let final_logit_softcap = self
+            .meta_f32(&format!("{prefix}.final_logit_softcapping"))
+            .unwrap_or(0.0);
+
         Ok(ModelConfig {
             architecture,
             vocab_size,
@@ -282,6 +292,8 @@ impl GgufFile {
             max_seq_len,
             rope_theta,
             rms_norm_eps,
+            attn_logit_softcap,
+            final_logit_softcap,
         })
     }
 

--- a/flare-loader/src/weights.rs
+++ b/flare-loader/src/weights.rs
@@ -167,6 +167,24 @@ fn load_layer_weights(
     )
     .ok();
 
+    // Post-norms for Gemma 2 (absent in other architectures)
+    let post_attn_norm = find_tensor(
+        tensors,
+        &[
+            &format!("blk.{i}.post_attn_norm.weight"),
+            &format!("model.layers.{i}.post_attention_layernorm.weight"),
+        ],
+    )
+    .ok();
+    let post_ffn_norm = find_tensor(
+        tensors,
+        &[
+            &format!("blk.{i}.post_ffw_norm.weight"),
+            &format!("model.layers.{i}.post_feedforward_layernorm.weight"),
+        ],
+    )
+    .ok();
+
     Ok(LayerWeights {
         attn_norm,
         wq,
@@ -180,6 +198,8 @@ fn load_layer_weights(
         attn_q_bias,
         attn_k_bias,
         attn_v_bias,
+        post_attn_norm,
+        post_ffn_norm,
     })
 }
 

--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -224,6 +224,25 @@
           out += '<|start_header_id|>assistant<|end_header_id|>\n\n';
           return out;
         }
+        case 'Phi3': {
+          let out = '';
+          for (const m of hist) {
+            const tag = m.role === 'assistant' ? '<|assistant|>' :
+                        m.role === 'system'    ? '<|system|>' : '<|user|>';
+            out += `${tag}\n${m.content}<|end|>\n`;
+          }
+          out += '<|assistant|>\n';
+          return out;
+        }
+        case 'Gemma': {
+          let out = '';
+          for (const m of hist) {
+            const role = m.role === 'assistant' ? 'model' : 'user';
+            out += `<start_of_turn>${role}\n${m.content}<end_of_turn>\n`;
+          }
+          out += '<start_of_turn>model\n';
+          return out;
+        }
         case 'Alpaca': {
           const parts = [];
           for (const m of hist) {

--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -24,11 +24,6 @@
       border-radius: 4px; width: 100%; box-sizing: border-box; margin-bottom: 0.5rem;
     }
     textarea { resize: vertical; min-height: 3.5rem; }
-    pre {
-      background: #8881; padding: 0.75rem; border-radius: 4px;
-      overflow-x: auto; font-size: 0.9rem; white-space: pre-wrap;
-      word-break: break-word; min-height: 2rem;
-    }
     .stats { font-size: 0.85rem; opacity: 0.8; }
     .error { color: #d33; }
     progress { width: 100%; height: 8px; }
@@ -47,6 +42,34 @@
     .badge.info { background: #4488ff22; border-color: #4488ff44; color: #48f; }
     label.checkbox { display: flex; align-items: center; gap: 0.4rem; font-size: 0.9rem; cursor: pointer; }
     .field-label { font-size: 0.85rem; opacity: 0.8; margin-bottom: 0.25rem; }
+
+    /* ---- Chat thread ---- */
+    .chat-thread {
+      display: flex; flex-direction: column; gap: 0.75rem;
+      max-height: 420px; overflow-y: auto;
+      padding: 0.5rem 0; margin-bottom: 0.75rem;
+    }
+    .chat-thread:empty::before {
+      content: 'Your conversation will appear here.';
+      opacity: 0.4; font-size: 0.9rem; text-align: center; padding: 1rem 0;
+      display: block;
+    }
+    .msg {
+      max-width: 88%; padding: 0.6rem 0.9rem; border-radius: 12px;
+      font-size: 0.95rem; line-height: 1.5; white-space: pre-wrap; word-break: break-word;
+    }
+    .msg.user {
+      align-self: flex-end;
+      background: #4488ff22; border: 1px solid #4488ff44;
+      border-bottom-right-radius: 3px;
+    }
+    .msg.assistant {
+      align-self: flex-start;
+      background: #8881; border: 1px solid #8884;
+      border-bottom-left-radius: 3px;
+    }
+    .msg.assistant.streaming { border-color: #4488ff66; }
+    .msg-role { font-size: 0.7rem; opacity: 0.55; margin-bottom: 0.2rem; }
   </style>
 </head>
 <body>
@@ -98,7 +121,7 @@
   </div>
 
   <div class="panel">
-    <h3>3. Generate</h3>
+    <h3>3. Chat</h3>
 
     <div style="margin-bottom:0.75rem;">
       <label class="checkbox">
@@ -113,24 +136,27 @@
     </div>
 
     <div id="system-prompt-row" style="margin-bottom:0.5rem;">
-      <div class="field-label">System prompt (optional)</div>
+      <div class="field-label">System prompt (optional, applied on first turn)</div>
       <textarea id="system-input" placeholder="You are a helpful assistant." disabled rows="2"></textarea>
     </div>
 
+    <!-- Conversation thread -->
+    <div class="chat-thread" id="chat"></div>
+
     <div>
-      <div class="field-label">User message</div>
-      <textarea id="prompt-input" placeholder="Once upon a time" disabled rows="2"></textarea>
+      <div class="field-label">Your message</div>
+      <textarea id="prompt-input" placeholder="Ask me anything…" disabled rows="2"></textarea>
     </div>
 
     <div style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;">
-      <button id="generate" disabled>Generate</button>
+      <button id="generate" disabled>Send</button>
       <button id="stop" disabled>Stop</button>
+      <button id="clear" disabled>Clear conversation</button>
       <label style="font-size:0.85rem;">
         Max tokens:&nbsp;<input type="number" id="max-tokens" value="128"
           min="1" max="512" style="width:5rem;margin-bottom:0;">
       </label>
     </div>
-    <pre id="output"></pre>
     <p class="stats" id="gen-stats"></p>
   </div>
 
@@ -165,20 +191,82 @@
     const $promptIn    = $('prompt-input');
     const $generate    = $('generate');
     const $stop        = $('stop');
+    const $clear       = $('clear');
     const $maxTokens   = $('max-tokens');
-    const $output      = $('output');
+    const $chat        = $('chat');
     const $genStats    = $('gen-stats');
 
     let engine    = null;
     let tokenizer = null;
-    let streaming = false;   // true while a stream is running
+    let streaming = false;
 
-    // Show/hide system prompt row based on chat-mode checkbox
+    // Conversation history: [{role: 'user'|'assistant'|'system', content: string}]
+    let history = [];
+
+    // ---------- Template formatting ----------
+    // Build the full prompt from conversation history, formatted for the model's
+    // chat template.  Each turn is included so the model has full context.
+    function buildPrompt(hist, templateName) {
+      switch (templateName) {
+        case 'ChatML': {
+          let out = '';
+          for (const m of hist) {
+            out += `<|im_start|>${m.role}\n${m.content}<|im_end|>\n`;
+          }
+          out += '<|im_start|>assistant\n';
+          return out;
+        }
+        case 'Llama3': {
+          let out = '<|begin_of_text|>';
+          for (const m of hist) {
+            out += `<|start_header_id|>${m.role}<|end_header_id|>\n\n${m.content}<|eot_id|>`;
+          }
+          out += '<|start_header_id|>assistant<|end_header_id|>\n\n';
+          return out;
+        }
+        case 'Alpaca': {
+          const parts = [];
+          for (const m of hist) {
+            if (m.role === 'user')      parts.push(`### Instruction:\n${m.content}`);
+            else if (m.role === 'assistant') parts.push(`### Response:\n${m.content}`);
+          }
+          parts.push('### Response:');
+          return parts.join('\n\n');
+        }
+        default: // 'Raw' — no template; just concatenate user/assistant turns
+          return hist.filter(m => m.role !== 'system').map(m => m.content).join('\n');
+      }
+    }
+
+    // ---------- Chat UI helpers ----------
+    function appendBubble(role, content, isStreaming = false) {
+      const wrap = document.createElement('div');
+      const label = document.createElement('div');
+      label.className = 'msg-role';
+      label.textContent = role === 'user' ? 'You' : 'Assistant';
+      const bubble = document.createElement('div');
+      bubble.className = `msg ${role}` + (isStreaming ? ' streaming' : '');
+      bubble.textContent = content;
+      wrap.appendChild(label);
+      wrap.appendChild(bubble);
+      $chat.appendChild(wrap);
+      $chat.scrollTop = $chat.scrollHeight;
+      return bubble;
+    }
+
+    function clearChat() {
+      $chat.innerHTML = '';
+      history = [];
+      if (engine) engine.reset();
+      $genStats.textContent = '';
+    }
+
+    // ---------- Show/hide system prompt row ----------
     $chatMode.addEventListener('change', () => {
       $systemRow.style.display = $chatMode.checked ? '' : 'none';
     });
 
-    // Tab switching: each panel has its own set of .tab-btn / .tab-panel pairs
+    // ---------- Tab switching ----------
     document.querySelectorAll('.tab-btn').forEach(btn => {
       btn.addEventListener('click', () => {
         const panel = btn.closest('.panel');
@@ -189,7 +277,7 @@
       });
     });
 
-    // Progress bar helpers
+    // ---------- Progress bar ----------
     function showProgress(label) {
       $progress.hidden = false;
       $progressLbl.hidden = false;
@@ -216,6 +304,7 @@
       }, 600);
     }
 
+    // ---------- Model loaded ----------
     function onModelLoaded(eng, ms) {
       engine = eng;
       const tmplName = eng.chat_template_name;
@@ -226,7 +315,7 @@
       $generate.disabled = false;
       $promptIn.disabled = false;
       $systemIn.disabled = false;
-      // Update template badge
+      $clear.disabled = false;
       $tmplBadge.textContent = tmplName;
       $tmplBadge.style.display = '';
       hideProgress();
@@ -242,7 +331,7 @@
         `EOS: ${tok.eos_token_id ?? 'none'}`;
     }
 
-    // WASM init
+    // ---------- WASM init ----------
     async function startWasm() {
       try {
         await init();
@@ -256,7 +345,7 @@
       }
     }
 
-    // Model — file
+    // ---------- Model loaders ----------
     $fileInput.addEventListener('change', async e => {
       const file = e.target.files[0];
       if (!file) return;
@@ -267,14 +356,15 @@
         updateProgress(file.size, file.size, 'Parsing…');
         await new Promise(r => setTimeout(r, 10));
         const t0 = performance.now();
+        clearChat();
         onModelLoaded(FlareEngine.load(new Uint8Array(buffer)), performance.now() - t0);
       } catch (err) {
-        $modelInfo.textContent = 'Error: ' + err; $modelInfo.classList.add('error');
+        $modelInfo.textContent = 'Error: ' + err;
+        $modelInfo.classList.add('error');
         hideProgress();
       }
     });
 
-    // Model — URL
     $urlLoad.addEventListener('click', async () => {
       const url = $urlInput.value.trim();
       if (!url) return;
@@ -283,27 +373,29 @@
       $urlLoad.disabled = true;
       try {
         const t0 = performance.now();
+        clearChat();
         const eng = await new FlareProgressiveLoader(url)
           .load((l, t) => updateProgress(l, t, 'Downloading…'));
         onModelLoaded(eng, performance.now() - t0);
       } catch (err) {
-        $modelInfo.textContent = 'Error: ' + err; $modelInfo.classList.add('error');
+        $modelInfo.textContent = 'Error: ' + err;
+        $modelInfo.classList.add('error');
         hideProgress();
       } finally { $urlLoad.disabled = false; }
     });
 
-    // Tokenizer — file
+    // ---------- Tokenizer loaders ----------
     $tokFileIn.addEventListener('change', async e => {
       const file = e.target.files[0];
       if (!file) return;
       try {
         onTokenizerLoaded(FlareTokenizer.from_json(await file.text()));
       } catch (err) {
-        $tokInfo.textContent = 'Error: ' + err; $tokInfo.classList.add('error');
+        $tokInfo.textContent = 'Error: ' + err;
+        $tokInfo.classList.add('error');
       }
     });
 
-    // Tokenizer — URL
     $tokUrlLoad.addEventListener('click', async () => {
       const url = $tokUrlIn.value.trim();
       if (!url) return;
@@ -314,48 +406,77 @@
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         onTokenizerLoaded(FlareTokenizer.from_json(await resp.text()));
       } catch (err) {
-        $tokInfo.textContent = 'Error: ' + err; $tokInfo.classList.add('error');
+        $tokInfo.textContent = 'Error: ' + err;
+        $tokInfo.classList.add('error');
       } finally { $tokUrlLoad.disabled = false; }
     });
 
-    // Stop button
+    // ---------- Clear conversation ----------
+    $clear.addEventListener('click', () => {
+      clearChat();
+    });
+
+    // ---------- Stop ----------
     $stop.addEventListener('click', () => {
       if (engine && streaming) engine.stop_stream();
       streaming = false;
     });
 
-    // Generate — uses token-by-token streaming via requestAnimationFrame
+    // ---------- Generate (multi-turn streaming) ----------
     $generate.addEventListener('click', async () => {
       if (!engine || streaming) return;
+
+      const userText = $promptIn.value.trim();
+      if (!userText) return;
+
       streaming = true;
       $generate.disabled = true;
       $stop.disabled = false;
-      $output.textContent = '';
-      $output.classList.remove('error');
+      $promptIn.value = '';
       $genStats.textContent = 'Generating…';
       await new Promise(r => setTimeout(r, 10));
 
-      const maxToks  = parseInt($maxTokens.value, 10) || 128;
-      const userText = $promptIn.value.trim() || 'Once upon a time';
-      const sysText  = $systemIn.value.trim();
-      const chatMode = $chatMode.checked;
+      const maxToks   = parseInt($maxTokens.value, 10) || 128;
+      const sysText   = $systemIn.value.trim();
+      const chatMode  = $chatMode.checked;
+
+      // Add user bubble
+      appendBubble('user', userText);
+
+      // Build conversation history for this turn
+      if (chatMode) {
+        // Prepend system message only on the first turn
+        if (history.length === 0 && sysText) {
+          history.push({ role: 'system', content: sysText });
+        }
+        history.push({ role: 'user', content: userText });
+      }
 
       try {
-        engine.reset();
-
-        const inputText = chatMode
-          ? engine.apply_chat_template(userText, sysText)
-          : userText;
+        // Format the full prompt including all prior turns
+        let inputText;
+        if (chatMode) {
+          inputText = buildPrompt(history, engine.chat_template_name);
+        } else {
+          inputText = userText;
+        }
 
         const promptIds = tokenizer
           ? tokenizer.encode(inputText)
           : new Uint32Array([1]);
 
+        // Reset KV cache and re-run prefill over the full context each turn.
+        // For small models this is fast; a KV-cache continuation API can be
+        // added later for larger models.
+        engine.reset();
         engine.begin_stream(promptIds, maxToks);
 
         const t0 = performance.now();
         let count = 0;
-        const tokenIds = [];
+        let assistantText = '';
+
+        // Streaming assistant bubble
+        const bubble = appendBubble('assistant', '', true);
 
         function tick() {
           if (!streaming) {
@@ -369,13 +490,16 @@
             return;
           }
           count++;
-          tokenIds.push(id);
           if (tokenizer) {
-            $output.textContent += tokenizer.decode_one(id);
+            const piece = tokenizer.decode_one(id);
+            assistantText += piece;
+            bubble.textContent = assistantText;
           } else {
-            $output.textContent = `Token IDs: [${tokenIds.join(', ')}]`;
+            assistantText += `[${id}]`;
+            bubble.textContent = assistantText;
           }
-          // Update running stats every 8 tokens
+          $chat.scrollTop = $chat.scrollHeight;
+
           if (count % 8 === 0) {
             const ms = performance.now() - t0;
             $genStats.textContent = `${count} tokens · ${(count / (ms / 1000)).toFixed(1)} tok/s`;
@@ -384,26 +508,42 @@
         }
 
         function finishStream() {
+          bubble.classList.remove('streaming');
+
+          // Save completed assistant response to history
+          const finalText = assistantText ||
+            (!tokenizer ? '(load a tokenizer to see decoded text)' : '');
+          if (chatMode && finalText) {
+            history.push({ role: 'assistant', content: assistantText });
+          }
+          if (!tokenizer && count > 0) {
+            bubble.textContent = `${count} token(s) generated. Load a tokenizer (step 2) to see decoded text.`;
+          }
+
           const ms = performance.now() - t0;
           const tokS = count / (ms / 1000);
-          if (!tokenizer && tokenIds.length > 0) {
-            $output.textContent =
-              `Token IDs: [${tokenIds.join(', ')}]\n\nLoad a tokenizer (step 2) to see decoded text.`;
-          }
           $genStats.textContent =
             `${count} tokens in ${ms.toFixed(0)} ms = ${tokS.toFixed(1)} tok/s` +
             (chatMode ? ` · template: ${engine.chat_template_name}` : '');
+
           $generate.disabled = false;
           $stop.disabled = true;
         }
 
         requestAnimationFrame(tick);
       } catch (err) {
-        $output.textContent = 'Error: ' + err;
-        $output.classList.add('error');
+        appendBubble('assistant', 'Error: ' + err).classList.add('error');
         streaming = false;
         $generate.disabled = false;
         $stop.disabled = true;
+      }
+    });
+
+    // Allow Ctrl+Enter / Cmd+Enter to send
+    $promptIn.addEventListener('keydown', e => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        e.preventDefault();
+        if (!$generate.disabled) $generate.click();
       }
     });
 

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -170,6 +170,8 @@ impl FlareEngine {
         match self.chat_template {
             ChatTemplate::Llama3 => "Llama3".to_string(),
             ChatTemplate::ChatML => "ChatML".to_string(),
+            ChatTemplate::Phi3 => "Phi3".to_string(),
+            ChatTemplate::Gemma => "Gemma".to_string(),
             ChatTemplate::Alpaca => "Alpaca".to_string(),
             ChatTemplate::Raw => "Raw".to_string(),
         }


### PR DESCRIPTION
## Summary
- Adds Architecture::Phi3 and Architecture::Gemma2 variants
- Phi-3 uses the same forward pass as Llama (identical architecture) with its own chat template (uses <|user|>...<|end|> tokens)
- Gemma 2 changes:
  - Post-attention and post-FFN RMSNorm layers
  - GELU activation in FFN (tanh approximation) instead of SiLU
  - Attention logit soft-capping: tanh(score / cap) * cap (cap from GGUF metadata)
  - Final logit soft-capping applied after output projection
  - Optional post_attn_norm and post_ffn_norm tensors loaded from GGUF
- New chat template detection: <|user|> -> Phi3, <start_of_turn> -> Gemma
- Browser demo JS buildPrompt() supports Phi3 and Gemma templates

## Test plan
- All 77+ existing tests pass
- cargo test --workspace passes
- Load Phi-3.5-mini-instruct Q4_K_M GGUF -- model loads and generates text
- Load Gemma-2-2B-it Q4_K_M GGUF -- model loads and generates text

Closes #100