### PR TITLE
Fix server concurrency, GGUF tokenization, and browser model caching

### DIFF
--- a/flare-loader/src/tokenizer.rs
+++ b/flare-loader/src/tokenizer.rs
@@ -149,9 +149,88 @@ impl GgufVocab {
         result
     }
 
-    /// Look up a token string to get its ID.
+    /// Look up a single token string by exact match.
     pub fn encode_token(&self, token: &str) -> Option<u32> {
         self.token_to_id.get(token).copied()
+    }
+
+    /// Encode text to token IDs using the BPE-merge algorithm over the
+    /// embedded GGUF vocabulary.
+    ///
+    /// This implements the "llama.cpp"-style SentencePiece BPE tokenizer:
+    /// 1. Normalize: replace spaces with the ▁ marker (U+2581) and prepend ▁.
+    /// 2. Split into per-character symbols; unknown chars fall back to
+    ///    `<0xXX>` byte tokens.
+    /// 3. Repeatedly merge the adjacent pair with the highest vocabulary score
+    ///    until no more merges exist.
+    ///
+    /// Does not prepend BOS — the caller (chat template / server) is
+    /// responsible for that.
+    pub fn encode(&self, text: &str) -> Vec<u32> {
+        if text.is_empty() {
+            return Vec::new();
+        }
+
+        // Step 1: normalize — prepend ▁ and replace spaces with ▁
+        let normalized = format!("\u{2581}{}", text.replace(' ', "\u{2581}"));
+
+        // Step 2: seed symbols — one unicode scalar at a time; fall back to bytes
+        let mut symbols: Vec<u32> = Vec::with_capacity(normalized.len());
+        for ch in normalized.chars() {
+            let s = ch.to_string();
+            if let Some(&id) = self.token_to_id.get(&s) {
+                symbols.push(id);
+            } else {
+                // UTF-8 byte fallback
+                for byte in s.as_bytes() {
+                    let byte_tok = format!("<0x{byte:02X}>");
+                    let id = self.token_to_id.get(&byte_tok).copied().unwrap_or(0);
+                    symbols.push(id);
+                }
+            }
+        }
+
+        // Step 3: greedy BPE merge — O(n²) but sufficient for typical prompt lengths
+        loop {
+            let mut best_score = f32::NEG_INFINITY;
+            let mut best_pos: Option<usize> = None;
+            let mut best_id: Option<u32> = None;
+
+            for i in 0..symbols.len().saturating_sub(1) {
+                let left = match self.id_to_token.get(symbols[i] as usize) {
+                    Some(s) => s.as_str(),
+                    None => continue,
+                };
+                let right = match self.id_to_token.get(symbols[i + 1] as usize) {
+                    Some(s) => s.as_str(),
+                    None => continue,
+                };
+                // Avoid heap allocation for the common case where concat is long
+                let merged = format!("{left}{right}");
+                if let Some(&id) = self.token_to_id.get(&merged) {
+                    let score = self
+                        .scores
+                        .get(id as usize)
+                        .copied()
+                        .unwrap_or(f32::NEG_INFINITY);
+                    if score > best_score {
+                        best_score = score;
+                        best_pos = Some(i);
+                        best_id = Some(id);
+                    }
+                }
+            }
+
+            match (best_pos, best_id) {
+                (Some(pos), Some(id)) => {
+                    symbols[pos] = id;
+                    symbols.remove(pos + 1);
+                }
+                _ => break,
+            }
+        }
+
+        symbols
     }
 
     /// Get all control tokens.
@@ -283,5 +362,87 @@ mod tests {
             tensor_data_offset: 0,
         };
         assert!(GgufVocab::from_gguf(&gguf).is_err());
