### PR TITLE
Add GPU dequantization shaders for Q5_K and Q6_K formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "flarellm-core",
+ "flarellm-loader",
  "log",
  "pollster",
  "thiserror 2.0.18",

--- a/flare-gpu/Cargo.toml
+++ b/flare-gpu/Cargo.toml
@@ -23,3 +23,4 @@ pollster = "0.4"
 
 [dev-dependencies]
 pollster = "0.4"
+flare-loader = { package = "flarellm-loader", path = "../flare-loader", version = "0.1.0" }

--- a/flare-gpu/shaders/dequant_q5k.wgsl
+++ b/flare-gpu/shaders/dequant_q5k.wgsl
@@ -1,0 +1,93 @@
+// Dequantize Q5_K blocks on GPU.
+//
+// Layout (176 bytes / 44 u32 per block, 256 weights per block):
+//   bytes  0-1  : d    (f16 LE)
+//   bytes  2-3  : dmin (f16 LE)
+//   bytes  4-15 : scales[12] — 8 (scale, min) pairs, same 6-bit encoding as Q4_K
+//   bytes 16-47 : qh[32]    — one high bit per weight; qh[j/8] bit (j%8) = 5th bit
+//                             of weight j; qh[(j+128)/8] bit (j%8) = 5th bit of weight j+128
+//   bytes 48-175: ql[128]   — low 4 bits per weight; ql[j] & 0xF = lo nibble (weight j),
+//                             ql[j] >> 4 = hi nibble (weight j+128)
+//
+// Weight reconstruction:
+//   q_lo  = (ql[j] & 0x0F) | ((qh[j/8] >> (j%8)) & 1) << 4)    — 5-bit value
+//   q_hi  = ((ql[j] >> 4) & 0x0F) | (((qh[(j+128)/8] >> (j%8)) & 1) << 4)
+//   output[j]     = d * sc[j/32]   * q_lo - dmin * mn[j/32]
+//   output[j+128] = d * sc[j/32+4] * q_hi - dmin * mn[j/32+4]
+//
+// Scale decoding: identical to Q4_K (scales_raw[0..12] in bytes 4-15).
+// Each thread handles one block.
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_blocks: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(64)
+fn dequant_q5k(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+    let block_idx = gid.x;
+    if block_idx >= params.num_blocks {
+        return;
+    }
+
+    // 176 bytes per block = 44 u32; u is the base u32 index for this block.
+    let u = block_idx * 44u;
+
+    // d and dmin packed as two f16 in the first u32.
+    let dm = unpack2x16float(raw[u]);
+    let d    = dm.x;
+    let dmin = dm.y;
+
+    // Decode 8 scale/min pairs from scales_raw[0..12] = raw[u+1 .. u+4].
+    //   scales_raw[0..4]  packed in raw[u+1]
+    //   scales_raw[4..8]  packed in raw[u+2]
+    //   scales_raw[8..12] packed in raw[u+3]
+    // Same 6-bit encoding as Q4_K.
+    var sc: array<u32, 8>;
+    var mn: array<u32, 8>;
+    for (var i = 0u; i < 4u; i = i + 1u) {
+        let sr_i  = (raw[u + 1u] >> (i * 8u)) & 0xFFu;
+        let sr_i4 = (raw[u + 2u] >> (i * 8u)) & 0xFFu;
+        let sr_i8 = (raw[u + 3u] >> (i * 8u)) & 0xFFu;
+        sc[i]      = sr_i & 0x3Fu;
+        mn[i]      = sr_i4 & 0x3Fu;
+        sc[i + 4u] = (sr_i >> 6u) | ((sr_i8 & 0x0Fu) << 2u);
+        mn[i + 4u] = (sr_i4 >> 6u) | ((sr_i8 >> 4u) << 2u);
+    }
+
+    // qh at raw[u+4 .. u+12]  (8 u32 = 32 bytes, bytes 16-47 of block)
+    // ql at raw[u+12 .. u+44] (32 u32 = 128 bytes, bytes 48-175 of block)
+    let out_base = block_idx * 256u;
+    for (var j = 0u; j < 128u; j = j + 1u) {
+        // ql[j]: u32 index u+12+j/4, byte (j%4)
+        let ql_u32  = raw[u + 12u + j / 4u];
+        let ql_byte = (ql_u32 >> ((j % 4u) * 8u)) & 0xFFu;
+        let lo_nibble = ql_byte & 0x0Fu;
+        let hi_nibble = (ql_byte >> 4u) & 0x0Fu;
+
+        // qh bit for weight j (lo):  qh byte at index j/8, bit (j%8).
+        //   qh byte j/8 is in u32[4 + j/32], at byte-within-u32 = (j/8) % 4.
+        let qh_lo_u32  = raw[u + 4u + j / 32u];
+        let qh_lo_byte = (qh_lo_u32 >> (((j / 8u) % 4u) * 8u)) & 0xFFu;
+        let qh_lo_bit  = (qh_lo_byte >> (j % 8u)) & 1u;
+
+        // qh bit for weight j+128 (hi): qh byte at index j/8+16, bit (j%8).
+        //   qh byte (j/8+16) is in u32[8 + j/32], same byte-within-u32 = (j/8) % 4.
+        let qh_hi_u32  = raw[u + 8u + j / 32u];
+        let qh_hi_byte = (qh_hi_u32 >> (((j / 8u) % 4u) * 8u)) & 0xFFu;
+        let qh_hi_bit  = (qh_hi_byte >> (j % 8u)) & 1u;
+
+        // Assemble 5-bit quantized values.
+        let q_lo = lo_nibble | (qh_lo_bit << 4u);
+        let q_hi = hi_nibble | (qh_hi_bit << 4u);
+        let sub  = j / 32u;
+
+        output[out_base + j]        = d * f32(sc[sub])      * f32(q_lo) - dmin * f32(mn[sub]);
+        output[out_base + j + 128u] = d * f32(sc[sub + 4u]) * f32(q_hi) - dmin * f32(mn[sub + 4u]);
+    }
+}

