### PR TITLE
Add fused Q5_K dequant+matvec WGSL shader

### DIFF
--- a/flare-gpu/shaders/dequant_matvec_q5k.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q5k.wgsl
@@ -1,0 +1,145 @@
+// Fused Q5_K dequantize + matrix-vector multiply on GPU.
+//
+// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+//
+// Q5_K block layout (176 bytes = 44 u32 per block, 256 weights per block):
+//   u32[0]      : d (f16 LE, lower 16 bits) + dmin (f16 LE, upper 16 bits)
+//   u32[1..4]   : scales[12] — 8 (scale, min) pairs packed in 12 bytes
+//   u32[4..12]  : qh[32]     — 1 high bit per weight (2 × 128-weight groups)
+//   u32[12..44] : ql[128]    — low 4 bits per weight; ql[j] & 0xF → weight j lo nibble,
+//                              ql[j] >> 4 → weight j+128 lo nibble
+//
+// Scale decoding (identical to Q4_K):
+//   sc[i]     = scales_raw[i]   & 0x3F
+//   mn[i]     = scales_raw[i+4] & 0x3F
+//   sc[i+4]   = (scales_raw[i] >> 6) | ((scales_raw[i+8] & 0x0F) << 2)
+//   mn[i+4]   = (scales_raw[i+4] >> 6) | ((scales_raw[i+8] >> 4) << 2)
+//
+// Weight reconstruction (for j in 0..128):
+//   qh_lo_bit = (qh[j/8] >> (j%8)) & 1
+//   qh_hi_bit = (qh[j/8 + 16] >> (j%8)) & 1
+//   q_lo = (ql[j] & 0x0F) | (qh_lo_bit << 4)   — 5-bit value
+//   q_hi = ((ql[j] >> 4) & 0x0F) | (qh_hi_bit << 4)
+//   w[j]     = d * sc[j/32]   * q_lo - dmin * mn[j/32]
+//   w[j+128] = d * sc[j/32+4] * q_hi - dmin * mn[j/32+4]
+//
+// One workgroup per output row. 64 threads stride across blocks in the row;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
+//   binding 0: raw    — packed Q5_K weight data [num_rows * num_blocks_per_row * 44]
+//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 256]
+//   binding 2: output — f32 result              [num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+@compute @workgroup_size(64)
+fn dequant_matvec_q5k(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row = wid.x;
+    if row >= params.num_rows {
+        return;
+    }
+
+    let tid = lid.x;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across blocks in this row (64-thread stride).
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Base offset for this block in the raw u32 array (44 u32 per block).
+        let raw_base = (row * params.num_blocks_per_row + b) * 44u;
+        // Corresponding start position in the input vector (256 elements per block).
+        let vec_base = b * 256u;
+
+        // d and dmin packed as two f16 in the first u32.
+        let dm   = unpack2x16float(raw[raw_base]);
+        let d    = dm.x;
+        let dmin = dm.y;
+
+        // Decode 8 scale/min pairs from scales_raw[0..12] = raw[raw_base+1 .. raw_base+4].
+        var sc: array<u32, 8>;
+        var mn: array<u32, 8>;
+        for (var i = 0u; i < 4u; i = i + 1u) {
+            let sr_i  = (raw[raw_base + 1u] >> (i * 8u)) & 0xFFu;
+            let sr_i4 = (raw[raw_base + 2u] >> (i * 8u)) & 0xFFu;
+            let sr_i8 = (raw[raw_base + 3u] >> (i * 8u)) & 0xFFu;
+            sc[i]      = sr_i & 0x3Fu;
+            mn[i]      = sr_i4 & 0x3Fu;
+            sc[i + 4u] = (sr_i >> 6u) | ((sr_i8 & 0x0Fu) << 2u);
+            mn[i + 4u] = (sr_i4 >> 6u) | ((sr_i8 >> 4u) << 2u);
+        }
+
+        // Process ql[128] + qh[32]: each ql byte yields one lo-nibble (weight j)
+        // and one hi-nibble (weight j+128); qh contributes the 5th bit.
+        for (var j = 0u; j < 128u; j = j + 1u) {
+            // ql byte j: u32[12 + j/4], byte (j%4)
+            let ql_u32  = raw[raw_base + 12u + j / 4u];
+            let ql_byte = (ql_u32 >> ((j % 4u) * 8u)) & 0xFFu;
+            let lo_nibble = ql_byte & 0x0Fu;
+            let hi_nibble = (ql_byte >> 4u) & 0x0Fu;
+
+            // qh bit for weight j (lo): qh byte at index j/8 → u32[4 + j/32], byte (j/8)%4.
+            let qh_lo_u32  = raw[raw_base + 4u + j / 32u];
+            let qh_lo_byte = (qh_lo_u32 >> (((j / 8u) % 4u) * 8u)) & 0xFFu;
+            let qh_lo_bit  = (qh_lo_byte >> (j % 8u)) & 1u;
+
+            // qh bit for weight j+128 (hi): qh byte at j/8+16 → u32[8 + j/32], same byte pos.
+            let qh_hi_u32  = raw[raw_base + 8u + j / 32u];
+            let qh_hi_byte = (qh_hi_u32 >> (((j / 8u) % 4u) * 8u)) & 0xFFu;
+            let qh_hi_bit  = (qh_hi_byte >> (j % 8u)) & 1u;
+
+            // Assemble 5-bit quantized values.
+            let q_lo = lo_nibble | (qh_lo_bit << 4u);
+            let q_hi = hi_nibble | (qh_hi_bit << 4u);
+            let sub  = j / 32u;
+
+            let w_lo = d * f32(sc[sub])      * f32(q_lo) - dmin * f32(mn[sub]);
+            let w_hi = d * f32(sc[sub + 4u]) * f32(q_hi) - dmin * f32(mn[sub + 4u]);
+
+            acc = acc + w_lo * vec[vec_base + j];
+            acc = acc + w_hi * vec[vec_base + j + 128u];
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u { partials[tid] = partials[tid] + partials[tid + 32u]; }
+    workgroupBarrier();
+    if tid < 16u { partials[tid] = partials[tid] + partials[tid + 16u]; }
+    workgroupBarrier();
+    if tid <  8u { partials[tid] = partials[tid] + partials[tid +  8u]; }
+    workgroupBarrier();
+    if tid <  4u { partials[tid] = partials[tid] + partials[tid +  4u]; }
+    workgroupBarrier();
+    if tid <  2u { partials[tid] = partials[tid] + partials[tid +  2u]; }
+    workgroupBarrier();
+    if tid <  1u { partials[tid] = partials[tid] + partials[tid +  1u]; }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -27,6 +27,7 @@ const ATTENTION_SHADER: &str = include_str!("../shaders/attention.wgsl");
 const DEQUANT_Q4_1_SHADER: &str = include_str!("../shaders/dequant_q4_1.wgsl");
 const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
 const DEQUANT_MATVEC_Q4K_SHADER: &str = include_str!("../shaders/dequant_matvec_q4k.wgsl");
+const DEQUANT_MATVEC_Q5K_SHADER: &str = include_str!("../shaders/dequant_matvec_q5k.wgsl");
 const DEQUANT_Q5K_SHADER: &str = include_str!("../shaders/dequant_q5k.wgsl");
 const DEQUANT_Q6K_SHADER: &str = include_str!("../shaders/dequant_q6k.wgsl");
 const PREFILL_ATTENTION_SHADER: &str = include_str!("../shaders/prefill_attention.wgsl");
@@ -469,6 +470,63 @@ impl WebGpuBackend {
             "dequant_matvec_q4k",
             DEQUANT_MATVEC_Q4K_SHADER,
             "dequant_matvec_q4k",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
+                // One workgroup per output row.
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused Q5_K dequantize + matrix-vector multiply.
+    ///
+    /// Reads packed Q5_K weight data, dequantizes each 176-byte block on-the-fly,
+    /// and accumulates the dot product with `input` in the same kernel.
+    ///
+    /// - `raw_bytes`: packed GGUF data — `num_rows × num_blocks_per_row × 176` bytes
+    /// - `input`: f32 input vector of length `num_blocks_per_row × 256`
+    /// - Returns `num_rows` f32 dot products
+    pub fn dequant_matvec_q5k(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * 4;
+
+        let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_q5k",
+            DEQUANT_MATVEC_Q5K_SHADER,
+            "dequant_matvec_q5k",
             &layout_entries,
             |cached| {
                 let bind_group =
@@ -1639,6 +1697,76 @@ mod tests {
                 (g - c).abs() < 1e-4,
                 "prefill_attention mismatch at [{i}]: gpu={g}, cpu={c}"
             );
+        }
+    }
+
+    /// Verify fused Q5_K dequant-matvec against the CPU reference.
+    ///
+    /// Block setup: d=1.0, dmin=0.0, sc[*]=1 (scales_raw[0..4]=0x41), mn[*]=0,
+    /// qh=0 (no high bit), ql all 0x12 (lo nibble=2, hi nibble=1).
+    /// Input vector = all 1.0.
+    /// Expected: dot = 128 × 2.0 + 128 × 1.0 = 384.0 (same as Q4_K with identical values).
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q5k_matches_cpu() {
+        let mut raw = [0u8; 176];
+        // d = 1.0 as f16 LE
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // scales_raw[0..4] = 0x41: sc[i]=1, bits[7:6]=01 → sc[i+4]=1
+        for b in raw[4..8].iter_mut() {
+            *b = 0x41;
+        }
+        // qh[0..32] = 0x00: qh_bit=0 for all weights
+        // ql[128] at bytes 48-175: lo nibble=2, hi nibble=1 → byte = 0x12
+        for b in raw[48..176].iter_mut() {
+            *b = 0x12;
+        }
+
+        let input = [1.0f32; 256];
+        let expected = 128.0 * 2.0 + 128.0 * 1.0; // 384.0
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q5k(&raw, &input, 1, 1);
+
+        assert_eq!(result.len(), 1, "expected one output value");
+        assert!(
+            (result[0] - expected).abs() < 1e-1,
+            "dequant_matvec_q5k mismatch: got {}, expected {}",
+            result[0],
+            expected
+        );
+    }
+
+    /// Multi-row test: 3 rows × 1 Q5_K block, input = all 1.0.
+    /// All rows should give 384.0.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q5k_multi_row() {
+        let mut block = [0u8; 176];
+        block[0] = 0x00;
+        block[1] = 0x3C; // d = 1.0
+        for b in block[4..8].iter_mut() {
+            *b = 0x41; // sc[*]=1
+        }
+        for b in block[48..176].iter_mut() {
+            *b = 0x12; // ql: lo=2, hi=1; qh=0
+        }
+
+        let num_rows = 3usize;
+        let raw: Vec<u8> = block.iter().copied().cycle().take(176 * num_rows).collect();
+        let input = [1.0f32; 256];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q5k(&raw, &input, num_rows, 1);
+
+        assert_eq!(result.len(), num_rows);
+        for (i, &v) in result.iter().enumerate() {
+            assert!((v - 384.0).abs() < 1e-1, "row {i}: got {v}, expected 384.0");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `flare-gpu/shaders/dequant_matvec_q5k.wgsl`: fused Q5_K dequantize + matrix-vector multiply compute shader
- One workgroup per output row; 64-thread stride across blocks; parallel tree reduction (64→1)
- Adds `dequant_matvec_q5k()` method in `flare-gpu/src/backend.rs` with matching `#[ignore]` GPU tests
- Q5_K layout: 176 bytes = 44 u32 per block; extracts 5-bit weights via ql (4 bits) + qh (1 bit) per weight

## Test plan
- [ ] `cargo test --workspace` passes (all non-GPU tests)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] GPU tests (marked `#[ignore]`) pass on hardware with WebGPU support

Closes #142