### PR TITLE
Add GPU Q3_K dequantization shader for 3-bit quantized models

### DIFF
--- a/flare-gpu/shaders/dequant_q3k.wgsl
+++ b/flare-gpu/shaders/dequant_q3k.wgsl
@@ -1,0 +1,103 @@
+// Dequantize Q3_K blocks on GPU.
+//
+// Layout (110 bytes per block, 256 weights per block):
+//   bytes   0-31:  hmask[32] — high bit (bit 2) for each weight, 8 per byte
+//   bytes  32-95:  qs[64]    — low 2 bits of each weight, 4 per byte
+//   bytes  96-107: scales[12] — 8 sub-block scales (6-bit) via kmask transform
+//   bytes 108-109: d (f16 LE)
+//
+// 110 bytes is not u32-aligned. The Rust caller pads the raw byte buffer to the
+// nearest 4-byte multiple before uploading. Weights are accessed via byte-offset
+// helpers that extract individual bytes from the u32 storage array.
+//
+// Scale decoding (kmask transform, b = scales_raw = block bytes 96..108):
+//   scales[0] = (b[0] & 0x0F) | (((b[8]  >> 4) & 3) << 4) − 32
+//   scales[1] = (b[1] & 0x0F) | (((b[9]  >> 4) & 3) << 4) − 32
+//   scales[2] = (b[2] & 0x0F) | (((b[10] >> 4) & 3) << 4) − 32
+//   scales[3] = (b[3] & 0x0F) | (((b[11] >> 4) & 3) << 4) − 32
+//   scales[4] = (b[4] & 0x0F) | (((b[8]  >> 6) & 3) << 4) − 32
+//   scales[5] = (b[5] & 0x0F) | (((b[9]  >> 6) & 3) << 4) − 32
+//   scales[6] = (b[6] & 0x0F) | (((b[10] >> 6) & 3) << 4) − 32
+//   scales[7] = (b[7] & 0x0F) | (((b[11] >> 6) & 3) << 4) − 32
+//
+// Weight reconstruction (mirrors dequant_q3k_block in flare-loader):
+//   For oi in 0..2 (each outer iteration covers 128 output elements):
+//     For si in 0..4 (each sub-block covers 32 elements):
+//       m = 1 << (oi*4 + si)    — hmask bit selector
+//       shift = si * 2           — qs bit position
+//       scale_idx = oi*4 + si
+//       For l in 0..32:
+//         qs_byte = qs[oi*32 + l] = block byte 32 + oi*32 + l
+//         low2  = (qs_byte >> shift) & 3
+//         sub   = if (hmask[l] & m) != 0 { 0 } else { 4 }
+//         q     = i32(low2) - sub     — range [−4, 3]
+//         output[oi*128 + si*32 + l] = d * scales[scale_idx] * q
+//
+// Each thread handles one block.
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_blocks: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+@compute @workgroup_size(64)
+fn dequant_q3k(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+    let block_idx = gid.x;
+    if block_idx >= params.num_blocks {
+        return;
+    }
+
+    // 110 bytes per block; bb is the byte offset of this block's start.
+    let bb = block_idx * 110u;
+
+    // d at bytes 108-109 of this block (LE f16).
+    let d_packed = read_byte(bb + 108u) | (read_byte(bb + 109u) << 8u);
+    let d = unpack2x16float(d_packed).x;
+
+    // Decode 8 scales from scales_raw bytes 96..108 using kmask transform.
+    // b[k] = block byte at bb + 96 + k.
+    var scales: array<i32, 8>;
+    for (var k = 0u; k < 4u; k = k + 1u) {
+        let bk    = read_byte(bb + 96u + k);
+        let bk4   = read_byte(bb + 96u + k + 4u);
+        let bk8   = read_byte(bb + 96u + k + 8u);
+        scales[k]      = i32((bk  & 0x0Fu) | (((bk8 >> 4u) & 3u) << 4u)) - 32;
+        scales[k + 4u] = i32((bk4 & 0x0Fu) | (((bk8 >> 6u) & 3u) << 4u)) - 32;
+    }
+
+    let out_base = block_idx * 256u;
+
+    for (var oi = 0u; oi < 2u; oi = oi + 1u) {
+        for (var si = 0u; si < 4u; si = si + 1u) {
+            let shift      = si * 2u;
+            let scale_idx  = oi * 4u + si;
+            let m          = 1u << scale_idx;   // hmask bit selector (fits in u8)
+            let d_scale    = d * f32(scales[scale_idx]);
+
+            for (var l = 0u; l < 32u; l = l + 1u) {
+                // qs byte for weight oi*128 + si*32 + l:
+                //   block byte at 32 + oi*32 + l
+                let qs_byte = read_byte(bb + 32u + oi * 32u + l);
+                let low2 = (qs_byte >> shift) & 3u;
+
+                // hmask byte for weight index l within the group:
+                //   block byte at l (same l for all si within same oi)
+                let hmask_byte = read_byte(bb + l);
+                let sub = select(4, 0, (hmask_byte & m) != 0u);
+                let q = i32(low2) - sub;
+
+                output[out_base + oi * 128u + si * 32u + l] = d_scale * f32(q);
+            }
+        }
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -31,6 +31,7 @@ const DEQUANT_MATVEC_Q5K_SHADER: &str = include_str!("../shaders/dequant_matvec_
 const DEQUANT_Q5K_SHADER: &str = include_str!("../shaders/dequant_q5k.wgsl");
 const DEQUANT_Q6K_SHADER: &str = include_str!("../shaders/dequant_q6k.wgsl");
 const PREFILL_ATTENTION_SHADER: &str = include_str!("../shaders/prefill_attention.wgsl");
+const DEQUANT_Q3K_SHADER: &str = include_str!("../shaders/dequant_q3k.wgsl");
 
 /// WebGPU/wgpu compute backend.
 ///
@@ -413,6 +414,61 @@ impl WebGpuBackend {
             "dequant_q6k",
             DEQUANT_Q6K_SHADER,
             "dequant_q6k",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_single_input_bind_group(cached, &raw_buf, &out_buf, &params_buf);
+                let dispatch_x = (num_blocks as u32).div_ceil(64);
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [dispatch_x, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Dequantize Q3_K blocks on the GPU.
+    ///
+    /// Runs `dequant_q3k.wgsl` with one thread per block (workgroup 64, dispatch
+    /// ceil(num_blocks/64) × 1 × 1).  Returns `num_blocks * 256` f32 values.
+    ///
+    /// Q3_K blocks are 110 bytes each (not u32-aligned).  The raw bytes are
+    /// padded to the nearest 4-byte multiple before upload so that the wgpu
+    /// storage buffer size requirement is satisfied.
+    pub fn dequant_q3k(&self, raw_bytes: &[u8], num_blocks: usize) -> Vec<f32> {
+        let output_size = (num_blocks * 256) as u64 * 4;
+
+        // Q3_K blocks are 110 bytes — pad to next multiple of 4 for wgpu.
+        #[allow(clippy::manual_is_multiple_of)]
+        let raw_buf = if raw_bytes.len() % 4 == 0 {
+            self.pool.get_storage(&self.device, &self.queue, raw_bytes)
+        } else {
+            let mut padded = raw_bytes.to_vec();
+            padded.resize((padded.len() + 3) & !3, 0);
+            self.pool.get_storage(&self.device, &self.queue, &padded)
+        };
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 1] = [num_blocks as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::single_input_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_q3k",
+            DEQUANT_Q3K_SHADER,
+            "dequant_q3k",
             &layout_entries,
             |cached| {
                 let bind_group =
@@ -1700,6 +1756,30 @@ mod tests {
         }
     }
 
+    /// Verify Q3_K GPU dequant with a zeroed block (d=0.0 → all outputs = 0.0).
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_q3k_zeroed() {
+        use flare_loader::quantize::dequant_q3k_block;
+
+        let raw = [0u8; 110];
+        let mut cpu_out = [0.0f32; 256];
+        dequant_q3k_block(&raw, &mut cpu_out);
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_q3k(&raw, 1);
+
+        assert_eq!(result.len(), 256);
+        for (j, (&gpu, &cpu)) in result.iter().zip(cpu_out.iter()).enumerate() {
+            assert!(
+                (gpu - cpu).abs() < 1e-3,
+                "q3k zeroed mismatch at [{j}]: gpu={gpu}, cpu={cpu}"
+            );
+        }
+    }
+
     /// Verify fused Q5_K dequant-matvec against the CPU reference.
     ///
     /// Block setup: d=1.0, dmin=0.0, sc[*]=1 (scales_raw[0..4]=0x41), mn[*]=0,
@@ -1767,6 +1847,58 @@ mod tests {
         assert_eq!(result.len(), num_rows);
         for (i, &v) in result.iter().enumerate() {
             assert!((v - 384.0).abs() < 1e-1, "row {i}: got {v}, expected 384.0");
+        }
+    }
+
+    /// Verify Q3_K GPU dequant matches CPU reference with d=1.0 and non-trivial weights.
+    ///
+    /// Block setup: d=1.0, all scales=1 (using kmask encoding), hmask=0xFF (all high bits set,
+    /// so no subtraction), qs all 0x55 (low2=1 for all shift positions).
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_q3k_matches_cpu() {
+        use flare_loader::quantize::dequant_q3k_block;
+
+        let mut raw = [0u8; 110];
+        // d = 1.0 as f16 LE at bytes 108-109
+        raw[108] = 0x00;
+        raw[109] = 0x3C;
+        // hmask[32] = 0xFF: all high bits set → sub=0 for all weights
+        for b in raw[0..32].iter_mut() {
+            *b = 0xFF;
+        }
+        // qs[64] at bytes 32..96 = 0x55 = 0b01010101:
+        //   shift 0 → bits[1:0]=01=1, shift 2 → bits[3:2]=01=1,
+        //   shift 4 → bits[5:4]=01=1, shift 6 → bits[7:6]=01=1
+        for b in raw[32..96].iter_mut() {
+            *b = 0x55;
+        }
+        // scales_raw[12] at bytes 96..108:
+        //   set b[0..8]=0x21 so (0x21 & 0x0F)=1, b[8..12]=0x00 → scales[0..4]=1-32=-31
+        //   For a simple non-zero test, use values that produce known output.
+        //   Instead: set all scales_raw to encode scales[i]=1:
+        //     scales[i] = (b[i] & 0x0F) | extra_bits - 32 = 1
+        //     → raw_val = 33 = 0x21 for b[0..4], b[8..12] bits[7:4]=0
+        for b in raw[96..104].iter_mut() {
+            *b = 0x21; // b[0..7]: low nibble=1 → after extra bits=0: scales[0..7]=1-32=-31
+        }
+        // b[8..12] = 0x00 → extra bits for scales[0..7] = 0
+
+        // CPU reference
+        let mut cpu_out = [0.0f32; 256];
+        dequant_q3k_block(&raw, &mut cpu_out);
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_q3k(&raw, 1);
+
+        assert_eq!(result.len(), 256);
+        for (j, (&gpu, &cpu)) in result.iter().zip(cpu_out.iter()).enumerate() {
+            assert!(
+                (gpu - cpu).abs() < 1e-3,
+                "q3k mismatch at [{j}]: gpu={gpu}, cpu={cpu}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `flare-gpu/shaders/dequant_q3k.wgsl`: GPU dequantization for Q3_K blocks (110 bytes — not u32-aligned)
- Uses byte-offset helper functions (same pattern as Q6_K) to handle non-aligned block layout
- One thread per block, 64-thread workgroups; Rust caller pads to 4-byte multiple before upload
- Adds `WebGpuBackend::dequant_q3k()` in `flare-gpu/src/backend.rs` with two `#[ignore]` GPU tests

## Q3_K Block Layout (110 bytes)
- `hmask[32]`: bytes 0–31 — high bit (bit 2) per weight, 8 per byte
- `qs[64]`: bytes 32–95 — low 2 bits per weight, 4 per byte
- `scales[12]`: bytes 96–107 — 8 sub-block scales via kmask transform
- `d[2]`: bytes 108–109 — f16 delta

## Test plan
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] GPU tests (marked `#[ignore]`) pass on hardware with WebGPU support

Closes #143