### PR TITLE
Add GPU dequantization shaders for Q4_1 and Q4_K formats

### DIFF
--- a/flare-gpu/shaders/dequant_q4_1.wgsl
+++ b/flare-gpu/shaders/dequant_q4_1.wgsl
@@ -1,0 +1,51 @@
+// Dequantize Q4_1 blocks on GPU.
+//
+// Layout (20 bytes / 5 u32 per block, 32 weights per block):
+//   bytes 0-1  : d  (f16 LE scale)
+//   bytes 2-3  : m  (f16 LE additive bias)
+//   bytes 4-19 : qs[16] (4-bit nibbles, low nibble = even weight, high = odd)
+//
+// Reconstruction: output[i] = d * q + m, q in [0, 15].
+//
+// Each thread handles one block.
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_blocks: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(64)
+fn dequant_q4_1(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+    let block_idx = gid.x;
+    if block_idx >= params.num_blocks {
+        return;
+    }
+
+    // 20 bytes per block = 5 u32
+    let u = block_idx * 5u;
+
+    // d and m are f16 LE packed as two f16 in a u32
+    let dm = unpack2x16float(raw[u]);
+    let d = dm.x;
+    let m = dm.y;
+
+    let out_base = block_idx * 32u;
+
+    // qs[16] are in raw[u+1 .. u+5], 4 bytes (8 nibble-pairs) per u32
+    for (var qi = 0u; qi < 4u; qi = qi + 1u) {
+        let q_u32 = raw[u + 1u + qi];
+        for (var bi = 0u; bi < 4u; bi = bi + 1u) {
+            let byte_val = (q_u32 >> (bi * 8u)) & 0xFFu;
+            let lo = byte_val & 0x0Fu;
+            let hi = (byte_val >> 4u) & 0x0Fu;
+            let pos = qi * 8u + bi * 2u;
+            output[out_base + pos] = d * f32(lo) + m;
+            output[out_base + pos + 1u] = d * f32(hi) + m;
+        }
+    }
+}

--- a/flare-gpu/shaders/dequant_q4k.wgsl
+++ b/flare-gpu/shaders/dequant_q4k.wgsl
@@ -1,0 +1,75 @@
+// Dequantize Q4_K blocks on GPU.
+//
+// Layout (144 bytes / 36 u32 per block, 256 weights per block):
+//   bytes  0-1  : d    (f16 LE overall delta)
+//   bytes  2-3  : dmin (f16 LE overall min delta)
+//   bytes  4-15 : scales[12] — 8 sub-block (scale, min) pairs encoded in 12 bytes
+//   bytes 16-143: qs[128]    — 4-bit nibbles; low nibbles → weights 0..127,
+//                              high nibbles → weights 128..255
+//
+// Scale decoding (matches llama.cpp Q4_K):
+//   For i in 0..4:
+//     sc[i]     = scales_raw[i]     & 0x3F
+//     mn[i]     = scales_raw[i+4]   & 0x3F
+//     sc[i+4]   = (scales_raw[i] >> 6) | ((scales_raw[i+8] & 0x0F) << 2)
+//     mn[i+4]   = (scales_raw[i+4] >> 6) | ((scales_raw[i+8] >>  4) << 2)
+//
+// Reconstruction: output[j]     = d * sc[j/32]   * low_nibble  - dmin * mn[j/32]
+//                 output[j+128] = d * sc[j/32+4] * high_nibble - dmin * mn[j/32+4]
+//
+// Each thread handles one block.
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_blocks: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(64)
+fn dequant_q4k(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+    let block_idx = gid.x;
+    if block_idx >= params.num_blocks {
+        return;
+    }
+
+    // 144 bytes per block = 36 u32
+    let u = block_idx * 36u;
+
+    // d and dmin as two f16 packed in the first u32
+    let dm = unpack2x16float(raw[u]);
+    let d = dm.x;
+    let dmin = dm.y;
+
+    // Decode 8 scale/min pairs from scales_raw[0..12] = raw[u+1 .. u+4]
+    // scales_raw[0..4]  packed in raw[u+1]
+    // scales_raw[4..8]  packed in raw[u+2]
+    // scales_raw[8..12] packed in raw[u+3]
+    var sc: array<u32, 8>;
+    var mn: array<u32, 8>;
+    for (var i = 0u; i < 4u; i = i + 1u) {
+        let sr_i  = (raw[u + 1u] >> (i * 8u)) & 0xFFu;
+        let sr_i4 = (raw[u + 2u] >> (i * 8u)) & 0xFFu;
+        let sr_i8 = (raw[u + 3u] >> (i * 8u)) & 0xFFu;
+        sc[i]      = sr_i & 0x3Fu;
+        mn[i]      = sr_i4 & 0x3Fu;
+        sc[i + 4u] = (sr_i >> 6u) | ((sr_i8 & 0x0Fu) << 2u);
+        mn[i + 4u] = (sr_i4 >> 6u) | ((sr_i8 >> 4u) << 2u);
+    }
+
+    // qs[128] at bytes 16-143 = raw[u+4 .. u+36]  (32 u32 = 128 bytes)
+    let out_base = block_idx * 256u;
+    for (var j = 0u; j < 128u; j = j + 1u) {
+        let q_u32    = raw[u + 4u + j / 4u];
+        let byte_val = (q_u32 >> ((j % 4u) * 8u)) & 0xFFu;
+        let lo_nibble = byte_val & 0x0Fu;
+        let hi_nibble = (byte_val >> 4u) & 0x0Fu;
+
+        let sub = j / 32u;
+        output[out_base + j]       = d * f32(sc[sub])      * f32(lo_nibble) - dmin * f32(mn[sub]);
+        output[out_base + j + 128u] = d * f32(sc[sub + 4u]) * f32(hi_nibble) - dmin * f32(mn[sub + 4u]);
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -21,6 +21,8 @@ const MATMUL_SHADER: &str = include_str!("../shaders/matmul.wgsl");
 const SILU_MUL_SHADER: &str = include_str!("../shaders/silu_mul.wgsl");
 const SOFTMAX_SHADER: &str = include_str!("../shaders/softmax.wgsl");
 const ATTENTION_SHADER: &str = include_str!("../shaders/attention.wgsl");
+const DEQUANT_Q4_1_SHADER: &str = include_str!("../shaders/dequant_q4_1.wgsl");
+const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
 
 /// WebGPU/wgpu compute backend.
 ///
@@ -230,6 +232,92 @@ impl WebGpuBackend {
                 },
             ],
         })
