### PR TITLE
Add batched Q/K/V matmul to reduce per-token GPU dispatch overhead

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -173,6 +173,34 @@ pub trait ComputeBackend: Send + Sync {
         }
         output
     }
+
+    /// Batched matrix-vector multiply: apply the same weight matrix to each row of the input.
+    ///
+    /// For each batch item `b` in `0..batch`:
+    ///   `output[b * out_rows .. (b+1) * out_rows] = weight × input[b * in_cols .. (b+1) * in_cols]`
+    ///
+    /// - `weight`: f32 matrix `[out_rows × in_cols]`, row-major
+    /// - `input`:  f32 batch  `[batch × in_cols]`, row-major
+    /// - Returns:  f32 result `[batch × out_rows]`, row-major
+    ///
+    /// GPU backends override this for a single kernel dispatch;
+    /// the default implementation loops over batch items and calls `matvec`.
+    fn batched_matmul(
+        &self,
+        weight: &[f32],
+        input: &[f32],
+        out_rows: usize,
+        in_cols: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        let mut output = vec![0.0f32; batch * out_rows];
+        for b in 0..batch {
+            let in_row = &input[b * in_cols..(b + 1) * in_cols];
+            let out_row = matvec(weight, in_row, out_rows, in_cols);
+            output[b * out_rows..(b + 1) * out_rows].copy_from_slice(&out_row);
+        }
+        output
+    }
 }
 
 /// Default CPU compute backend. Uses optimized scalar loops.
@@ -585,7 +613,7 @@ impl Model {
                     .collect()
             };
 