+    }
+
+    /// Build a vocab that can encode a few words via BPE merges.
+    fn make_merge_vocab() -> GgufVocab {
+        // Tokens: index 0=<unk>, 1=▁, 2=h, 3=e, 4=l, 5=o, 6=▁h, 7=▁he, 8=▁hel, 9=▁hell, 10=▁hello
+        let tokens = vec![
+            "<unk>".to_string(),
+            "\u{2581}".to_string(), // ▁
+            "h".to_string(),
+            "e".to_string(),
+            "l".to_string(),
+            "o".to_string(),
+            "\u{2581}h".to_string(),     // ▁h
+            "\u{2581}he".to_string(),    // ▁he
+            "\u{2581}hel".to_string(),   // ▁hel
+            "\u{2581}hell".to_string(),  // ▁hell
+            "\u{2581}hello".to_string(), // ▁hello
+        ];
+        // Scores: higher = preferred merge. Each multi-char token gets its index as score.
+        let scores: Vec<f32> = (0..tokens.len()).map(|i| i as f32).collect();
+        let vocab_size = tokens.len();
+        let mut token_to_id = HashMap::new();
+        for (i, t) in tokens.iter().enumerate() {
+            token_to_id.insert(t.clone(), i as u32);
+        }
+        GgufVocab {
+            id_to_token: tokens,
+            token_to_id,
+            scores,
+            token_types: vec![TokenType::Normal; vocab_size],
+            bos_id: None,
+            eos_id: None,
+            vocab_size,
+        }
+    }
+
+    #[test]
+    fn test_encode_bpe_merges() {
+        let vocab = make_merge_vocab();
+        // "hello" → normalize to "▁hello" → should merge all the way to token 10
+        let ids = vocab.encode("hello");
+        assert_eq!(
+            ids,
+            vec![10],
+            "expected single ▁hello token (id=10), got {ids:?}"
+        );
+    }
+
+    #[test]
+    fn test_encode_empty() {
+        let vocab = make_merge_vocab();
+        assert_eq!(vocab.encode(""), Vec::<u32>::new());
+    }
+
+    #[test]
+    fn test_encode_byte_fallback() {
+        // A vocab with only byte tokens should encode unknown chars as bytes.
+        let mut tokens = vec!["<unk>".to_string()];
+        // Add all 256 byte tokens
+        for b in 0u8..=255 {
+            tokens.push(format!("<0x{b:02X}>"));
+        }
+        let vocab_size = tokens.len();
+        let mut token_to_id = HashMap::new();
+        for (i, t) in tokens.iter().enumerate() {
+            token_to_id.insert(t.clone(), i as u32);
+        }
+        let vocab = GgufVocab {
+            id_to_token: tokens,
+            token_to_id,
+            scores: vec![0.0; vocab_size],
+            token_types: vec![TokenType::Normal; vocab_size],
+            bos_id: None,
+            eos_id: None,
+            vocab_size,
+        };
+        // "A" = 0x41 = byte index 0x41+1 = 66th entry (1-indexed because <unk> is 0)
+        let ids = vocab.encode("A");
+        // ▁ (0xE2 0x96 0x81 in UTF-8) + A (0x41) encoded as bytes
+        assert!(!ids.is_empty());
+        // Last token should correspond to 'A' = 0x41
+        assert_eq!(*ids.last().unwrap(), 0x42); // 1-based byte token index
     }
 }

--- a/flare-server/src/main.rs
+++ b/flare-server/src/main.rs
@@ -11,7 +11,10 @@ use axum::{
 use clap::Parser;
 use std::fs::File;
 use std::io::BufReader;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
 use tower_http::cors::{Any, CorsLayer};
 
 use flare_core::chat::{ChatMessage, ChatTemplate, Role};
@@ -231,6 +234,9 @@ fn model_not_loaded_error() -> Response {
         .into_response()
 }
 
+/// How long a request will wait for the model lock before returning 503.
+const INFERENCE_TIMEOUT: Duration = Duration::from_secs(30);
+
 async fn chat_completions(
     State(state): State<Arc<AppState>>,
     Json(req): Json<ChatCompletionRequest>,
@@ -257,9 +263,9 @@ async fn chat_completions(
         .to_string();
 
     if req.stream {
-        stream_response(&model_name, &req, model_mutex, tokenizer, template)
+        stream_response(&model_name, &req, model_mutex, tokenizer, template).await
     } else {
-        non_stream_response(&model_name, &req, model_mutex, tokenizer, template)
+        non_stream_response(&model_name, &req, model_mutex, tokenizer, template).await
     }
 }
 
@@ -289,15 +295,7 @@ fn encode_prompt(text: &str, tokenizer: &TokenizerState) -> Vec<u32> {
                 text.bytes().map(|b| b as u32).collect()
             }
         },
-        TokenizerState::Gguf(vocab) => {
-            // Byte-level fallback: look up each byte in GGUF vocab
-            text.bytes()
-                .map(|b| {
-                    let byte_token = format!("<0x{b:02X}>");
-                    vocab.encode_token(&byte_token).unwrap_or(b as u32)
-                })
-                .collect()
-        }
+        TokenizerState::Gguf(vocab) => vocab.encode(text),
     }
 }
 
