### PR TITLE
Activate WebGPU backend in browser + SafeTensors weight loading

### DIFF
--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -462,6 +462,13 @@ impl ComputeBackend for WebGpuBackend {
     }
 }
 
+// WASM is single-threaded; wgpu's JS-backed types don't impl Send/Sync but it's
+// safe to assert them here because no other threads exist.
+#[cfg(target_arch = "wasm32")]
+unsafe impl Send for WebGpuBackend {}
+#[cfg(target_arch = "wasm32")]
+unsafe impl Sync for WebGpuBackend {}
+
 // Helper functions for bind group layout entries
 fn storage_ro_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
     wgpu::BindGroupLayoutEntry {

--- a/flare-loader/src/lib.rs
+++ b/flare-loader/src/lib.rs
@@ -25,4 +25,7 @@ pub mod weights;
 pub use gguf::{GgufError, GgufFile};
 pub use quantize::QuantFormat;
 pub use safetensors::{SafeTensorsError, SafeTensorsFile};
-pub use weights::{load_model_weights, load_model_weights_with_progress};
+pub use weights::{
+    infer_model_config_from_safetensors, load_model_weights, load_model_weights_from_safetensors,
+    load_model_weights_with_progress,
+};

--- a/flare-loader/src/weights.rs
+++ b/flare-loader/src/weights.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 
+use flare_core::config::{Architecture, ModelConfig};
 use flare_core::model::{LayerWeights, ModelWeights};
 use flare_core::tensor::Tensor;
 
 use crate::gguf::{GgufError, GgufFile};
+use crate::safetensors::{SafeTensorInfo, SafeTensorsError, SafeTensorsFile};
 
 /// Load ModelWeights from a parsed GGUF file.
 ///
@@ -219,6 +221,234 @@ fn find_tensor(tensors: &HashMap<String, Tensor>, names: &[&str]) -> Result<Tens
     ))
 }
 