+    }
+
+    /// Dequantize Q4_1 blocks on GPU.
+    ///
+    /// `raw_bytes` is the packed GGUF tensor data (num_blocks × 20 bytes).
+    /// Returns a flat `Vec<f32>` of num_blocks × 32 dequantized weights.
+    pub fn dequant_q4_1(&self, raw_bytes: &[u8], num_blocks: usize) -> Vec<f32> {
+        let output_size = (num_blocks * 32) as u64 * 4;
+
+        let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 1] = [num_blocks as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::single_input_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_q4_1",
+            DEQUANT_Q4_1_SHADER,
+            "dequant_q4_1",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_single_input_bind_group(cached, &raw_buf, &out_buf, &params_buf);
+                let dispatch_x = (num_blocks as u32).div_ceil(64);
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [dispatch_x, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Dequantize Q4_K blocks on GPU.
+    ///
+    /// `raw_bytes` is the packed GGUF tensor data (num_blocks × 144 bytes).
+    /// Returns a flat `Vec<f32>` of num_blocks × 256 dequantized weights.
+    pub fn dequant_q4k(&self, raw_bytes: &[u8], num_blocks: usize) -> Vec<f32> {
+        let output_size = (num_blocks * 256) as u64 * 4;
+
+        let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 1] = [num_blocks as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::single_input_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_q4k",
+            DEQUANT_Q4K_SHADER,
+            "dequant_q4k",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_single_input_bind_group(cached, &raw_buf, &out_buf, &params_buf);
+                let dispatch_x = (num_blocks as u32).div_ceil(64);
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [dispatch_x, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
     }
 
     /// Build a 4-entry bind group from the standard layout.
@@ -790,5 +878,93 @@ mod tests {
             (sum - 1.0).abs() < 1e-5,
             "softmax output sum should be 1.0, got {sum}"
         );
+    }
+
+    /// Verify GPU Q4_1 dequantization against a known reference.
+    ///
+    /// One block: d=1.0 (f16 0x3C00), m=0.0 (f16 0x0000), all qs bytes = 0x12
+    /// → 16 pairs of (lo=2, hi=1) → output = [2, 1, 2, 1, …] (32 floats).
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_q4_1_matches_cpu() {
+        let mut raw = vec![0u8; 20];
+        // d = 1.0 as f16 LE: 0x3C00 → bytes [0x00, 0x3C]
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // m = 0.0 as f16 LE: 0x0000 → bytes [0x00, 0x00] (already zero)
+        // qs[16]: lo nibble = 2, hi nibble = 1 → byte = 0x12
+        for b in raw[4..20].iter_mut() {
+            *b = 0x12;
+        }
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_q4_1(&raw, 1);
+
+        assert_eq!(result.len(), 32, "expected 32 weights");
+        for i in 0..16 {
+            assert!(
+                (result[i * 2] - 2.0).abs() < 1e-3,
+                "q4_1 lo mismatch at [{}]: got {}, expected 2.0",
+                i * 2,
+                result[i * 2]
+            );
+            assert!(
+                (result[i * 2 + 1] - 1.0).abs() < 1e-3,
+                "q4_1 hi mismatch at [{}]: got {}, expected 1.0",
+                i * 2 + 1,
+                result[i * 2 + 1]
+            );
+        }
+    }
+
+    /// Verify GPU Q4_K dequantization against a known reference.
+    ///
+    /// One block: d=1.0, dmin=0.0, all sc[*]=1, mn[*]=0, all qs bytes = 0x12
+    /// → output[0..128]=2.0, output[128..256]=1.0.
+    ///
+    /// Scale encoding: scales_raw[0..4] = 0x41 sets sc[0..4]=1 and sc[4..8]=1
+    /// (upper 2 bits of 0x41 are 01, so (0x41>>6)=1; scales_raw[8..12]=0 so
+    /// (0 & 0x0F)<<2=0; sc[i+4] = 1|0 = 1). mn[*]=0 since scales_raw[4..8]=0.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_q4k_matches_cpu() {
+        let mut raw = vec![0u8; 144];
+        // d = 1.0 as f16 LE
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // dmin = 0.0 (already zero)
+        // scales_raw[0..4] = 0x41: sc[i]=1, bits[7:6]=01 → sc[i+4]=1
+        for b in raw[4..8].iter_mut() {
+            *b = 0x41;
+        }
+        // scales_raw[4..8] = 0x00: mn[*]=0 (already zero)
+        // scales_raw[8..12] = 0x00 (already zero): lower nibble=0 → sc[i+4] unchanged
+        // qs[128]: lo=2, hi=1 → byte = 0x12
+        for b in raw[16..144].iter_mut() {
+            *b = 0x12;
+        }
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_q4k(&raw, 1);
+
+        assert_eq!(result.len(), 256, "expected 256 weights");
+        for j in 0..128 {
+            assert!(
+                (result[j] - 2.0).abs() < 1e-3,
+                "q4k lo mismatch at [{}]: got {}, expected 2.0",
+                j,
+                result[j]
+            );
+            assert!(
+                (result[j + 128] - 1.0).abs() < 1e-3,
+                "q4k hi mismatch at [{}]: got {}, expected 1.0",
+                j + 128,
+                result[j + 128]
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `flare-gpu/shaders/dequant_q4_1.wgsl` — WGSL compute shader for Q4_1 blocks (20 B/block, 32 weights, reconstruction `w = d*q + m`)
- Adds `flare-gpu/shaders/dequant_q4k.wgsl` — WGSL compute shader for Q4_K blocks (144 B/block, 256 weights, 8 sub-block scale/min pairs)
- Adds `WebGpuBackend::dequant_q4_1(raw_bytes, num_blocks) -> Vec<f32>` and `dequant_q4k(raw_bytes, num_blocks) -> Vec<f32>` reusing the existing `single_input_layout` / `make_single_input_bind_group` path
- Both shaders use `@workgroup_size(64)`, one thread per block, and `unpack2x16float` for the packed f16 delta/min in each block header
- Adds `#[ignore]` GPU tests verifying each method against a hand-crafted single block with known output

## Test plan

- [ ] `cargo check --workspace` passes (verified locally)
- [ ] `cargo clippy -p flarellm-gpu -- -D warnings` passes (verified locally)
- [ ] `cargo fmt --all -- --check` passes (verified locally)
- [ ] CI passes
- [ ] `cargo test -p flarellm-gpu -- --ignored` (requires GPU adapter, run manually)

Closes #129