### PR TITLE
Add GPU batched causal prefill attention shader

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -127,6 +127,52 @@ pub trait ComputeBackend: Send + Sync {
     ) -> Vec<f32> {
         panic!("GPU KV cache is not initialized — call init_gpu_kv_cache first");
     }
+
+    /// Batched causal prefill attention for all token positions in a sequence.
+    ///
+    /// Computes causal self-attention for each position `t` in the sequence,
+    /// where position `t` attends only to keys/values at positions `0..=t`.
+    /// Backends that support GPU dispatch (e.g. `WebGpuBackend`) override this
+    /// to run a single parallel kernel instead of the O(seq_len²) CPU loop.
+    ///
+    /// - `q`: query vectors `[seq_len * num_heads * head_dim]`
+    /// - `k`: key vectors `[seq_len * num_kv_heads * head_dim]`
+    /// - `v`: value vectors `[seq_len * num_kv_heads * head_dim]`
+    /// - Returns `[seq_len * num_heads * head_dim]`
+    #[allow(clippy::too_many_arguments)]
+    fn prefill_attention_gpu(
+        &self,
+        q: &[f32],
+        k: &[f32],
+        v: &[f32],
+        seq_len: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        attn_softcap: f32,
+    ) -> Vec<f32> {
+        // CPU fallback: iterate over positions and call the per-position GQA.
+        let q_dim = num_heads * head_dim;
+        let kv_dim = num_kv_heads * head_dim;
+        let mut output = vec![0.0f32; seq_len * q_dim];
+        for t in 0..seq_len {
+            let q_t = &q[t * q_dim..(t + 1) * q_dim];
+            let k_t = &k[0..(t + 1) * kv_dim];
+            let v_t = &v[0..(t + 1) * kv_dim];
+            let attn_t = cpu_grouped_query_attention(
+                q_t,
+                k_t,
+                v_t,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                t + 1,
+                attn_softcap,
+            );
+            output[t * q_dim..(t + 1) * q_dim].copy_from_slice(&attn_t);
+        }
+        output
+    }
 }
 
 /// Default CPU compute backend. Uses optimized scalar loops.
@@ -590,24 +636,17 @@ impl Model {
                 }
             }
 