--- a/flare-gpu/shaders/dequant_q6k.wgsl
+++ b/flare-gpu/shaders/dequant_q6k.wgsl
@@ -1,0 +1,96 @@
+// Dequantize Q6_K blocks on GPU.
+//
+// Layout (210 bytes per block, 256 weights per block):
+//   bytes   0-127: ql[128] — lower 4 bits of the 6-bit weights (two interleaved groups)
+//   bytes 128-191: qh[64]  — upper 2 bits of the 6-bit weights
+//   bytes 192-207: scales[16] — signed i8 scale per sub-block
+//   bytes 208-209: d (f16 LE)
+//
+// 210 bytes is not u32-aligned.  The Rust caller pads the raw byte buffer to the
+// nearest 4-byte multiple before uploading.  Weights are accessed via byte-offset
+// helpers that extract individual bytes from the u32 storage array.
+//
+// Reconstruction (mirrors llama.cpp dequant_row_q6_K):
+//   For half in 0..2 (each covering 128 output elements):
+//     ql_off = half*64,  qh_off = half*32,  sc_off = half*8,  y_off = half*128
+//     For l in 0..32:
+//       q1 = (ql[ql_off+l]    & 0xF)  | ((qh[qh_off+l] & 3)       << 4) − 32
+//       q2 = (ql[ql_off+l+32] & 0xF)  | (((qh[qh_off+l] >> 2) & 3) << 4) − 32
+//       q3 =  (ql[ql_off+l]    >> 4)  | (((qh[qh_off+l] >> 4) & 3) << 4) − 32
+//       q4 =  (ql[ql_off+l+32] >> 4)  | (((qh[qh_off+l] >> 6) & 3) << 4) − 32
+//       output[y_off+l]    = d * sc[sc_off + l/16]     * q1
+//       output[y_off+l+32] = d * sc[sc_off + l/16 + 2] * q2
+//       output[y_off+l+64] = d * sc[sc_off + l/16 + 4] * q3
+//       output[y_off+l+96] = d * sc[sc_off + l/16 + 6] * q4
+//
+// Each thread handles one block.
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_blocks: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+/// Reinterpret an 8-bit unsigned value as a signed 8-bit integer (i32).
+fn sign_extend_byte(b: u32) -> i32 {
+    return bitcast<i32>(b << 24u) >> 24u;
+}
+
+@compute @workgroup_size(64)
+fn dequant_q6k(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+    let block_idx = gid.x;
+    if block_idx >= params.num_blocks {
+        return;
+    }
+
+    // 210 bytes per block; bb is the byte offset of this block's start.
+    let bb = block_idx * 210u;
+
+    // d at bytes 208-209 of this block (LE f16).
+    let d_packed = read_byte(bb + 208u) | (read_byte(bb + 209u) << 8u);
+    let d = unpack2x16float(d_packed).x;
+
+    let out_base = block_idx * 256u;
+
+    for (var half = 0u; half < 2u; half = half + 1u) {
+        let ql_off = half * 64u;
+        let qh_off = half * 32u;
+        let sc_off = half * 8u;
+        let y_off  = half * 128u;
+
+        for (var l = 0u; l < 32u; l = l + 1u) {
+            // ql bytes: lower 4 bits of the 6-bit weight.
+            let ql_a = read_byte(bb + ql_off + l);
+            let ql_b = read_byte(bb + ql_off + l + 32u);
+            // qh byte: upper 2 bits for four weights packed in 8 bits.
+            let qh_b = read_byte(bb + 128u + qh_off + l);
+
+            // Assemble 6-bit unsigned values, then offset-binary subtract 32.
+            let q1 = i32((ql_a & 0x0Fu) | ((qh_b & 3u) << 4u)) - 32;
+            let q2 = i32((ql_b & 0x0Fu) | (((qh_b >> 2u) & 3u) << 4u)) - 32;
+            let q3 = i32((ql_a >> 4u)   | (((qh_b >> 4u) & 3u) << 4u)) - 32;
+            let q4 = i32((ql_b >> 4u)   | (((qh_b >> 6u) & 3u) << 4u)) - 32;
+
+            // Signed i8 scales (two scale values per 32-element group, 4 groups per half).
+            let is = l / 16u;
+            let sc1 = sign_extend_byte(read_byte(bb + 192u + sc_off + is));
+            let sc2 = sign_extend_byte(read_byte(bb + 192u + sc_off + is + 2u));
+            let sc3 = sign_extend_byte(read_byte(bb + 192u + sc_off + is + 4u));
+            let sc4 = sign_extend_byte(read_byte(bb + 192u + sc_off + is + 6u));
+
+            output[out_base + y_off + l]        = d * f32(sc1) * f32(q1);
+            output[out_base + y_off + l + 32u]  = d * f32(sc2) * f32(q2);
+            output[out_base + y_off + l + 64u]  = d * f32(sc3) * f32(q3);
+            output[out_base + y_off + l + 96u]  = d * f32(sc4) * f32(q4);
+        }
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -27,6 +27,8 @@ const ATTENTION_SHADER: &str = include_str!("../shaders/attention.wgsl");
 const DEQUANT_Q4_1_SHADER: &str = include_str!("../shaders/dequant_q4_1.wgsl");
 const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
 const DEQUANT_MATVEC_Q4K_SHADER: &str = include_str!("../shaders/dequant_matvec_q4k.wgsl");
+const DEQUANT_Q5K_SHADER: &str = include_str!("../shaders/dequant_q5k.wgsl");
+const DEQUANT_Q6K_SHADER: &str = include_str!("../shaders/dequant_q6k.wgsl");
 
 /// WebGPU/wgpu compute backend.
 ///
@@ -311,6 +313,103 @@ impl WebGpuBackend {
             "dequant_q4k",
             DEQUANT_Q4K_SHADER,
             "dequant_q4k",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_single_input_bind_group(cached, &raw_buf, &out_buf, &params_buf);
+                let dispatch_x = (num_blocks as u32).div_ceil(64);
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [dispatch_x, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Dequantize Q5_K blocks on GPU.
+    ///
+    /// `raw_bytes` is the packed GGUF tensor data (num_blocks × 176 bytes).
+    /// Returns a flat `Vec<f32>` of num_blocks × 256 dequantized weights.
+    pub fn dequant_q5k(&self, raw_bytes: &[u8], num_blocks: usize) -> Vec<f32> {
+        let output_size = (num_blocks * 256) as u64 * 4;
+
+        let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 1] = [num_blocks as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::single_input_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_q5k",
+            DEQUANT_Q5K_SHADER,
+            "dequant_q5k",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_single_input_bind_group(cached, &raw_buf, &out_buf, &params_buf);
+                let dispatch_x = (num_blocks as u32).div_ceil(64);
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [dispatch_x, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Dequantize Q6_K blocks on GPU.
+    ///
+    /// `raw_bytes` is the packed GGUF tensor data (num_blocks × 210 bytes).
+    /// Returns a flat `Vec<f32>` of num_blocks × 256 dequantized weights.
+    ///
+    /// Q6_K blocks are 210 bytes each (not u32-aligned).  The raw bytes are
+    /// padded to the nearest 4-byte multiple before upload so that the wgpu
+    /// storage buffer size requirement is satisfied.
+    pub fn dequant_q6k(&self, raw_bytes: &[u8], num_blocks: usize) -> Vec<f32> {
+        let output_size = (num_blocks * 256) as u64 * 4;
+
+        // Q6_K blocks are 210 bytes — pad to next multiple of 4 for wgpu.
+        let raw_buf = if raw_bytes.len().is_multiple_of(4) {
+            self.pool.get_storage(&self.device, &self.queue, raw_bytes)
+        } else {
+            let mut padded = raw_bytes.to_vec();
+            padded.resize((padded.len() + 3) & !3, 0);
+            self.pool.get_storage(&self.device, &self.queue, &padded)
+        };
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 1] = [num_blocks as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::single_input_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_q6k",
+            DEQUANT_Q6K_SHADER,
+            "dequant_q6k",
             &layout_entries,
             |cached| {
                 let bind_group =
@@ -1259,6 +1358,119 @@ mod tests {
         assert_eq!(result.len(), num_rows);
         for (i, &v) in result.iter().enumerate() {
             assert!((v - 384.0).abs() < 1e-1, "row {i}: got {v}, expected 384.0");
+        }
+    }
+
+    /// Verify Q5_K GPU dequant matches the CPU reference.
+    ///
+    /// Block setup: d=1.0, dmin=0.0, all sc[*]=1 (scales_raw[0..4]=0x41),
+    /// mn[*]=0, qh=0 (no high bit), ql all 0x12 (lo=2, hi=1).
+    /// Expected: output[0..128]=2.0, output[128..256]=1.0
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_q5k_matches_cpu() {
+        use flare_loader::quantize::dequant_q5k_block;
+
+        let mut raw = [0u8; 176];
+        // d = 1.0 as f16 LE
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // dmin = 0.0 (already zero)
+        // scales_raw[0..4] = 0x41: sc[i]=1 (bits[5:0]=1), bits[7:6]=01 → sc[i+4]=1
+        for b in raw[4..8].iter_mut() {
+            *b = 0x41;
+        }
+        // scales_raw[4..12] = 0x00: mn[*]=0 (already zero)
+        // qh[0..32] = 0x00: no high bits → lo/hi nibbles are the full 4-bit value
+        // ql[128] at bytes 48-175: lo=2, hi=1 → byte = 0x12
+        for b in raw[48..176].iter_mut() {
+            *b = 0x12;
+        }
+
+        // CPU reference
+        let mut cpu_out = [0.0f32; 256];
+        dequant_q5k_block(&raw, &mut cpu_out);
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_q5k(&raw, 1);
+
+        assert_eq!(result.len(), 256, "expected 256 weights");
+        for (j, (&gpu, &cpu)) in result.iter().zip(cpu_out.iter()).enumerate() {
+            assert!(
+                (gpu - cpu).abs() < 1e-3,
+                "q5k mismatch at [{j}]: gpu={gpu}, cpu={cpu}"
+            );
+        }
+    }
+
+    /// Verify Q6_K GPU dequant matches the CPU reference.
+    ///
+    /// Block setup: all-zero block (d=0.0 → all outputs = 0.0).
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_q6k_zeroed() {
+        use flare_loader::quantize::dequant_q6k_block;
+
+        let raw = [0u8; 210];
+
+        let mut cpu_out = [0.0f32; 256];
+        dequant_q6k_block(&raw, &mut cpu_out);
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_q6k(&raw, 1);
+
+        assert_eq!(result.len(), 256);
+        for (j, (&gpu, &cpu)) in result.iter().zip(cpu_out.iter()).enumerate() {
+            assert!(
+                (gpu - cpu).abs() < 1e-3,
+                "q6k zeroed mismatch at [{j}]: gpu={gpu}, cpu={cpu}"
+            );
+        }
+    }
+
+    /// Verify Q6_K GPU dequant with d=1.0, non-trivial scales and qh bits.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_q6k_matches_cpu() {
+        use flare_loader::quantize::dequant_q6k_block;
+
+        let mut raw = [0u8; 210];
+        // d = 1.0 as f16 LE at bytes 208-209
+        raw[208] = 0x00;
+        raw[209] = 0x3C;
+        // scales[16] at bytes 192-207: set all to 1 (0x01 as signed i8)
+        for b in raw[192..208].iter_mut() {
+            *b = 0x01;
+        }
+        // ql[128] at bytes 0-127: lo nibble = 1, hi nibble = 2 → byte = 0x21
+        for b in raw[0..128].iter_mut() {
+            *b = 0x21;
+        }
+        // qh[64] at bytes 128-191: set upper 2 bits to 0b01 per group of 4
+        // qh byte = 0x55 = 0b01010101: bits [1:0]=01, [3:2]=01, [5:4]=01, [7:6]=01
+        for b in raw[128..192].iter_mut() {
+            *b = 0x55;
+        }
+
+        // CPU reference
+        let mut cpu_out = [0.0f32; 256];
+        dequant_q6k_block(&raw, &mut cpu_out);
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_q6k(&raw, 1);
+
+        assert_eq!(result.len(), 256);
+        for (j, (&gpu, &cpu)) in result.iter().zip(cpu_out.iter()).enumerate() {
+            assert!(
+                (gpu - cpu).abs() < 1e-3,
+                "q6k mismatch at [{j}]: gpu={gpu}, cpu={cpu}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

- **`dequant_q5k.wgsl`**: 176-byte Q5_K blocks (d/dmin + scales[12] + qh[32] + ql[128]). Assembles 5-bit weights from 4-bit low nibble plus one high bit extracted from `qh`. Scale/min decoding is identical to Q4_K. 44 u32 per block — cleanly aligned.
- **`dequant_q6k.wgsl`**: 210-byte Q6_K blocks (ql[128] + qh[64] + scales[16] + d). Reconstructs 6-bit offset-binary weights (`q − 32`) using two interleaved ql regions and two-bit upper fields packed in qh. Signed i8 scales sign-extended via `bitcast<i32>(b << 24u) >> 24u`. Uses byte-offset helper functions since 210 is not u32-aligned.
- **`WebGpuBackend::dequant_q5k` / `dequant_q6k`** methods wired to the shaders. Q6_K pads raw bytes to next multiple of 4 before GPU upload.
- `#[ignore]` GPU tests cross-validate against the CPU reference implementations in `flare-loader`.

Closes #138

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo test --workspace` passes (non-GPU tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test -p flarellm-gpu -- --ignored` on a machine with GPU adapter (verifies Q5_K and Q6_K GPU output matches CPU reference)