### PR TITLE
Move KV cache to GPU-resident buffers to eliminate CPU round-trips

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -110,9 +110,9 @@ pub trait ComputeBackend: Send + Sync {
     /// Grouped-query attention using GPU-resident KV cache buffers.
     ///
     /// Avoids re-uploading the KV cache from CPU on each forward pass —
-    /// the data written by [`gpu_kv_write`] is used directly.
+    /// the data written by `gpu_kv_write` is used directly.
     ///
-    /// Only valid after [`init_gpu_kv_cache`] has been called
+    /// Only valid after `init_gpu_kv_cache` has been called
     /// (`has_gpu_kv_cache()` returns `true`).
     #[allow(clippy::too_many_arguments)]
     fn grouped_query_attention_from_gpu_cache(

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -72,6 +72,61 @@ pub trait ComputeBackend: Send + Sync {
             attn_softcap,
         )
     }
+
+    /// Initialize GPU-resident KV cache storage for backends that support it.
+    ///
+    /// Call this once after [`Model::set_backend`] to allocate GPU-side
+    /// ring-buffer storage for all layers.  Backends that do not support GPU
+    /// KV cache (e.g. `CpuBackend`) provide a no-op default.
+    fn init_gpu_kv_cache(
+        &self,
+        _num_layers: usize,
+        _max_seq_len: usize,
+        _num_kv_heads: usize,
+        _head_dim: usize,
+    ) {
+    }
+
+    /// Write a new K/V pair into the GPU-resident cache (no CPU readback).
+    ///
+    /// For backends without GPU KV cache this is a no-op.
+    #[allow(clippy::too_many_arguments)]
+    fn gpu_kv_write(
+        &self,
+        _layer: usize,
+        _position: usize,
+        _num_kv_heads: usize,
+        _head_dim: usize,
+        _key: &[f32],
+        _value: &[f32],
+    ) {
+    }
+
+    /// Returns `true` if a GPU-resident KV cache has been initialized.
+    fn has_gpu_kv_cache(&self) -> bool {
+        false
+    }
+
+    /// Grouped-query attention using GPU-resident KV cache buffers.
+    ///
+    /// Avoids re-uploading the KV cache from CPU on each forward pass —
+    /// the data written by [`gpu_kv_write`] is used directly.
+    ///
+    /// Only valid after [`init_gpu_kv_cache`] has been called
+    /// (`has_gpu_kv_cache()` returns `true`).
+    #[allow(clippy::too_many_arguments)]
+    fn grouped_query_attention_from_gpu_cache(
+        &self,
+        _q: &[f32],
+        _layer: usize,
+        _num_heads: usize,
+        _num_kv_heads: usize,
+        _head_dim: usize,
+        _seq_len: usize,
+        _attn_softcap: f32,
+    ) -> Vec<f32> {
+        panic!("GPU KV cache is not initialized — call init_gpu_kv_cache first");
+    }
 }
 
 /// Default CPU compute backend. Uses optimized scalar loops.
@@ -201,9 +256,20 @@ impl Model {
     }
 
     /// Replace the compute backend (e.g. with a GPU backend).
