### PR TITLE
Add Dockerfile and docker-compose for flare-server (#116)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --workspace --no-deps --all-features
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image (no push)
+        run: docker build --tag flare-server:ci .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# Multi-stage build for flare-server
+#
+# Stage 1 — Build
+#   Compiles the native server binary with cargo.
+# Stage 2 — Runtime
+#   Minimal Debian image with only the binary and its shared-library deps.
+#
+# Usage:
+#   docker build -t flare-server .
+#   docker run -p 8080:8080 flare-server
+#   docker run -p 8080:8080 -v ./models:/models -e MODEL_FILE=/models/model.gguf flare-server
+
+# ---------------------------------------------------------------------------
+# Stage 1: builder
+# ---------------------------------------------------------------------------
+FROM rust:1.82-slim AS builder
+
+WORKDIR /build
+
+# Install build-time C deps (linker, etc.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy workspace files
+COPY Cargo.toml Cargo.lock ./
+COPY flare-core       flare-core/
+COPY flare-loader     flare-loader/
+COPY flare-gpu        flare-gpu/
+COPY flare-simd       flare-simd/
+COPY flare-server     flare-server/
+# flare-web is WASM-only; skip it to avoid needing wasm-pack in the builder
+COPY flare-web/Cargo.toml flare-web/Cargo.toml
+RUN mkdir -p flare-web/src && echo 'fn main() {}' > flare-web/src/lib.rs
+
+RUN cargo build --release -p flarellm-server
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/flare-server /usr/local/bin/flare-server
+
+# Optional: volume mount point for model files
+VOLUME ["/models"]
+
+ENV HOST=0.0.0.0
+ENV PORT=8080
+# Set MODEL_FILE to the path inside /models to load a model on startup, e.g.:
+#   -e MODEL_FILE=/models/phi-3-mini.gguf
+ENV MODEL_FILE=""
+
+EXPOSE 8080
+
+ENTRYPOINT ["/bin/sh", "-c", \
+  "if [ -n \"$MODEL_FILE\" ]; then \
+     exec flare-server --model \"$MODEL_FILE\" --host \"$HOST\" --port \"$PORT\"; \
+   else \
+     exec flare-server --host \"$HOST\" --port \"$PORT\"; \
+   fi"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  flare-server:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./models:/models:ro
+    environment:
+      - MODEL_FILE=${MODEL_FILE:-}
+      - MODEL_NAME=${MODEL_NAME:-flare-local}
+      - HOST=0.0.0.0
+      - PORT=8080
+    restart: unless-stopped


### PR DESCRIPTION
Add Dockerfile and docker-compose for flare-server deployment

- Multi-stage Dockerfile: rust:1.82-slim builder + debian:bookworm-slim runtime
- MODEL_FILE env var mounts a GGUF model from the /models volume
- docker-compose.yml with ./models bind-mount and MODEL_FILE/MODEL_NAME env vars
- CI: docker build check added to ci.yml (build only, no push)

Closes #116

## Usage

### Without a model (health/info endpoints only)
```bash
docker compose up
# Server at http://localhost:8080
```

### With a GGUF model
```bash
MODEL_FILE=/models/phi-3-mini.gguf docker compose up
# Or: docker run -p 8080:8080 -v ./models:/models -e MODEL_FILE=/models/phi-3-mini.gguf flare-server
```

### Build and check image size
```bash
docker build -t flare-server .
docker images flare-server
```

## Changes
- `Dockerfile`: multi-stage, rust:1.82-slim builder → debian:bookworm-slim runtime
- `docker-compose.yml`: binds `./models` and passes `MODEL_FILE`/`MODEL_NAME`
- `.github/workflows/ci.yml`: added `docker build` check step