@@ -332,6 +330,21 @@ fn make_rng() -> impl FnMut() -> f32 {
     }
 }
 
+fn server_busy_error() -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        [(header::RETRY_AFTER, "5")],
+        Json(serde_json::json!({
+            "error": {
+                "message": "Model is busy — another request is in progress. Retry shortly.",
+                "type": "server_busy",
+                "code": 503,
+            }
+        })),
+    )
+        .into_response()
+}
+
 fn lock_error_response(err: &str) -> Response {
     (
         StatusCode::INTERNAL_SERVER_ERROR,
@@ -345,16 +358,16 @@ fn lock_error_response(err: &str) -> Response {
         .into_response()
 }
 
-fn non_stream_response(
+async fn non_stream_response(
     model_name: &str,
     req: &ChatCompletionRequest,
     model_mutex: &Mutex<Model>,
     tokenizer: &TokenizerState,
     template: &ChatTemplate,
 ) -> Response {
-    let mut model = match model_mutex.lock() {
+    let mut model = match timeout(INFERENCE_TIMEOUT, model_mutex.lock()).await {
         Ok(guard) => guard,
-        Err(e) => return lock_error_response(&e.to_string()),
+        Err(_) => return server_busy_error(),
     };
 
     let prompt = format_prompt(&req.messages, template);
@@ -398,16 +411,16 @@ fn non_stream_response(
     .into_response()
 }
 
-fn stream_response(
+async fn stream_response(
     model_name: &str,
     req: &ChatCompletionRequest,
     model_mutex: &Mutex<Model>,
     tokenizer: &TokenizerState,
     template: &ChatTemplate,
 ) -> Response {
-    let mut model = match model_mutex.lock() {
+    let mut model = match timeout(INFERENCE_TIMEOUT, model_mutex.lock()).await {
         Ok(guard) => guard,
-        Err(e) => return lock_error_response(&e.to_string()),
+        Err(_) => return server_busy_error(),
     };
 
     let model_name_owned = model_name.to_string();

--- a/flare-server/src/main.rs
+++ b/flare-server/src/main.rs
@@ -345,19 +345,6 @@ fn server_busy_error() -> Response {
         .into_response()
 }
 
-fn lock_error_response(err: &str) -> Response {
-    (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        Json(serde_json::json!({
-            "error": {
-                "message": format!("Model lock error: {err}"),
-                "type": "server_error",
-            }
-        })),
-    )
-        .into_response()
-}
-
 async fn non_stream_response(
     model_name: &str,
     req: &ChatCompletionRequest,

--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -395,6 +395,55 @@
       }
     });
 
+    // Cache name — bump version to invalidate all cached models on format change.
+    const MODEL_CACHE = 'flare-models-v1';
+
+    async function loadModelFromUrl(url) {
+      // 1. Check browser Cache API for a previously downloaded copy.
+      if ('caches' in window) {
+        try {
+          const cache = await caches.open(MODEL_CACHE);
+          const cached = await cache.match(url);
+          if (cached) {
+            updateProgress(1, 1, 'Loading from cache…');
+            const buf = new Uint8Array(await cached.arrayBuffer());
+            return { bytes: buf, fromCache: true };
+          }
+        } catch (_) { /* Cache API unavailable in this context — fall through */ }
+      }
+
+      // 2. Fresh download: stream the response body to show progress.
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
+      const total = parseInt(resp.headers.get('Content-Length') || '0', 10);
+      const reader = resp.body.getReader();
+      const chunks = [];
+      let loaded = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        loaded += value.byteLength;
+        updateProgress(loaded, total || loaded, 'Downloading…');
+      }
+      // Concatenate chunks
+      const buf = new Uint8Array(loaded);
+      let offset = 0;
+      for (const chunk of chunks) { buf.set(chunk, offset); offset += chunk.byteLength; }
+
+      // 3. Store in Cache API for next visit (best-effort).
+      if ('caches' in window) {
+        try {
+          const cache = await caches.open(MODEL_CACHE);
+          await cache.put(url, new Response(buf, {
+            headers: { 'Content-Type': 'application/octet-stream', 'Content-Length': String(loaded) }
+          }));
+        } catch (_) { /* Quota exceeded or private browsing — ignore */ }
+      }
+
+      return { bytes: buf, fromCache: false };
+    }
+
     $urlLoad.addEventListener('click', async () => {
       const url = $urlInput.value.trim();
       if (!url) return;
@@ -404,8 +453,10 @@
       try {
         const t0 = performance.now();
         clearChat();
-        const eng = await new FlareProgressiveLoader(url)
-          .load((l, t) => updateProgress(l, t, 'Downloading…'));
+        const { bytes, fromCache } = await loadModelFromUrl(url);
+        updateProgress(bytes.length, bytes.length, fromCache ? 'Parsing (cached)…' : 'Parsing…');
+        await new Promise(r => setTimeout(r, 10)); // yield so progress renders
+        const eng = FlareEngine.load(bytes);
         await onModelLoaded(eng, performance.now() - t0);
       } catch (err) {
         $modelInfo.textContent = 'Error: ' + err;


### PR DESCRIPTION
## Summary

Three production blockers fixed in one PR.

### 1. Server no longer blocks on concurrent requests
`std::sync::Mutex` was blocking the entire Tokio thread pool during inference (each forward pass holds the lock for the full generation duration). Any second request would stall the event loop.

- Switched to `tokio::sync::Mutex` — waiting requests yield the thread
- Added 30-second `INFERENCE_TIMEOUT` on lock acquisition
- Returns **HTTP 503** with `Retry-After: 5` when the model is busy, instead of hanging indefinitely
- `stream_response` / `non_stream_response` are now `async fn`

### 2. GGUF tokenizer now encodes correctly
`encode_prompt` for `TokenizerState::Gguf` was doing a byte-by-byte fallback — encoding every character as a raw byte token, producing garbage input to the model. This broke all inference with GGUF-embedded vocabularies (Llama, Phi-3, Gemma-2).

- Implemented `GgufVocab::encode()` using the BPE-merge algorithm over embedded vocab scores — same approach as llama.cpp's SentencePiece tokenizer
- Normalizes spaces → ▁ marker, seeds symbols per unicode char with `<0xXX>` byte fallback, then greedily merges by score
- Server `encode_prompt` now calls `vocab.encode(text)` instead of the byte fallback
- 3 new unit tests: BPE merge correctness, empty string, byte fallback

### 3. Browser caches downloaded models
URL-loaded models were re-downloaded on every page visit, even for large (500 MB+) files.

- `loadModelFromUrl()` checks the **Cache API** (`flare-models-v1`) before fetching
- On cache hit: loads instantly, shows "Loading from cache…"
- On cache miss: streams the response body with byte-accurate progress, then writes bytes to cache for next visit
- Falls back silently when Cache API is unavailable (private browsing, storage quota exceeded)

## Test plan
- [ ] `cargo test --workspace` passes (3 new tokenizer tests)
- [ ] `cargo check --workspace --all-targets` clean
- [ ] Server: two concurrent requests → second gets 503 with Retry-After instead of hanging
- [ ] Server: inference with GGUF-only model produces coherent text (not garbage)
- [ ] Browser: second URL load is instant and shows "Loading from cache…"