+    ///
+    /// After swapping the backend, initializes GPU-resident KV cache storage
+    /// if the new backend supports it (default: no-op for CPU backends).
+    ///
     /// Returns the previous backend.
     pub fn set_backend(&mut self, backend: Box<dyn ComputeBackend>) -> Box<dyn ComputeBackend> {
-        std::mem::replace(&mut self.backend, backend)
+        let old = std::mem::replace(&mut self.backend, backend);
+        self.backend.init_gpu_kv_cache(
+            self.config.num_layers,
+            self.config.max_seq_len,
+            self.config.num_kv_heads,
+            self.config.head_dim,
+        );
+        old
     }
 
     pub fn config(&self) -> &ModelConfig {
@@ -288,21 +354,37 @@ impl Model {
                 config.rope_theta,
             );
 
-            // Write K, V to cache
+            // Write K, V to CPU cache (always) and GPU cache (if initialized).
+            // The GPU write is a host→device queue.write_buffer — no readback.
             self.kv_cache.write(layer_idx, &k_data, &v_data);
+            self.backend
+                .gpu_kv_write(layer_idx, pos, num_kv_heads, head_dim, &k_data, &v_data);
 
-            // Grouped-query attention — dispatch to backend (GPU or CPU)
+            // Grouped-query attention — use GPU-resident cache when available to
+            // avoid re-uploading the full KV cache on every token.
             let seq_len = self.kv_cache.len() + 1; // include current position
-            let attn_output = self.backend.grouped_query_attention(
-                &q_data,
-                self.kv_cache.keys(layer_idx).data(),
-                self.kv_cache.values(layer_idx).data(),
-                num_heads,
-                num_kv_heads,
-                head_dim,
-                seq_len,
-                config.attn_logit_softcap,
-            );
+            let attn_output = if self.backend.has_gpu_kv_cache() {
+                self.backend.grouped_query_attention_from_gpu_cache(
+                    &q_data,
+                    layer_idx,
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                    seq_len,
+                    config.attn_logit_softcap,
+                )
+            } else {
+                self.backend.grouped_query_attention(
+                    &q_data,
+                    self.kv_cache.keys(layer_idx).data(),
+                    self.kv_cache.values(layer_idx).data(),
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                    seq_len,
+                    config.attn_logit_softcap,
+                )
+            };
 
             // Output projection
             let attn_proj =
@@ -590,13 +672,21 @@ impl Model {
             }
         }
 