+// ---------------------------------------------------------------------------
+// SafeTensors loading
+// ---------------------------------------------------------------------------
+
+/// Infer a `ModelConfig` from the tensor shapes in a SafeTensors file.
+///
+/// Values that cannot be derived from weights alone (`rope_theta`,
+/// `rms_norm_eps`, `max_seq_len`) use standard defaults. For production use,
+/// parse the accompanying `config.json` and override these fields.
+pub fn infer_model_config_from_safetensors(
+    tensors: &HashMap<String, SafeTensorInfo>,
+) -> Result<ModelConfig, SafeTensorsError> {
+    // Embedding → [vocab_size, hidden_dim]
+    let emb = tensors
+        .get("model.embed_tokens.weight")
+        .ok_or_else(|| SafeTensorsError::TensorNotFound("model.embed_tokens.weight".into()))?;
+    let vocab_size = emb.shape[0];
+    let hidden_dim = emb.shape[1];
+
+    // Count transformer layers by probing for input_layernorm weights
+    let num_layers = (0usize..)
+        .take_while(|&i| {
+            tensors.contains_key(&format!("model.layers.{i}.input_layernorm.weight"))
+        })
+        .count();
+    if num_layers == 0 {
+        return Err(SafeTensorsError::TensorNotFound(
+            "model.layers.0.input_layernorm.weight".into(),
+        ));
+    }
+
+    // WQ shape → [num_heads * head_dim, hidden_dim]
+    let wq = tensors
+        .get("model.layers.0.self_attn.q_proj.weight")
+        .ok_or_else(|| {
+            SafeTensorsError::TensorNotFound("model.layers.0.self_attn.q_proj.weight".into())
+        })?;
+    let q_proj_out = wq.shape[0];
+
+    // WK shape → [num_kv_heads * head_dim, hidden_dim]
+    let wk = tensors
+        .get("model.layers.0.self_attn.k_proj.weight")
+        .ok_or_else(|| {
+            SafeTensorsError::TensorNotFound("model.layers.0.self_attn.k_proj.weight".into())
+        })?;
+    let k_proj_out = wk.shape[0];
+
+    // Infer head_dim: try common values in order of prevalence
+    let head_dim = [128usize, 64, 96, 48, 32]
+        .iter()
+        .copied()
+        .find(|&hd| q_proj_out % hd == 0 && k_proj_out % hd == 0)
+        .unwrap_or(64); // fallback — may be wrong for unusual architectures
+    let num_heads = q_proj_out / head_dim;
+    let num_kv_heads = k_proj_out / head_dim;
+
+    // Intermediate dim from gate proj shape → [intermediate_dim, hidden_dim]
+    let w_gate = tensors
+        .get("model.layers.0.mlp.gate_proj.weight")
+        .ok_or_else(|| {
+            SafeTensorsError::TensorNotFound("model.layers.0.mlp.gate_proj.weight".into())
+        })?;
+    let intermediate_dim = w_gate.shape[0];
+
+    Ok(ModelConfig {
+        architecture: Architecture::Llama,
+        vocab_size,
+        hidden_dim,
+        intermediate_dim,
+        num_layers,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        max_seq_len: 2048,
+        rope_theta: 10000.0,
+        rms_norm_eps: 1e-5,
+        attn_logit_softcap: 0.0,
+        final_logit_softcap: 0.0,
+    })
+}
+
+/// Like `find_tensor` but returns `SafeTensorsError`.
+fn find_st_tensor(
+    tensors: &HashMap<String, Tensor>,
+    names: &[&str],
+) -> Result<Tensor, SafeTensorsError> {
+    for name in names {
+        if let Some(t) = tensors.get(*name) {
+            return Ok(t.clone());
+        }
+    }
+    Err(SafeTensorsError::TensorNotFound(
+        names
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join(" | "),
+    ))
+}
+
+fn load_st_layer_weights(
+    tensors: &HashMap<String, Tensor>,
+    layer_idx: usize,
+) -> Result<LayerWeights, SafeTensorsError> {
+    let i = layer_idx;
+
+    let attn_norm = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.input_layernorm.weight")],
+    )?;
+    let wq = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.self_attn.q_proj.weight")],
+    )?;
+    let wk = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.self_attn.k_proj.weight")],
+    )?;
+    let wv = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.self_attn.v_proj.weight")],
+    )?;
+    let wo = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.self_attn.o_proj.weight")],
+    )?;
+    let ffn_norm = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.post_attention_layernorm.weight")],
+    )?;
+    let w_gate = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.mlp.gate_proj.weight")],
+    )?;
+    let w_up =
+        find_st_tensor(tensors, &[&format!("model.layers.{i}.mlp.up_proj.weight")])?;
+    let w_down =
+        find_st_tensor(tensors, &[&format!("model.layers.{i}.mlp.down_proj.weight")])?;
+
+    let attn_q_bias = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.self_attn.q_proj.bias")],
+    )
+    .ok();
+    let attn_k_bias = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.self_attn.k_proj.bias")],
+    )
+    .ok();
+    let attn_v_bias = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.self_attn.v_proj.bias")],
+    )
+    .ok();
+    let post_attn_norm = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.post_attention_layernorm.weight")],
+    )
+    .ok();
+    let post_ffn_norm = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.post_feedforward_layernorm.weight")],
+    )
+    .ok();
+
+    Ok(LayerWeights {
+        attn_norm,
+        wq,
+        wk,
+        wv,
+        wo,
+        ffn_norm,
+        w_gate,
+        w_up,
+        w_down,
+        attn_q_bias,
+        attn_k_bias,
+        attn_v_bias,
+        post_attn_norm,
+        post_ffn_norm,
+    })
+}
+
+/// Load `ModelWeights` and infer `ModelConfig` from a SafeTensors file.
+///
+/// Reads all tensors from `reader` in one pass, then maps them to the
+/// `LayerWeights` / `ModelWeights` structure using HuggingFace-style names
+/// (`model.layers.{i}.self_attn.q_proj.weight` etc.).
+///
+/// # Config inference
+/// `ModelConfig` fields that can be derived from tensor shapes are inferred
+/// automatically. Fields that require a separate `config.json`
+/// (`rope_theta`, `rms_norm_eps`, `max_seq_len`) are set to safe defaults.
+pub fn load_model_weights_from_safetensors<R: Read + Seek>(
+    sf: &SafeTensorsFile,
+    reader: &mut R,
+) -> Result<(ModelWeights, ModelConfig), SafeTensorsError> {
+    // Load all tensors into memory up front
+    let mut tensors: HashMap<String, Tensor> = HashMap::with_capacity(sf.tensors.len());
+    for name in sf.tensor_names() {
+        let tensor = sf.read_tensor(reader, name)?;
+        tensors.insert(name.to_string(), tensor);
+    }
+
+    let config = infer_model_config_from_safetensors(&sf.tensors)?;
+
+    let token_embedding =
+        find_st_tensor(&tensors, &["model.embed_tokens.weight"])?;
+    let output_norm = find_st_tensor(&tensors, &["model.norm.weight"])?;
+    let output_weight = find_st_tensor(&tensors, &["lm_head.weight"])
+        .unwrap_or_else(|_| token_embedding.clone());
+
+    let mut layers = Vec::with_capacity(config.num_layers);
+    for i in 0..config.num_layers {
+        layers.push(load_st_layer_weights(&tensors, i)?);
+    }
+
+    Ok((
+        ModelWeights {
+            token_embedding,
+            layers,
+            output_norm,
+            output_weight,
+        },
+        config,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -363,5 +593,107 @@ mod tests {
         // Layer 5 doesn't exist
         let result = load_layer_weights(&tensors, 5);
         assert!(result.is_err());
+    }
+
+    // ---- SafeTensors config inference ----
+
+    fn make_st_info(shape: Vec<usize>) -> SafeTensorInfo {
+        let numel: usize = shape.iter().product::<usize>().max(1);
+        SafeTensorInfo {
+            name: String::new(),
+            dtype: crate::safetensors::Dtype::F32,
+            shape,
+            start: 0,
+            end: numel * 4,
+        }
+    }
+
+    fn build_st_tensors(
+        vocab: usize,
+        hidden: usize,
+        inter: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        num_layers: usize,
+    ) -> HashMap<String, SafeTensorInfo> {
+        let mut m = HashMap::new();
+        m.insert(
+            "model.embed_tokens.weight".into(),
+            make_st_info(vec![vocab, hidden]),
+        );
+        m.insert("model.norm.weight".into(), make_st_info(vec![hidden]));
+        m.insert(
+            "lm_head.weight".into(),
+            make_st_info(vec![vocab, hidden]),
+        );
+        for i in 0..num_layers {
+            m.insert(
+                format!("model.layers.{i}.input_layernorm.weight"),
+                make_st_info(vec![hidden]),
+            );
+            m.insert(
+                format!("model.layers.{i}.self_attn.q_proj.weight"),
+                make_st_info(vec![num_heads * head_dim, hidden]),
+            );
+            m.insert(
+                format!("model.layers.{i}.self_attn.k_proj.weight"),
+                make_st_info(vec![num_kv_heads * head_dim, hidden]),
+            );
+            m.insert(
+                format!("model.layers.{i}.self_attn.v_proj.weight"),
+                make_st_info(vec![num_kv_heads * head_dim, hidden]),
+            );
+            m.insert(
+                format!("model.layers.{i}.self_attn.o_proj.weight"),
+                make_st_info(vec![hidden, num_heads * head_dim]),
+            );
+            m.insert(
+                format!("model.layers.{i}.post_attention_layernorm.weight"),
+                make_st_info(vec![hidden]),
+            );
+            m.insert(
+                format!("model.layers.{i}.mlp.gate_proj.weight"),
+                make_st_info(vec![inter, hidden]),
+            );
+            m.insert(
+                format!("model.layers.{i}.mlp.up_proj.weight"),
+                make_st_info(vec![inter, hidden]),
+            );
+            m.insert(
+                format!("model.layers.{i}.mlp.down_proj.weight"),
+                make_st_info(vec![hidden, inter]),
+            );
+        }
+        m
+    }
+
+    #[test]
+    fn test_infer_config_from_safetensors() {
+        let tensors = build_st_tensors(32000, 4096, 11008, 32, 8, 128, 32);
+        let cfg = infer_model_config_from_safetensors(&tensors).unwrap();
+        assert_eq!(cfg.vocab_size, 32000);
+        assert_eq!(cfg.hidden_dim, 4096);
+        assert_eq!(cfg.intermediate_dim, 11008);
+        assert_eq!(cfg.num_layers, 32);
+        assert_eq!(cfg.num_heads, 32);
+        assert_eq!(cfg.num_kv_heads, 8);
+        assert_eq!(cfg.head_dim, 128);
+    }
+
+    #[test]
+    fn test_infer_config_gqa() {
+        // Llama-3.1-8B: hidden=4096, heads=32, kv_heads=8, head_dim=128
+        let tensors = build_st_tensors(128256, 4096, 14336, 32, 8, 128, 32);
+        let cfg = infer_model_config_from_safetensors(&tensors).unwrap();
+        assert_eq!(cfg.num_heads, 32);
+        assert_eq!(cfg.num_kv_heads, 8);
+        assert_eq!(cfg.head_dim, 128);
+    }
+
+    #[test]
+    fn test_infer_config_missing_embedding_fails() {
+        let m: HashMap<String, SafeTensorInfo> = HashMap::new();
+        assert!(infer_model_config_from_safetensors(&m).is_err());
     }
 }

--- a/flare-loader/src/weights.rs
+++ b/flare-loader/src/weights.rs
@@ -242,9 +242,7 @@ pub fn infer_model_config_from_safetensors(
 
     // Count transformer layers by probing for input_layernorm weights
     let num_layers = (0usize..)
-        .take_while(|&i| {
-            tensors.contains_key(&format!("model.layers.{i}.input_layernorm.weight"))
-        })
+        .take_while(|&i| tensors.contains_key(&format!("model.layers.{i}.input_layernorm.weight")))
         .count();
     if num_layers == 0 {
         return Err(SafeTensorsError::TensorNotFound(
@@ -355,10 +353,11 @@ fn load_st_layer_weights(
         tensors,
         &[&format!("model.layers.{i}.mlp.gate_proj.weight")],
     )?;
-    let w_up =
-        find_st_tensor(tensors, &[&format!("model.layers.{i}.mlp.up_proj.weight")])?;
-    let w_down =
-        find_st_tensor(tensors, &[&format!("model.layers.{i}.mlp.down_proj.weight")])?;
+    let w_up = find_st_tensor(tensors, &[&format!("model.layers.{i}.mlp.up_proj.weight")])?;
+    let w_down = find_st_tensor(
+        tensors,
+        &[&format!("model.layers.{i}.mlp.down_proj.weight")],
+    )?;
 
     let attn_q_bias = find_st_tensor(
         tensors,
@@ -382,7 +381,9 @@ fn load_st_layer_weights(
     .ok();
     let post_ffn_norm = find_st_tensor(
         tensors,
-        &[&format!("model.layers.{i}.post_feedforward_layernorm.weight")],
+        &[&format!(
+            "model.layers.{i}.post_feedforward_layernorm.weight"
+        )],
     )
     .ok();
 
@@ -427,11 +428,10 @@ pub fn load_model_weights_from_safetensors<R: Read + Seek>(
 
     let config = infer_model_config_from_safetensors(&sf.tensors)?;
 
-    let token_embedding =
-        find_st_tensor(&tensors, &["model.embed_tokens.weight"])?;
+    let token_embedding = find_st_tensor(&tensors, &["model.embed_tokens.weight"])?;
     let output_norm = find_st_tensor(&tensors, &["model.norm.weight"])?;
-    let output_weight = find_st_tensor(&tensors, &["lm_head.weight"])
-        .unwrap_or_else(|_| token_embedding.clone());
+    let output_weight =
+        find_st_tensor(&tensors, &["lm_head.weight"]).unwrap_or_else(|_| token_embedding.clone());
 
     let mut layers = Vec::with_capacity(config.num_layers);
     for i in 0..config.num_layers {
@@ -623,10 +623,7 @@ mod tests {
             make_st_info(vec![vocab, hidden]),
         );
         m.insert("model.norm.weight".into(), make_st_info(vec![hidden]));
-        m.insert(
-            "lm_head.weight".into(),
-            make_st_info(vec![vocab, hidden]),
-        );
+        m.insert("lm_head.weight".into(), make_st_info(vec![vocab, hidden]));
         for i in 0..num_layers {
             m.insert(
                 format!("model.layers.{i}.input_layernorm.weight"),

--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -324,7 +324,7 @@
     }
 
     // ---------- Model loaded ----------
-    function onModelLoaded(eng, ms) {
+    async function onModelLoaded(eng, ms) {
       engine = eng;
       const tmplName = eng.chat_template_name;
       $modelInfo.textContent =
@@ -338,6 +338,17 @@
       $tmplBadge.textContent = tmplName;
       $tmplBadge.style.display = '';
       hideProgress();
+
+      // Try to activate WebGPU backend for faster matrix ops
+      if (webgpu_available()) {
+        $env.textContent = 'WebGPU: initialising…';
+        try {
+          const gpuOn = await eng.init_gpu();
+          $env.textContent = gpuOn ? 'WebGPU: ✓ active' : 'WebGPU: available but init failed';
+        } catch (e) {
+          $env.textContent = 'WebGPU: error — ' + e;
+        }
+      }
     }
 
     function onTokenizerLoaded(tok) {
@@ -376,7 +387,7 @@
         await new Promise(r => setTimeout(r, 10));
         const t0 = performance.now();
         clearChat();
-        onModelLoaded(FlareEngine.load(new Uint8Array(buffer)), performance.now() - t0);
+        await onModelLoaded(FlareEngine.load(new Uint8Array(buffer)), performance.now() - t0);
       } catch (err) {
         $modelInfo.textContent = 'Error: ' + err;
         $modelInfo.classList.add('error');
@@ -395,7 +406,7 @@
         clearChat();
         const eng = await new FlareProgressiveLoader(url)
           .load((l, t) => updateProgress(l, t, 'Downloading…'));
-        onModelLoaded(eng, performance.now() - t0);
+        await onModelLoaded(eng, performance.now() - t0);
       } catch (err) {
         $modelInfo.textContent = 'Error: ' + err;
         $modelInfo.classList.add('error');

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -29,6 +29,7 @@ use flare_core::generate::Generator;
 use flare_core::model::Model;
 use flare_core::sampling::{self, SamplingParams};
 use flare_core::tokenizer::{BpeTokenizer, Tokenizer};
+use flare_gpu::WebGpuBackend;
 use flare_loader::gguf::GgufFile;
 use flare_loader::weights::{load_model_weights, load_model_weights_with_progress};
 use wasm_bindgen::prelude::*;
@@ -136,6 +137,33 @@ impl FlareEngine {
             stream_remaining: 0,
             stream_done: true,
         })
+    }
+
+    /// Try to initialise the WebGPU compute backend.
+    ///
+    /// Call this after `load()` to enable GPU-accelerated matrix operations
+    /// (matvec, matmul, silu_mul). Falls back silently to CPU if WebGPU is
+    /// unavailable or adapter request fails.
+    ///
+    /// Returns `true` if a GPU backend was successfully initialised.
+    ///
+    /// ```javascript
+    /// const engine = FlareEngine.load(bytes);
+    /// const gpuEnabled = await engine.init_gpu();
+    /// console.log('GPU:', gpuEnabled);
+    /// ```
+    #[wasm_bindgen]
+    pub async fn init_gpu(&mut self) -> bool {
+        if !webgpu_available() {
+            return false;
+        }
+        match WebGpuBackend::new().await {
+            Ok(gpu) => {
+                self.model.set_backend(Box::new(gpu));
+                true
+            }
+            Err(_) => false,
+        }
     }
 
     /// Reset the KV cache (start a new conversation).


### PR DESCRIPTION
## Summary

### WebGPU activation in browser
- `flare-gpu`: add `unsafe impl Send + Sync for WebGpuBackend` under `#[cfg(target_arch = "wasm32")]` — safe because WASM is single-threaded
- `flare-web`: add `FlareEngine::init_gpu()` async WASM export that tries `WebGpuBackend::new()`, calls `model.set_backend()` on success, returns `bool`
- Browser demo now calls `await engine.init_gpu()` after load and shows "WebGPU: active" in the status line when GPU is available

This activates the existing GPU kernels (matvec, matmul, silu_mul) which were already written but never reached from the browser code path.

### SafeTensors weight loading (`flare-loader`)
- `infer_model_config_from_safetensors(tensors)` — derives `ModelConfig` from HF tensor shapes
- `load_model_weights_from_safetensors(sf, reader)` — maps HF-style names to `ModelWeights`; returns `(ModelWeights, ModelConfig)` so callers need no GGUF file
- Both functions re-exported from the `flare-loader` crate root

## Test plan
- [ ] `cargo test --workspace` passes (3 new SafeTensors config inference tests)
- [ ] `cargo check --workspace --all-targets` clean
- [ ] WASM build: `wasm-pack build flare-web --target web`
- [ ] WebGPU-capable browser: status shows "WebGPU: active" after model load
- [ ] Non-WebGPU context: gracefully shows "WebGPU: no", generation still works via CPU
