### PR TITLE
Add encode_text, decode_ids, generate_text to FlareEngine WASM API (#114)

### DIFF
--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -155,6 +155,7 @@
       <button id="generate" disabled>Send</button>
       <button id="stop" disabled>Stop</button>
       <button id="clear" disabled>Clear conversation</button>
+      <button id="quick-test" disabled title="Run a quick test using the embedded GGUF tokenizer (no tokenizer.json needed)">Quick test</button>
       <label style="font-size:0.85rem;">
         Max tokens:&nbsp;<input type="number" id="max-tokens" value="128"
           min="1" max="512" style="width:5rem;margin-bottom:0;">
@@ -196,6 +197,7 @@
     const $generate      = $('generate');
     const $stop          = $('stop');
     const $clear         = $('clear');
+    const $quickTest     = $('quick-test');
     const $maxTokens     = $('max-tokens');
     const $chat          = $('chat');
     const $genStats      = $('gen-stats');
@@ -339,6 +341,7 @@
       $promptIn.disabled = false;
       $systemIn.disabled = false;
       $clear.disabled = false;
+      $quickTest.disabled = false;
       $tmplBadge.textContent = tmplName;
       $tmplBadge.style.display = '';
       hideProgress();
@@ -499,6 +502,28 @@
     // ---------- Clear conversation ----------
     $clear.addEventListener('click', () => {
       clearChat();
+    });
+
+    // ---------- Quick test (generate_text — no tokenizer.json needed) ----------
+    $quickTest.addEventListener('click', () => {
+      if (!engine || streaming) return;
+      const prompt = $promptIn.value.trim() || 'Hello';
+      $genStats.textContent = 'Running quick test…';
+      const t0 = performance.now();
+      engine.reset();
+      const result = engine.generate_text(prompt, parseInt($maxTokens.value, 10) || 64);
+      const ms = performance.now() - t0;
+      if (result) {
+        appendBubble('user', prompt);
+        appendBubble('assistant', result);
+        history.push({ role: 'user', content: prompt });
+        history.push({ role: 'assistant', content: result });
+        $promptIn.value = '';
+        $tokenCounter.textContent = '';
+        $genStats.textContent = `Quick test done in ${ms.toFixed(0)} ms (embedded GGUF tokenizer)`;
+      } else {
+        $genStats.textContent = 'Quick test unavailable: no embedded GGUF tokenizer in this model.';
+      }
     });
 
     // ---------- Stop ----------

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -273,6 +273,78 @@ impl FlareEngine {
         }
     }
 
+    /// Encode `text` to token IDs using the embedded GGUF vocabulary.
+    ///
+    /// Returns an empty array if no GGUF vocab is available.
+    ///
+    /// # JS example
+    /// ```javascript
+    /// const ids = engine.encode_text("Hello, world!");
+    /// const output = engine.generate_tokens(ids, 64);
+    /// ```
+    #[wasm_bindgen]
+    pub fn encode_text(&self, text: &str) -> Vec<u32> {
+        match &self.gguf_vocab {
+            Some(vocab) => vocab.encode(text),
+            None => Vec::new(),
+        }
+    }
+
+    /// Decode token IDs to text using the embedded GGUF vocabulary.
+    ///
+    /// Returns an empty string if no GGUF vocab is available.
+    ///
+    /// # JS example
+    /// ```javascript
+    /// const text = engine.decode_ids(generatedIds);
+    /// ```
+    #[wasm_bindgen]
+    pub fn decode_ids(&self, ids: &[u32]) -> String {
+        match &self.gguf_vocab {
+            Some(vocab) => vocab.decode(ids),
+            None => String::new(),
+        }
+    }
+
+    /// Full text-in / text-out generation using the embedded GGUF vocabulary.
+    ///
+    /// Encodes `prompt` with the embedded vocab, runs greedy generation for up
+    /// to `max_tokens` steps, then decodes the output back to text. Stops
+    /// automatically at EOS.
+    ///
+    /// Returns an empty string if no GGUF vocab is available.
+    ///
+    /// # JS example
+    /// ```javascript
+    /// engine.reset();
+    /// const response = engine.generate_text("What is Rust?", 128);
+    /// output.textContent = response;
+    /// ```
+    #[wasm_bindgen]
+    pub fn generate_text(&mut self, prompt: &str, max_tokens: u32) -> String {
+        let prompt_tokens = match &self.gguf_vocab {
+            Some(vocab) => vocab.encode(prompt),
+            None => return String::new(),
+        };
+        let params = SamplingParams {
+            temperature: 0.0,
+            ..Default::default()
+        };
+        let eos = self.eos_token_id;
+        let mut gen = Generator::new(&mut self.model, params);
+        let generated = gen.generate(
+            &prompt_tokens,
+            max_tokens as usize,
+            eos,
+            || 0.5,
+            |_, _| true,
+        );
+        match &self.gguf_vocab {
+            Some(vocab) => vocab.decode(&generated),
+            None => String::new(),
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Token-by-token streaming API
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Add encode_text, decode_ids, and generate_text to FlareEngine WASM API

- encode_text(text): tokenize using embedded GGUF vocab (no tokenizer.json needed)
- decode_ids(ids): decode token IDs to text using embedded GGUF vocab
- generate_text(prompt, max_tokens): full text-in/text-out pipeline in one call
- Browser demo: "Quick test" button runs generate_text without requiring tokenizer.json

Closes #114

## Changes

### flare-web/src/lib.rs
- `encode_text(text: &str) -> Vec<u32>` — tokenizes using embedded GGUF vocab
- `decode_ids(ids: &[u32]) -> String` — decodes token IDs using embedded GGUF vocab
- `generate_text(prompt: &str, max_tokens: u32) -> String` — end-to-end pipeline: encode → generate (greedy) → decode

### flare-web/demo/index.html
- **Quick test** button runs `engine.generate_text()` — no tokenizer.json required
- Result appended to chat thread with timing stats
- Counter clears on send