-            // Causal self-attention: position t attends to positions 0..=t
-            let mut attn_out_batch = vec![0.0f32; seq_len * q_dim];
-            for t in 0..seq_len {
-                let q_t = &q_batch[t * q_dim..(t + 1) * q_dim];
-                let k_t = &k_all[layer_idx][0..(t + 1) * kv_dim];
-                let v_t = &v_all[layer_idx][0..(t + 1) * kv_dim];
-                let attn_t = cpu_grouped_query_attention(
-                    q_t,
-                    k_t,
-                    v_t,
-                    num_heads,
-                    num_kv_heads,
-                    head_dim,
-                    t + 1,
-                    config.attn_logit_softcap,
-                );
-                attn_out_batch[t * q_dim..(t + 1) * q_dim].copy_from_slice(&attn_t);
-            }
+            // Causal self-attention: dispatch to GPU (if available) or CPU fallback.
+            let attn_out_batch = self.backend.prefill_attention_gpu(
+                &q_batch,
+                &k_all[layer_idx],
+                &v_all[layer_idx],
+                seq_len,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                config.attn_logit_softcap,
+            );
 
             // Output projection + optional post-attention norm + residual
             {

--- a/flare-gpu/shaders/prefill_attention.wgsl
+++ b/flare-gpu/shaders/prefill_attention.wgsl
@@ -1,0 +1,144 @@
+// Batched causal prefill attention on GPU.
+//
+// Computes causal self-attention for every token position in a prefill
+// sequence in a single dispatch, replacing the O(seq_len²) CPU loop in
+// forward_prefill().
+//
+// Data layout (flat f32 arrays):
+//   q_all   [seq_len * num_heads    * head_dim] — queries for all positions and heads
+//   k_all   [seq_len * num_kv_heads * head_dim] — keys   for all positions and kv-heads
+//   v_all   [seq_len * num_kv_heads * head_dim] — values for all positions and kv-heads
+//   output  [seq_len * num_heads    * head_dim] — attention output (same layout as q_all)
+//
+//   Element at (pos, head, dim):  array[pos * H * D + head * D + dim]
+//   where H = num_heads (or num_kv_heads for K/V) and D = head_dim.
+//
+// Dispatch: [seq_len, num_heads, 1] workgroups of size [256, 1, 1].
+//   wid.x = query_pos   (0..seq_len)
+//   wid.y = head_idx    (0..num_heads)
+//
+// Causal masking: workgroup (query_pos, head_idx) attends to key/value
+//   positions 0..=query_pos only.
+//
+// Grouped-query attention: kv_head = head_idx % num_kv_heads.
+//
+// Supports optional Gemma-2-style logit soft-cap:
+//   score = tanh(raw_score / softcap) * softcap   (when softcap > 0)
+//
+// Maximum supported sequence length: 4096
+//   (limited by workgroup shared memory for the attention score array).
+
+@group(0) @binding(0) var<storage, read>       q_all:  array<f32>; // [seq_len * num_heads * head_dim]
+@group(0) @binding(1) var<storage, read>       k_all:  array<f32>; // [seq_len * num_kv_heads * head_dim]
+@group(0) @binding(2) var<storage, read>       v_all:  array<f32>; // [seq_len * num_kv_heads * head_dim]
+@group(0) @binding(3) var<storage, read_write> output: array<f32>; // [seq_len * num_heads * head_dim]
+
+struct Params {
+    seq_len:       u32,
+    num_heads:     u32,
+    num_kv_heads:  u32,
+    head_dim:      u32,
+    scale:         f32,  // 1.0 / sqrt(head_dim)
+    attn_softcap:  f32,  // Gemma-2 logit soft-cap; 0.0 = disabled
+}
+@group(0) @binding(4) var<uniform> params: Params;
+
+/// Per-workgroup attention score buffer.
+/// One entry per sequence position; max 4096 positions.
+var<workgroup> scores:    array<f32, 4096>;
+var<workgroup> max_score: f32;
+var<workgroup> sum_exp:   f32;
+
+@compute @workgroup_size(256)
+fn prefill_attention(
+    @builtin(local_invocation_id)  lid:     vec3<u32>,
+    @builtin(workgroup_id)         wid:     vec3<u32>,
+    @builtin(workgroup_size)       wg_size: vec3<u32>,
+) {
+    let query_pos  = wid.x;
+    let head_idx   = wid.y;
+    let tid        = lid.x;
+
+    let seq_len      = params.seq_len;
+    let num_heads    = params.num_heads;
+    let num_kv_heads = params.num_kv_heads;
+    let head_dim     = params.head_dim;
+
+    // Position query_pos attends to keys at positions 0..=query_pos.
+    let attend_len = query_pos + 1u;
+
+    // Shared memory holds at most 4096 scores.
+    // (All threads in the workgroup see the same query_pos, so all exit.)
+    if attend_len > 4096u {
+        return;
+    }
+
+    // Grouped-query attention: map attention head → KV head.
+    let kv_head = head_idx % num_kv_heads;
+
+    // Flat strides.
+    let q_stride  = num_heads    * head_dim;
+    let kv_stride = num_kv_heads * head_dim;
+
+    // Base index into q_all for this (query_pos, head_idx).
+    let q_base = query_pos * q_stride + head_idx * head_dim;
+
+    // --------------------------------------------------------------------
+    // Phase 1: QK^T
+    // Each thread computes the dot product for one or more key positions.
+    // --------------------------------------------------------------------
+    for (var t = tid; t < attend_len; t = t + wg_size.x) {
+        var dot = 0.0;
+        let k_base = t * kv_stride + kv_head * head_dim;
+        for (var d = 0u; d < head_dim; d = d + 1u) {
+            dot += q_all[q_base + d] * k_all[k_base + d];
+        }
+        var score = dot * params.scale;
+        // Optional logit soft-cap (Gemma-2).
+        if params.attn_softcap > 0.0 {
+            score = tanh(score / params.attn_softcap) * params.attn_softcap;
+        }
+        scores[t] = score;
+    }
+    workgroupBarrier();
+
+    // --------------------------------------------------------------------
+    // Phase 2: Stable softmax (single thread — QK^T above is the bottleneck)
+    // --------------------------------------------------------------------
+    if tid == 0u {
+        var m = -1e30;
+        for (var t = 0u; t < attend_len; t = t + 1u) {
+            m = max(m, scores[t]);
+        }
+        max_score = m;
+
+        var s = 0.0;
+        for (var t = 0u; t < attend_len; t = t + 1u) {
+            scores[t] = exp(scores[t] - max_score);
+            s += scores[t];
+        }
+        sum_exp = s;
+    }
+    workgroupBarrier();
+
+    // Parallel normalisation.
+    let inv_sum = 1.0 / sum_exp;
+    for (var t = tid; t < attend_len; t = t + wg_size.x) {
+        scores[t] = scores[t] * inv_sum;
+    }
+    workgroupBarrier();
+
+    // --------------------------------------------------------------------
+    // Phase 3: Weighted sum of values.
+    // Each thread computes one or more output dimensions.
+    // --------------------------------------------------------------------
+    let out_base = query_pos * q_stride + head_idx * head_dim;
+    for (var d = tid; d < head_dim; d = d + wg_size.x) {
+        var acc = 0.0;
+        for (var t = 0u; t < attend_len; t = t + 1u) {
+            let v_base = t * kv_stride + kv_head * head_dim;
+            acc += scores[t] * v_all[v_base + d];
+        }
+        output[out_base + d] = acc;
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -391,7 +391,8 @@ impl WebGpuBackend {
         let output_size = (num_blocks * 256) as u64 * 4;
 
         // Q6_K blocks are 210 bytes — pad to next multiple of 4 for wgpu.
-        let raw_buf = if raw_bytes.len().is_multiple_of(4) {
+        #[allow(clippy::manual_is_multiple_of)]
+        let raw_buf = if raw_bytes.len() % 4 == 0 {
             self.pool.get_storage(&self.device, &self.queue, raw_bytes)
         } else {
             let mut padded = raw_bytes.to_vec();

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -29,6 +29,7 @@ const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
 const DEQUANT_MATVEC_Q4K_SHADER: &str = include_str!("../shaders/dequant_matvec_q4k.wgsl");
 const DEQUANT_Q5K_SHADER: &str = include_str!("../shaders/dequant_q5k.wgsl");
 const DEQUANT_Q6K_SHADER: &str = include_str!("../shaders/dequant_q6k.wgsl");
+const PREFILL_ATTENTION_SHADER: &str = include_str!("../shaders/prefill_attention.wgsl");
 
 /// WebGPU/wgpu compute backend.
 ///
@@ -521,6 +522,91 @@ impl WebGpuBackend {
                 },
             ],
         })
+    }
+
+    /// Batched causal prefill attention for all token positions in a sequence.
+    ///
+    /// Dispatches one workgroup per `(query_pos, head)` pair so all positions
+    /// are processed in parallel.  Position `t` attends causally to keys at
+    /// positions `0..=t`.
+    ///
+    /// - `q`: `[seq_len * num_heads * head_dim]`
+    /// - `k`: `[seq_len * num_kv_heads * head_dim]`
+    /// - `v`: `[seq_len * num_kv_heads * head_dim]`
+    /// - Returns `[seq_len * num_heads * head_dim]`
+    #[allow(clippy::too_many_arguments)]
+    pub fn prefill_attention(
+        &self,
+        q: &[f32],
+        k: &[f32],
+        v: &[f32],
+        seq_len: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        attn_softcap: f32,
+    ) -> Vec<f32> {
+        let q_dim = num_heads * head_dim;
+        let output_size = (seq_len * q_dim) as u64 * 4;
+
+        let q_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(q));
+        let k_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(k));
+        let v_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(v));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let scale = 1.0_f32 / (head_dim as f32).sqrt();
+        let params: [u32; 6] = [
+            seq_len as u32,
+            num_heads as u32,
+            num_kv_heads as u32,
+            head_dim as u32,
+            scale.to_bits(),
+            attn_softcap.to_bits(),
+        ];
+        let params_buf = self
+            .pool
+            .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::attention_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "prefill_attention",
+            PREFILL_ATTENTION_SHADER,
+            "prefill_attention",
+            &layout_entries,
+            |cached| {
+                let bind_group = self.make_attention_bind_group(
+                    cached,
+                    &q_buf,
+                    &k_buf,
+                    &v_buf,
+                    &out_buf,
+                    &params_buf,
+                );
+                // Dispatch [seq_len, num_heads, 1]: one workgroup per (position, head).
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [seq_len as u32, num_heads as u32, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(q_buf);
+        self.pool.return_storage(k_buf);
+        self.pool.return_storage(v_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
     }
 }
 
@@ -1096,6 +1182,20 @@ impl ComputeBackend for WebGpuBackend {
 
         output
     }
+
+    fn prefill_attention_gpu(
+        &self,
+        q: &[f32],
+        k: &[f32],
+        v: &[f32],
+        seq_len: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        attn_softcap: f32,
+    ) -> Vec<f32> {
+        self.prefill_attention(q, k, v, seq_len, num_heads, num_kv_heads, head_dim, attn_softcap)
+    }
 }
 
 // WASM is single-threaded; wgpu's JS-backed types don't impl Send/Sync but it's