-            // Q/K/V projections, biases, RoPE — one token at a time
+            // Q/K/V projections: single batched dispatch per matrix, then per-token bias+RoPE.
             let mut q_batch = vec![0.0f32; seq_len * q_dim];
             {
                 let wq: Vec<f32> = self.weights.layers[layer_idx].wq.data().to_vec();
@@ -604,11 +632,21 @@ impl Model {
                     .as_ref()
                     .map(|t| t.data().to_vec());
 
+                // Three GPU dispatches instead of 3 × seq_len individual matvec calls.
+                let q_proj = self
+                    .backend
+                    .batched_matmul(&wq, &normed_batch, q_dim, dim, seq_len);
+                let k_proj = self
+                    .backend
+                    .batched_matmul(&wk, &normed_batch, kv_dim, dim, seq_len);
+                let v_proj = self
+                    .backend
+                    .batched_matmul(&wv, &normed_batch, kv_dim, dim, seq_len);
+
                 for t in 0..seq_len {
-                    let normed = &normed_batch[t * dim..(t + 1) * dim];
-                    let mut q = self.backend.matvec(&wq, normed, q_dim, dim);
-                    let mut k = self.backend.matvec(&wk, normed, kv_dim, dim);
-                    let mut v = self.backend.matvec(&wv, normed, kv_dim, dim);
+                    let mut q = q_proj[t * q_dim..(t + 1) * q_dim].to_vec();
+                    let mut k = k_proj[t * kv_dim..(t + 1) * kv_dim].to_vec();
+                    let mut v = v_proj[t * kv_dim..(t + 1) * kv_dim].to_vec();
 
                     if let Some(ref b) = q_bias {
                         for (qi, &bi) in q.iter_mut().zip(b.iter()) {

--- a/flare-gpu/shaders/batched_matvec.wgsl
+++ b/flare-gpu/shaders/batched_matvec.wgsl
@@ -1,0 +1,81 @@
+// Batched matrix-vector multiply.
+//
+// Computes: output[b * out_rows + i] = Σ_j weight[i * in_cols + j] * input[b * in_cols + j]
+//
+// i.e. for each batch item b, multiply the shared weight matrix W[out_rows × in_cols]
+// by the input row input_batch[b, :] and store the result in output[b, :].
+//
+// Bindings (standard 4-entry layout):
+//   binding 0: weight — f32 matrix [out_rows * in_cols], row-major
+//   binding 1: input  — f32 batch  [batch * in_cols], row-major
+//   binding 2: output — f32 result [batch * out_rows], row-major
+//   binding 3: params — uniform
+//
+// One workgroup per (output_row, batch_item) pair; 64-thread inner dot-product
+// with parallel tree reduction.
+// Dispatch: [out_rows, batch, 1].
+
+@group(0) @binding(0) var<storage, read> weight: array<f32>;
+@group(0) @binding(1) var<storage, read> inp: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    out_rows: u32,
+    in_cols:  u32,
+    batch:    u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+@compute @workgroup_size(64)
+fn batched_matvec(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row       = wid.x;
+    let batch_idx = wid.y;
+
+    if row >= params.out_rows || batch_idx >= params.batch {
+        return;
+    }
+
+    let tid = lid.x;
+    var acc: f32 = 0.0;
+
+    let weight_base = row * params.in_cols;
+    let input_base  = batch_idx * params.in_cols;
+
+    // Each thread strides across in_cols with a step of 64.
+    var j: u32 = tid;
+    loop {
+        if j >= params.in_cols {
+            break;
+        }
+        acc = acc + weight[weight_base + j] * inp[input_base + j];
+        j = j + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u { partials[tid] = partials[tid] + partials[tid + 32u]; }
+    workgroupBarrier();
+    if tid < 16u { partials[tid] = partials[tid] + partials[tid + 16u]; }
+    workgroupBarrier();
+    if tid <  8u { partials[tid] = partials[tid] + partials[tid +  8u]; }
+    workgroupBarrier();
+    if tid <  4u { partials[tid] = partials[tid] + partials[tid +  4u]; }
+    workgroupBarrier();
+    if tid <  2u { partials[tid] = partials[tid] + partials[tid +  2u]; }
+    workgroupBarrier();
+    if tid <  1u { partials[tid] = partials[tid] + partials[tid +  1u]; }
+    workgroupBarrier();
+
+    if tid == 0u {
+        // Row-major output: batch_idx selects the row, row selects the column.
+        output[batch_idx * params.out_rows + row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -32,6 +32,7 @@ const DEQUANT_Q5K_SHADER: &str = include_str!("../shaders/dequant_q5k.wgsl");
 const DEQUANT_Q6K_SHADER: &str = include_str!("../shaders/dequant_q6k.wgsl");
 const PREFILL_ATTENTION_SHADER: &str = include_str!("../shaders/prefill_attention.wgsl");
 const DEQUANT_Q3K_SHADER: &str = include_str!("../shaders/dequant_q3k.wgsl");
+const BATCHED_MATVEC_SHADER: &str = include_str!("../shaders/batched_matvec.wgsl");
 
 /// WebGPU/wgpu compute backend.
 ///
@@ -600,6 +601,67 @@ impl WebGpuBackend {
 
         self.pool.return_storage(raw_buf);
         self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Batched matrix-vector multiply on the GPU.
+    ///
+    /// For each batch item `b` in `0..batch`:
+    ///   `output[b * out_rows + i] = Σ_j weight[i * in_cols + j] * input[b * in_cols + j]`
+    ///
+    /// - `weight`: f32 matrix `[out_rows × in_cols]`, row-major — same for all items
+    /// - `input`:  f32 batch `[batch × in_cols]`, row-major — one row per batch item
+    /// - Returns:  f32 result `[batch × out_rows]`, row-major
+    ///
+    /// Dispatch: `[out_rows, batch, 1]`, workgroup size 64 with tree reduction.
+    pub fn batched_matvec(
+        &self,
+        weight: &[f32],
+        input: &[f32],
+        out_rows: usize,
+        in_cols: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        let output_size = (batch * out_rows) as u64 * 4;
+
+        let weight_buf =
+            self.pool
+                .get_storage(&self.device, &self.queue, bytemuck::cast_slice(weight));
+        let input_buf =
+            self.pool
+                .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 3] = [out_rows as u32, in_cols as u32, batch as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "batched_matvec",
+            BATCHED_MATVEC_SHADER,
+            "batched_matvec",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &weight_buf, &input_buf, &out_buf, &params_buf);
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [out_rows as u32, batch as u32, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(weight_buf);
+        self.pool.return_storage(input_buf);
         self.pool.return_output(out_buf);
         self.pool.return_uniform(params_buf);
 
@@ -1319,6 +1381,17 @@ impl ComputeBackend for WebGpuBackend {
             head_dim,
             attn_softcap,
         )
+    }
+
+    fn batched_matmul(
+        &self,
+        weight: &[f32],
+        input: &[f32],
+        out_rows: usize,
+        in_cols: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        self.batched_matvec(weight, input, out_rows, in_cols, batch)
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds batched_matvec.wgsl: GPU kernel applying a shared weight matrix to a batch of input vectors in a single dispatch
- Adds WebGpuBackend::batched_matvec() and ComputeBackend::batched_matmul() with CPU fallback
- Updates forward_prefill() to use 3 batched dispatches (Q, K, V) instead of 3 * seq_len individual matvec dispatches

## How it works
- Dispatch: [out_rows, batch, 1] workgroups; workgroup size 64 with parallel tree reduction
- One workgroup per (output_row, batch_item) pair -- reduces kernel overhead from O(seq_len) to O(1) per projection per layer
- Bias addition and RoPE remain per-token CPU operations

## Test plan
- cargo test --workspace passes
- cargo clippy --workspace --all-targets -- -D warnings passes
- cargo fmt --check passes

Closes #144