-        // Write computed K/V to cache and advance position for each token
+        // Write computed K/V to CPU cache and GPU cache (if initialized),
+        // then advance the ring-buffer position once per token.
+        let cache_pos = self.kv_cache.position(); // position before prefill tokens
         for t in 0..seq_len {
             for layer_idx in 0..num_layers {
-                self.kv_cache.write(
+                let k_slice = &k_all[layer_idx][t * kv_dim..(t + 1) * kv_dim];
+                let v_slice = &v_all[layer_idx][t * kv_dim..(t + 1) * kv_dim];
+                self.kv_cache.write(layer_idx, k_slice, v_slice);
+                self.backend.gpu_kv_write(
                     layer_idx,
-                    &k_all[layer_idx][t * kv_dim..(t + 1) * kv_dim],
-                    &v_all[layer_idx][t * kv_dim..(t + 1) * kv_dim],
+                    cache_pos + t,
+                    num_kv_heads,
+                    head_dim,
+                    k_slice,
+                    v_slice,
                 );
             }
             self.kv_cache.advance();

--- a/flare-gpu/shaders/attention.wgsl
+++ b/flare-gpu/shaders/attention.wgsl
@@ -4,16 +4,24 @@
 // This shader computes attention scores (Q @ K^T) for one query position
 // against all KV cache positions. Used during autoregressive generation
 // where we compute attention for the newest token against the full cache.
+//
+// The K/V buffers may be either:
+//   • Per-head slices  [seq_len, head_dim]:              num_kv_heads=1, kv_head_idx=0
+//   • Full-layer cache [seq_len, num_kv_heads, head_dim]: actual num_kv_heads / kv_head_idx
+//
+// Indexing: k_cache[t * num_kv_heads * head_dim + kv_head_idx * head_dim + d]
 
-@group(0) @binding(0) var<storage, read> q: array<f32>;      // [head_dim]
-@group(0) @binding(1) var<storage, read> k_cache: array<f32>; // [seq_len, head_dim]
-@group(0) @binding(2) var<storage, read> v_cache: array<f32>; // [seq_len, head_dim]
+@group(0) @binding(0) var<storage, read> q: array<f32>;       // [head_dim]
+@group(0) @binding(1) var<storage, read> k_cache: array<f32>; // [seq_len, num_kv_heads, head_dim]
+@group(0) @binding(2) var<storage, read> v_cache: array<f32>; // [seq_len, num_kv_heads, head_dim]
 @group(0) @binding(3) var<storage, read_write> output: array<f32>; // [head_dim]
 
 struct Params {
     seq_len: u32,
     head_dim: u32,
     scale: f32,
+    num_kv_heads: u32, // 1 for per-head slice layout, actual value for full-layer layout
+    kv_head_idx: u32,  // which KV head to attend to
 }
 @group(0) @binding(4) var<uniform> params: Params;
 
@@ -30,12 +38,14 @@ fn attention_scores(
     let tid = lid.x;
     let seq_len = params.seq_len;
     let head_dim = params.head_dim;
+    let kv_stride = params.num_kv_heads * head_dim;
+    let kv_head_base = params.kv_head_idx * head_dim;
 
     // Phase 1: Compute Q @ K^T scores
     // Each thread handles one or more sequence positions
     for (var t: u32 = tid; t < seq_len; t = t + wg_size.x) {
         var dot: f32 = 0.0;
-        let k_offset = t * head_dim;
+        let k_offset = t * kv_stride + kv_head_base;
         for (var d: u32 = 0u; d < head_dim; d = d + 1u) {
             dot = dot + q[d] * k_cache[k_offset + d];
         }
@@ -79,7 +89,7 @@ fn attention_scores(
     for (var d: u32 = tid; d < head_dim; d = d + wg_size.x) {
         var acc: f32 = 0.0;
         for (var t: u32 = 0u; t < seq_len; t = t + 1u) {
-            acc = acc + scores[t] * v_cache[t * head_dim + d];
+            acc = acc + scores[t] * v_cache[t * kv_stride + kv_head_base + d];
         }
         output[d] = acc;
     }

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -1,8 +1,11 @@
+use std::sync::Mutex;
+
 use flare_core::model::ComputeBackend;
 use flare_core::tensor::Tensor;
 use thiserror::Error;
 
 use crate::buffers::{self, BufferPool};
+use crate::kv_cache::GpuKvCache;
 use crate::pipeline::{CachedPipeline, PipelineCache};
 
 #[derive(Debug, Error)]
@@ -32,12 +35,20 @@ const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
 /// Pipelines are cached on first use to avoid per-call shader compilation.
 /// Buffers are pooled so that repeated calls with the same tensor sizes reuse
 /// already-allocated GPU memory instead of allocating and freeing each time.
+///
+/// When `init_gpu_kv_cache` is called (automatically from `Model::set_backend`),
+/// the backend allocates `GpuKvCache` — GPU-resident ring buffers for K/V.
+/// Subsequent attention calls use those buffers directly, eliminating the
+/// CPU→GPU re-upload of the entire KV cache on every generated token.
 pub struct WebGpuBackend {
     device: wgpu::Device,
     queue: wgpu::Queue,
     cache: PipelineCache,
     /// Buffer pool: eliminates ~1–2 ms per-allocation overhead on repeated calls.
     pool: BufferPool,
+    /// GPU-resident KV cache.  `None` until `init_gpu_kv_cache` is called.
+    /// `Mutex` provides interior mutability so trait methods can take `&self`.
+    gpu_kv_cache: Mutex<Option<GpuKvCache>>,
 }
 
 impl WebGpuBackend {
@@ -73,6 +84,7 @@ impl WebGpuBackend {
             queue,
             cache: PipelineCache::new(),
             pool: BufferPool::new(),
+            gpu_kv_cache: Mutex::new(None),
         })
     }
 
@@ -727,11 +739,15 @@ impl ComputeBackend for WebGpuBackend {
                     .get_storage(&self.device, &self.queue, bytemuck::cast_slice(&v_head));
             let out_buf = self.pool.get_output(&self.device, output_size);
 
-            // Params: seq_len, head_dim, scale
-            let params_data: [u32; 3] = [
+            // Params: seq_len, head_dim, scale, num_kv_heads, kv_head_idx.
+            // The K/V slice is already per-head (extracted above), so num_kv_heads=1
+            // and kv_head_idx=0 — the shader indexes as t*1*head_dim + 0*head_dim + d.
+            let params_data: [u32; 5] = [
                 seq_len as u32,
                 head_dim as u32,
                 scale.to_bits(), // pass f32 as u32 raw bits; shader reads as f32
+                1u32,            // num_kv_heads: per-head slice layout
+                0u32,            // kv_head_idx: always 0 for per-head slices
             ];
             let params_buf = self.pool.get_uniform(
                 &self.device,
@@ -769,6 +785,153 @@ impl ComputeBackend for WebGpuBackend {
             self.pool.return_storage(q_buf);
             self.pool.return_storage(k_buf);
             self.pool.return_storage(v_buf);
+            self.pool.return_output(out_buf);
+            self.pool.return_uniform(params_buf);
+        }
+
+        output
+    }
+
+    fn init_gpu_kv_cache(
+        &self,
+        num_layers: usize,
+        max_seq_len: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+    ) {
+        let kv = GpuKvCache::new(
+            &self.device,
+            num_layers,
+            max_seq_len,
+            num_kv_heads,
+            head_dim,
+        );
+        *self
+            .gpu_kv_cache
+            .lock()
+            .expect("gpu_kv_cache mutex poisoned") = Some(kv);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn gpu_kv_write(
+        &self,
+        layer: usize,
+        position: usize,
+        _num_kv_heads: usize,
+        _head_dim: usize,
+        key: &[f32],
+        value: &[f32],
+    ) {
+        if let Some(ref kv) = *self
+            .gpu_kv_cache
+            .lock()
+            .expect("gpu_kv_cache mutex poisoned")
+        {
+            kv.write(&self.queue, layer, position, key, value);
+        }
+    }
+
+    fn has_gpu_kv_cache(&self) -> bool {
+        self.gpu_kv_cache
+            .lock()
+            .expect("gpu_kv_cache mutex poisoned")
+            .is_some()
+    }
+
+    /// Grouped-query attention using GPU-resident K/V buffers.
+    ///
+    /// Binds the full per-layer K/V GPU buffer directly — no CPU-side extraction
+    /// and no per-head CPU→GPU upload.  The WGSL shader handles head-stride
+    /// indexing via `num_kv_heads` and `kv_head_idx` params.
+    #[allow(clippy::too_many_arguments)]
+    fn grouped_query_attention_from_gpu_cache(
+        &self,
+        q: &[f32],
+        layer: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        seq_len: usize,
+        attn_softcap: f32,
+    ) -> Vec<f32> {
+        let guard = self
+            .gpu_kv_cache
+            .lock()
+            .expect("gpu_kv_cache mutex poisoned");
+        let kv = guard
+            .as_ref()
+            .expect("grouped_query_attention_from_gpu_cache called without GPU KV cache");
+
+        // Gemma-2 soft-cap is not implemented in the WGSL shader; fall back to CPU.
+        // The CPU path re-reads K/V from the GPU-resident buffers would require
+        // readback, which defeats the purpose.  Since Gemma-2 models are not the
+        // primary use-case for GPU inference today, panic loudly instead.
+        assert_eq!(
+            attn_softcap, 0.0,
+            "attn_logit_softcap != 0.0 is not supported with GPU KV cache"
+        );
+
+        let heads_per_kv = num_heads / num_kv_heads;
+        let mut output = vec![0.0f32; num_heads * head_dim];
+        let scale = 1.0_f32 / (head_dim as f32).sqrt();
+
+        let layout_entries = Self::attention_layout();
+
+        for h in 0..num_heads {
+            let kv_head = h / heads_per_kv;
+            let q_head = &q[h * head_dim..(h + 1) * head_dim];
+
+            let output_size = head_dim as u64 * 4;
+
+            // Upload Q for this head; bind the full-layer K/V GPU buffers directly.
+            let q_buf =
+                self.pool
+                    .get_storage(&self.device, &self.queue, bytemuck::cast_slice(q_head));
+            let out_buf = self.pool.get_output(&self.device, output_size);
+
+            // Params include num_kv_heads and kv_head_idx so the shader can index
+            // the interleaved full-layer K/V buffer without any CPU extraction.
+            let params_data: [u32; 5] = [
+                seq_len as u32,
+                head_dim as u32,
+                scale.to_bits(),
+                num_kv_heads as u32,
+                kv_head as u32,
+            ];
+            let params_buf = self.pool.get_uniform(
+                &self.device,
+                &self.queue,
+                bytemuck::cast_slice(&params_data),
+            );
+
+            let head_output = self.cache.with_pipeline(
+                &self.device,
+                "attention_scores",
+                ATTENTION_SHADER,
+                "attention_scores",
+                &layout_entries,
+                |cached| {
+                    let bind_group = self.make_attention_bind_group(
+                        cached,
+                        &q_buf,
+                        kv.key_buf(layer),
+                        kv.val_buf(layer),
+                        &out_buf,
+                        &params_buf,
+                    );
+                    self.dispatch_and_readback(
+                        &cached.pipeline,
+                        &bind_group,
+                        [1, 1, 1],
+                        &out_buf,
+                        output_size,
+                    )
+                },
+            );
+
+            output[h * head_dim..(h + 1) * head_dim].copy_from_slice(&head_output);
+
+            self.pool.return_storage(q_buf);
             self.pool.return_output(out_buf);
             self.pool.return_uniform(params_buf);
         }

--- a/flare-gpu/src/kv_cache.rs
+++ b/flare-gpu/src/kv_cache.rs
@@ -1,0 +1,97 @@
+use wgpu::util::DeviceExt;
+
+/// GPU-resident ring-buffer KV cache.
+///
+/// Each transformer layer gets a dedicated pair of `wgpu::Buffer`s for keys
+/// and values, pre-allocated at `max_seq_len * num_kv_heads * head_dim * 4`
+/// bytes each.  New K/V pairs are written via `queue.write_buffer` at the
+/// appropriate ring-buffer offset — no CPU readback is ever needed.
+///
+/// Buffer layout per layer (same for keys and values):
+///   `[max_seq_len, num_kv_heads, head_dim]` row-major f32
+///
+/// This means the K/V data for sequence position `p` and KV head `h` starts at
+/// byte offset `(p * num_kv_heads * head_dim + h * head_dim) * 4`.
+pub struct GpuKvCache {
+    key_bufs: Vec<wgpu::Buffer>,
+    val_bufs: Vec<wgpu::Buffer>,
+    pub max_seq_len: usize,
+    pub num_kv_heads: usize,
+    pub head_dim: usize,
+}
+
+impl GpuKvCache {
+    /// Allocate GPU buffers for `num_layers` layers, zeroed.
+    pub fn new(
+        device: &wgpu::Device,
+        num_layers: usize,
+        max_seq_len: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+    ) -> Self {
+        let buf_bytes = max_seq_len * num_kv_heads * head_dim * std::mem::size_of::<f32>();
+        let zeros = vec![0u8; buf_bytes];
+
+        let mut key_bufs = Vec::with_capacity(num_layers);
+        let mut val_bufs = Vec::with_capacity(num_layers);
+
+        for _ in 0..num_layers {
+            key_bufs.push(
+                device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("gpu_kv:key"),
+                    contents: &zeros,
+                    usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                }),
+            );
+            val_bufs.push(
+                device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("gpu_kv:val"),
+                    contents: &zeros,
+                    usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                }),
+            );
+        }
+
+        Self {
+            key_bufs,
+            val_bufs,
+            max_seq_len,
+            num_kv_heads,
+            head_dim,
+        }
+    }
+
+    /// Write a K/V pair at ring-buffer position `pos` for the given `layer`.
+    ///
+    /// `key` and `value` must each have `num_kv_heads * head_dim` elements.
+    /// The write is host→device via `queue.write_buffer` — no GPU readback.
+    pub fn write(&self, queue: &wgpu::Queue, layer: usize, pos: usize, key: &[f32], value: &[f32]) {
+        let kv_elems = self.num_kv_heads * self.head_dim;
+        debug_assert_eq!(key.len(), kv_elems);
+        debug_assert_eq!(value.len(), kv_elems);
+
+        let ring_pos = pos % self.max_seq_len;
+        let byte_offset = (ring_pos * kv_elems * std::mem::size_of::<f32>()) as u64;
+
+        queue.write_buffer(
+            &self.key_bufs[layer],
+            byte_offset,
+            bytemuck::cast_slice(key),
+        );
+        queue.write_buffer(
+            &self.val_bufs[layer],
+            byte_offset,
+            bytemuck::cast_slice(value),
+        );
+    }
+
+    /// GPU buffer for layer `layer` keys: `[max_seq_len, num_kv_heads, head_dim]` f32.
+    pub fn key_buf(&self, layer: usize) -> &wgpu::Buffer {
+        &self.key_bufs[layer]
+    }
+
+    /// GPU buffer for layer `layer` values: `[max_seq_len, num_kv_heads, head_dim]` f32.
+    pub fn val_buf(&self, layer: usize) -> &wgpu::Buffer {
+        &self.val_bufs[layer]
+    }
+}

--- a/flare-gpu/src/lib.rs
+++ b/flare-gpu/src/lib.rs
@@ -8,6 +8,8 @@
 
 pub mod backend;
 pub mod buffers;
+pub mod kv_cache;
 pub mod pipeline;
 
 pub use backend::WebGpuBackend;
+pub use kv_cache::GpuKvCache;

--- a/flarellm/src/lib.rs
+++ b/flarellm/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! - [`core`] — model, tensor, sampling, generation (always available)
 //! - [`loader`] — GGUF / SafeTensors loading (enabled by `loader` feature, default)
-//! - [`gpu`] — WebGPU compute backend (enabled by `gpu` feature)
+//! - `gpu` — WebGPU compute backend (enabled by `gpu` feature)
 //!
 //! ## Quick start
 //!


### PR DESCRIPTION
## Summary

- Adds `GpuKvCache` in `flare-gpu/src/kv_cache.rs` — per-layer `wgpu::Buffer` ring buffers (one pair per layer, sized `max_seq_len × num_kv_heads × head_dim × 4` bytes each), zeroed on allocation
- `Model::set_backend` automatically calls `backend.init_gpu_kv_cache(...)` so the GPU cache is ready before generation starts (no-op on `CpuBackend`)
- Every KV write in `forward()` and `forward_prefill()` is mirrored to the GPU via `queue.write_buffer` (host→device, no readback) in addition to the existing CPU `KvCache`
- `grouped_query_attention_from_gpu_cache` binds the full interleaved per-layer K/V GPU buffer directly to the attention shader — no per-head CPU extraction, no re-upload of the entire KV cache on every token
- `attention.wgsl` gains `num_kv_heads` and `kv_head_idx` params enabling the shader to index the interleaved layout; the existing CPU→GPU slice path passes `num_kv_heads=1, kv_head_idx=0` for backward compatibility
- The CPU `KvCache` is retained as a shadow (needed for correctness of CPU-path tests and for any future serialization / restore feature)

## Test plan

- [ ] `cargo check --workspace` passes (verified locally)
- [ ] `cargo clippy --workspace -- -D warnings` passes (verified locally)
- [ ] `cargo fmt --all -- --check` passes (verified locally)
- [ ] All 79 unit tests pass (verified locally)
- [ ] CI passes
- [ ] Manual GPU test: run `cargo test -p flarellm-gpu -- --ignored` on a GPU host

Closes #130