@@ -1470,6 +1570,54 @@ mod tests {
             assert!(
                 (gpu - cpu).abs() < 1e-3,
                 "q6k mismatch at [{j}]: gpu={gpu}, cpu={cpu}"
+            );
+        }
+    }
+
+    /// Verify GPU batched prefill attention matches the CPU reference.
+    ///
+    /// Uses a 3-position, 2-head, head_dim=4 setup:
+    ///   Q = K = V = identity-like pattern (ones on diagonal per head).
+    ///   Compares GPU output against `cpu_grouped_query_attention` per position.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_prefill_attention_matches_cpu() {
+        use flare_core::model::cpu_grouped_query_attention;
+
+        let seq_len = 4usize;
+        let num_heads = 2usize;
+        let num_kv_heads = 2usize;
+        let head_dim = 8usize;
+        let q_dim = num_heads * head_dim;
+        let kv_dim = num_kv_heads * head_dim;
+
+        // Fill Q, K, V with deterministic values.
+        let total_q = seq_len * q_dim;
+        let total_kv = seq_len * kv_dim;
+        let q: Vec<f32> = (0..total_q).map(|i| (i as f32) * 0.1).collect();
+        let k: Vec<f32> = (0..total_kv).map(|i| (i as f32) * 0.05).collect();
+        let v: Vec<f32> = (0..total_kv).map(|i| 1.0 / (1.0 + i as f32)).collect();
+
+        // CPU reference: compute per-position causal attention.
+        let mut cpu_out = vec![0.0f32; seq_len * q_dim];
+        for t in 0..seq_len {
+            let q_t = &q[t * q_dim..(t + 1) * q_dim];
+            let k_t = &k[0..(t + 1) * kv_dim];
+            let v_t = &v[0..(t + 1) * kv_dim];
+            let attn_t = cpu_grouped_query_attention(q_t, k_t, v_t, num_heads, num_kv_heads, head_dim, t + 1, 0.0);
+            cpu_out[t * q_dim..(t + 1) * q_dim].copy_from_slice(&attn_t);
+        }
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let gpu_out = backend.prefill_attention(&q, &k, &v, seq_len, num_heads, num_kv_heads, head_dim, 0.0);
+
+        assert_eq!(gpu_out.len(), cpu_out.len());
+        for (i, (&g, &c)) in gpu_out.iter().zip(cpu_out.iter()).enumerate() {
+            assert!(
+                (g - c).abs() < 1e-4,
+                "prefill_attention mismatch at [{i}]: gpu={g}, cpu={c}"
             );
         }
     }

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -570,9 +570,9 @@ impl WebGpuBackend {
             scale.to_bits(),
             attn_softcap.to_bits(),
         ];
