### PR TITLE
Add generate_stream WASM API and update Quick Test to stream

### DIFF
--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -504,26 +504,74 @@
       clearChat();
     });
 
-    // ---------- Quick test (generate_text — no tokenizer.json needed) ----------
+    // ---------- Quick test (streaming via embedded GGUF tokenizer, no tokenizer.json needed) ----------
     $quickTest.addEventListener('click', () => {
       if (!engine || streaming) return;
       const prompt = $promptIn.value.trim() || 'Hello';
-      $genStats.textContent = 'Running quick test…';
-      const t0 = performance.now();
-      engine.reset();
-      const result = engine.generate_text(prompt, parseInt($maxTokens.value, 10) || 64);
-      const ms = performance.now() - t0;
-      if (result) {
-        appendBubble('user', prompt);
-        appendBubble('assistant', result);
-        history.push({ role: 'user', content: prompt });
-        history.push({ role: 'assistant', content: result });
-        $promptIn.value = '';
-        $tokenCounter.textContent = '';
-        $genStats.textContent = `Quick test done in ${ms.toFixed(0)} ms (embedded GGUF tokenizer)`;
-      } else {
+      const maxToks = parseInt($maxTokens.value, 10) || 64;
+
+      // Check embedded vocab is available by encoding 1 token
+      const testEncode = engine.encode_text(prompt);
+      if (!testEncode || testEncode.length === 0) {
         $genStats.textContent = 'Quick test unavailable: no embedded GGUF tokenizer in this model.';
+        return;
       }
+
+      streaming = true;
+      $generate.disabled = true;
+      $stop.disabled = false;
+      $promptIn.value = '';
+      $tokenCounter.textContent = '';
+      $genStats.textContent = 'Generating…';
+
+      appendBubble('user', prompt);
+      history.push({ role: 'user', content: prompt });
+
+      engine.reset();
+      engine.begin_stream(testEncode, maxToks);
+
+      const t0 = performance.now();
+      let count = 0;
+      let assistantText = '';
+      const bubble = appendBubble('assistant', '', true);
+
+      function quickTick() {
+        if (!streaming) {
+          finishQuick();
+          return;
+        }
+        const id = engine.next_token();
+        if (id === undefined) {
+          streaming = false;
+          finishQuick();
+          return;
+        }
+        count++;
+        assistantText += engine.decode_ids(new Uint32Array([id]));
+        bubble.textContent = assistantText;
+        $chat.scrollTop = $chat.scrollHeight;
+
+        if (count % 8 === 0) {
+          const ms = performance.now() - t0;
+          $genStats.textContent = `${count} tokens · ${(count / (ms / 1000)).toFixed(1)} tok/s`;
+        }
+        requestAnimationFrame(quickTick);
+      }
+
+      function finishQuick() {
+        bubble.classList.remove('streaming');
+        if (assistantText) {
+          history.push({ role: 'assistant', content: assistantText });
+        }
+        const ms = performance.now() - t0;
+        $genStats.textContent =
+          `${count} tokens in ${ms.toFixed(0)} ms = ${(count / (ms / 1000)).toFixed(1)} tok/s ` +
+          `(embedded GGUF tokenizer)`;
+        $generate.disabled = false;
+        $stop.disabled = true;
+      }
+
+      requestAnimationFrame(quickTick);
     });
 
     // ---------- Stop ----------

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -345,6 +345,69 @@ impl FlareEngine {
         }
     }
 
+    /// Streaming text-in / text-out generation with a per-token JS callback.
+    ///
+    /// Encodes `prompt` with the embedded GGUF vocabulary, generates up to
+    /// `max_tokens` tokens, and calls `on_token(token_str)` with the decoded
+    /// text for each token as it is produced.  Returns the number of tokens
+    /// generated (excluding any EOS token).
+    ///
+    /// Returns 0 if no GGUF vocab is available.
+    ///
+    /// # Note on browser streaming
+    /// `on_token` is called synchronously inside WASM, so the browser will
+    /// not visually update between tokens.  For visible character-by-character
+    /// output, use `begin_stream` + `next_token` with `requestAnimationFrame`.
+    ///
+    /// # JS example
+    /// ```javascript
+    /// engine.reset();
+    /// let out = '';
+    /// const count = engine.generate_stream("What is Rust?", 128, (token) => {
+    ///   out += token;
+    /// });
+    /// output.textContent = out;
+    /// ```
+    #[wasm_bindgen]
+    pub fn generate_stream(
+        &mut self,
+        prompt: &str,
+        max_tokens: u32,
+        on_token: &js_sys::Function,
+    ) -> u32 {
+        // Encode and generate first, then decode per-token for callbacks.
+        let prompt_tokens = match &self.gguf_vocab {
+            Some(vocab) => vocab.encode(prompt),
+            None => return 0,
+        };
+        let params = SamplingParams {
+            temperature: 0.0,
+            ..Default::default()
+        };
+        let eos = self.eos_token_id;
+        // Generate all tokens — vocab and model are different fields so this
+        // is safe to split-borrow after the encode above.
+        let generated = {
+            let mut gen = Generator::new(&mut self.model, params);
+            gen.generate(
+                &prompt_tokens,
+                max_tokens as usize,
+                eos,
+                || 0.5,
+                |_, _| true,
+            )
+        };
+        let mut count = 0u32;
+        if let Some(vocab) = &self.gguf_vocab {
+            for id in &generated {
+                let token_str = vocab.decode(&[*id]);
+                let _ = on_token.call1(&JsValue::NULL, &JsValue::from_str(&token_str));
+                count += 1;
+            }
+        }
+        count
+    }
+
     // -----------------------------------------------------------------------
     // Token-by-token streaming API
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds FlareEngine::generate_stream(prompt, max_tokens, on_token) - encodes prompt, generates tokens, calls JS callback with each decoded token string.
- Updates browser demo Quick Test button to use begin_stream/next_token with requestAnimationFrame for live streaming UX.

Closes #121

## Test plan
- [x] cargo check -p flarellm-web passes
- [x] cargo clippy -p flarellm-web passes
- [x] CI green