### PR TITLE
Add count_tokens and max_seq_len to FlareEngine WASM API (#111)

### DIFF
--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -144,7 +144,10 @@
     <div class="chat-thread" id="chat"></div>
 
     <div>
-      <div class="field-label">Your message</div>
+      <div class="field-label" style="display:flex;justify-content:space-between;align-items:baseline;">
+        <span>Your message</span>
+        <span id="token-counter" style="font-size:0.8rem;color:#888;"></span>
+      </div>
       <textarea id="prompt-input" placeholder="Ask me anything…" disabled rows="2"></textarea>
     </div>
 
@@ -188,13 +191,14 @@
     const $tmplBadge   = $('template-badge');
     const $systemRow   = $('system-prompt-row');
     const $systemIn    = $('system-input');
-    const $promptIn    = $('prompt-input');
-    const $generate    = $('generate');
-    const $stop        = $('stop');
-    const $clear       = $('clear');
-    const $maxTokens   = $('max-tokens');
-    const $chat        = $('chat');
-    const $genStats    = $('gen-stats');
+    const $promptIn      = $('prompt-input');
+    const $tokenCounter  = $('token-counter');
+    const $generate      = $('generate');
+    const $stop          = $('stop');
+    const $clear         = $('clear');
+    const $maxTokens     = $('max-tokens');
+    const $chat          = $('chat');
+    const $genStats      = $('gen-stats');
 
     let engine    = null;
     let tokenizer = null;
@@ -514,6 +518,7 @@
       $generate.disabled = true;
       $stop.disabled = false;
       $promptIn.value = '';
+      $tokenCounter.textContent = '';
       $genStats.textContent = 'Generating…';
       await new Promise(r => setTimeout(r, 10));
 
@@ -618,6 +623,18 @@
         $generate.disabled = false;
         $stop.disabled = true;
       }
+    });
+
+    // Live token counter — updates as the user types
+    $promptIn.addEventListener('input', () => {
+      if (!engine || !$promptIn.value) {
+        $tokenCounter.textContent = '';
+        return;
+      }
+      const count = engine.count_tokens($promptIn.value);
+      const max   = engine.max_seq_len;
+      $tokenCounter.textContent = `${count} / ${max} tokens`;
+      $tokenCounter.style.color = count > max * 0.85 ? '#c00' : '#888';
     });
 
     // Allow Ctrl+Enter / Cmd+Enter to send

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -31,6 +31,7 @@ use flare_core::sampling::{self, SamplingParams};
 use flare_core::tokenizer::{BpeTokenizer, Tokenizer};
 use flare_gpu::WebGpuBackend;
 use flare_loader::gguf::GgufFile;
+use flare_loader::tokenizer::GgufVocab;
 use flare_loader::weights::{load_model_weights, load_model_weights_with_progress};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -96,6 +97,8 @@ fn detect_chat_template(gguf: &GgufFile) -> ChatTemplate {
 pub struct FlareEngine {
     model: Model,
     chat_template: ChatTemplate,
+    /// GGUF vocabulary for token counting (optional: absent for non-GGUF models).
+    gguf_vocab: Option<GgufVocab>,
     /// EOS token ID from GGUF metadata; generation stops when this token is produced.
     eos_token_id: Option<u32>,
     // --- Token-by-token streaming state ---
@@ -122,6 +125,7 @@ impl FlareEngine {
             .metadata
             .get("tokenizer.ggml.eos_token_id")
             .and_then(|v| v.as_u32());
+        let gguf_vocab = GgufVocab::from_gguf(&gguf).ok();
         let config = gguf
             .to_model_config()
             .map_err(|e| JsError::new(&format!("Model config error: {e}")))?;
@@ -131,6 +135,7 @@ impl FlareEngine {
         Ok(FlareEngine {
             model: Model::new(config, weights),
             chat_template,
+            gguf_vocab,
             eos_token_id,
             stream_last_token: 0,
             stream_pos: 0,
@@ -241,6 +246,31 @@ impl FlareEngine {
     #[wasm_bindgen(getter)]
     pub fn eos_token_id(&self) -> Option<u32> {
         self.eos_token_id
+    }
+
+    /// Maximum sequence length (context window size) of the loaded model.
+    ///
+    /// Use this to warn users when their prompt is approaching the limit.
+    #[wasm_bindgen(getter)]
+    pub fn max_seq_len(&self) -> u32 {
+        self.model.config().max_seq_len as u32
+    }
+
+    /// Count the number of tokens in `text` using the model's embedded GGUF vocabulary.
+    ///
+    /// Returns 0 if the model was not loaded from a GGUF file (e.g. SafeTensors only).
+    ///
+    /// # JS example
+    /// ```javascript
+    /// const n = engine.count_tokens(textarea.value);
+    /// counter.textContent = `${n} / ${engine.max_seq_len} tokens`;
+    /// ```
+    #[wasm_bindgen]
+    pub fn count_tokens(&self, text: &str) -> u32 {
+        match &self.gguf_vocab {
+            Some(vocab) => vocab.encode(text).len() as u32,
+            None => 0,
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -506,6 +536,7 @@ impl FlareProgressiveLoader {
             .metadata
             .get("tokenizer.ggml.eos_token_id")
             .and_then(|v| v.as_u32());
+        let gguf_vocab = GgufVocab::from_gguf(&gguf).ok();
         let config = gguf
             .to_model_config()
             .map_err(|e| JsError::new(&format!("model config error: {e}")))?;
@@ -521,6 +552,7 @@ impl FlareProgressiveLoader {
         Ok(FlareEngine {
             model: Model::new(config, weights),
             chat_template,
+            gguf_vocab,
             eos_token_id,
             stream_last_token: 0,
             stream_pos: 0,


### PR DESCRIPTION
Add count_tokens and max_seq_len to FlareEngine WASM API

- Store GgufVocab in FlareEngine (loaded from GGUF metadata)
- count_tokens(text): counts BPE tokens using the embedded vocab
- max_seq_len getter: exposes ModelConfig.max_seq_len to JS
- Browser demo: live token counter in the message field label,
  turns red at 85% of the context limit and clears on send

Closes #111

## Changes

### Rust (flare-web/src/lib.rs)
- Added `gguf_vocab: Option<GgufVocab>` field to `FlareEngine`
- Populated in both `FlareEngine::load()` and `FlareProgressiveLoader::load()`
- `count_tokens(text: &str) -> u32`: encodes text via `GgufVocab::encode()`, returns token count (0 if no GGUF vocab)
- `max_seq_len` getter: returns `model.config().max_seq_len as u32`

### Browser demo (flare-web/demo/index.html)
- Token counter displayed inline with the message label: `N / M tokens`
- Turns red when prompt is within 15% of the context limit
- Counter clears when the message is sent