-        let params_buf = self
-            .pool
-            .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
 
         let layout_entries = Self::attention_layout();
         let result = self.cache.with_pipeline(
@@ -1195,7 +1195,16 @@ impl ComputeBackend for WebGpuBackend {
         head_dim: usize,
         attn_softcap: f32,
     ) -> Vec<f32> {
-        self.prefill_attention(q, k, v, seq_len, num_heads, num_kv_heads, head_dim, attn_softcap)
+        self.prefill_attention(
+            q,
+            k,
+            v,
+            seq_len,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            attn_softcap,
+        )
     }
 }
 
@@ -1607,12 +1616,22 @@ mod tests {
             let q_t = &q[t * q_dim..(t + 1) * q_dim];
             let k_t = &k[0..(t + 1) * kv_dim];
             let v_t = &v[0..(t + 1) * kv_dim];
-            let attn_t = cpu_grouped_query_attention(q_t, k_t, v_t, num_heads, num_kv_heads, head_dim, t + 1, 0.0);
+            let attn_t = cpu_grouped_query_attention(
+                q_t,
+                k_t,
+                v_t,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                t + 1,
+                0.0,
+            );
             cpu_out[t * q_dim..(t + 1) * q_dim].copy_from_slice(&attn_t);
         }
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let gpu_out = backend.prefill_attention(&q, &k, &v, seq_len, num_heads, num_kv_heads, head_dim, 0.0);
+        let gpu_out =
+            backend.prefill_attention(&q, &k, &v, seq_len, num_heads, num_kv_heads, head_dim, 0.0);
 
         assert_eq!(gpu_out.len(), cpu_out.len());
         for (i, (&g, &c)) in gpu_out.iter().zip(cpu_out.iter()).enumerate() {


### PR DESCRIPTION
## Summary

- **`prefill_attention.wgsl`**: Compute shader that dispatches `[seq_len × num_heads, 1, 1]` workgroups. Each workgroup handles one `(query_pos, head_idx)` pair with a causal mask (position `t` attends only to positions `0..=t`). Supports grouped-query attention (`kv_head = head_idx % num_kv_heads`) and optional Gemma-2 logit soft-cap. Max supported sequence length: 4096.
- **`WebGpuBackend::prefill_attention`** method wired to the shader.
- **`ComputeBackend::prefill_attention_gpu`** trait method with a CPU fallback that calls `cpu_grouped_query_attention` per position (same behavior as before).
- **`forward_prefill()`** updated to call `self.backend.prefill_attention_gpu(...)` instead of the O(seq²) CPU loop — GPU backends get parallel causal attention, CPU backend gets the same sequential fallback.
- `#[ignore]` GPU test cross-validates against CPU reference with 4-position, 2-head, head_dim=8 inputs.

Closes #137

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test -p flarellm-gpu -- --ignored` on a GPU machine verifies GPU output matches CPU reference