### PR TITLE
Add fused Q6_K dequant+matvec WGSL shader

### DIFF
--- a/flare-gpu/shaders/dequant_matvec_q6k.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q6k.wgsl
@@ -1,0 +1,147 @@
+// Fused Q6_K dequantize + matrix-vector multiply on GPU.
+//
+// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+//
+// Q6_K block layout (210 bytes per block, 256 weights per block):
+//   bytes   0-127: ql[128] — lower 4 bits of 6-bit weights (two interleaved groups of 64)
+//   bytes 128-191: qh[64]  — upper 2 bits of 6-bit weights
+//   bytes 192-207: scales[16] — signed i8 scale per sub-block
+//   bytes 208-209: d (f16 LE)
+//
+// 210 bytes is not u32-aligned.  The Rust caller pads the raw byte buffer to the
+// nearest 4-byte multiple before upload.  Weights are accessed via byte-offset
+// helpers that extract individual bytes from the u32 storage array.
+//
+// Weight reconstruction (mirrors dequant_q6k.wgsl):
+//   For half in 0..2 (each covering 128 output elements):
+//     ql_off = half*64, qh_off = half*32, sc_off = half*8, y_off = half*128
+//     For l in 0..32:
+//       ql_a = ql[ql_off+l], ql_b = ql[ql_off+l+32], qh_b = qh[qh_off+l]
+//       q1 = (ql_a & 0xF)  | ((qh_b & 3)       << 4) − 32
+//       q2 = (ql_b & 0xF)  | (((qh_b >> 2) & 3) << 4) − 32
+//       q3 =  (ql_a >> 4)  | (((qh_b >> 4) & 3) << 4) − 32
+//       q4 =  (ql_b >> 4)  | (((qh_b >> 6) & 3) << 4) − 32
+//       is = l / 16
+//       sc1..sc4 = sign_extend(scales[sc_off+is+{0,2,4,6}])
+//       acc += d*sc1*q1 * vec[b*256 + y_off+l]
+//            + d*sc2*q2 * vec[b*256 + y_off+l+32]
+//            + d*sc3*q3 * vec[b*256 + y_off+l+64]
+//            + d*sc4*q4 * vec[b*256 + y_off+l+96]
+//
+// One workgroup per output row. 64 threads stride across blocks;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
+//   binding 0: raw    — packed Q6_K weight data [num_rows * num_blocks_per_row * 210 bytes, padded]
+//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 256]
+//   binding 2: output — f32 result              [num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+/// Reinterpret an 8-bit unsigned value as a signed 8-bit integer (i32).
+fn sign_extend_byte(b: u32) -> i32 {
+    return bitcast<i32>(b << 24u) >> 24u;
+}
+
+@compute @workgroup_size(64)
+fn dequant_matvec_q6k(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row = wid.x;
+    if row >= params.num_rows {
+        return;
+    }
+
+    let tid = lid.x;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across blocks in this row (64-thread stride).
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Byte offset for this block's start in the raw data (210 bytes per block).
+        let bb = (row * params.num_blocks_per_row + b) * 210u;
+        // Start position in the input vector (256 elements per block).
+        let vec_base = b * 256u;
+
+        // d at bytes 208-209 of this block (LE f16).
+        let d_packed = read_byte(bb + 208u) | (read_byte(bb + 209u) << 8u);
+        let d = unpack2x16float(d_packed).x;
+
+        // Process both halves (0 and 1), each covering 128 output elements.
+        for (var half = 0u; half < 2u; half = half + 1u) {
+            let ql_off = half * 64u;
+            let qh_off = half * 32u;
+            let sc_off = half * 8u;
+            let y_off  = half * 128u;
+
+            for (var l = 0u; l < 32u; l = l + 1u) {
+                let ql_a = read_byte(bb + ql_off + l);
+                let ql_b = read_byte(bb + ql_off + l + 32u);
+                let qh_b = read_byte(bb + 128u + qh_off + l);
+
+                // Assemble 6-bit unsigned values, then offset-binary subtract 32.
+                let q1 = i32((ql_a & 0x0Fu) | ((qh_b & 3u) << 4u)) - 32;
+                let q2 = i32((ql_b & 0x0Fu) | (((qh_b >> 2u) & 3u) << 4u)) - 32;
+                let q3 = i32((ql_a >> 4u)   | (((qh_b >> 4u) & 3u) << 4u)) - 32;
+                let q4 = i32((ql_b >> 4u)   | (((qh_b >> 6u) & 3u) << 4u)) - 32;
+
+                // Signed i8 scales (two scale values per 32-element group, 4 groups per half).
+                let is = l / 16u;
+                let sc1 = sign_extend_byte(read_byte(bb + 192u + sc_off + is));
+                let sc2 = sign_extend_byte(read_byte(bb + 192u + sc_off + is + 2u));
+                let sc3 = sign_extend_byte(read_byte(bb + 192u + sc_off + is + 4u));
+                let sc4 = sign_extend_byte(read_byte(bb + 192u + sc_off + is + 6u));
+
+                acc = acc + d * f32(sc1) * f32(q1) * vec[vec_base + y_off + l];
+                acc = acc + d * f32(sc2) * f32(q2) * vec[vec_base + y_off + l + 32u];
+                acc = acc + d * f32(sc3) * f32(q3) * vec[vec_base + y_off + l + 64u];
+                acc = acc + d * f32(sc4) * f32(q4) * vec[vec_base + y_off + l + 96u];
+            }
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u { partials[tid] = partials[tid] + partials[tid + 32u]; }
+    workgroupBarrier();
+    if tid < 16u { partials[tid] = partials[tid] + partials[tid + 16u]; }
+    workgroupBarrier();
+    if tid <  8u { partials[tid] = partials[tid] + partials[tid +  8u]; }
+    workgroupBarrier();
+    if tid <  4u { partials[tid] = partials[tid] + partials[tid +  4u]; }
+    workgroupBarrier();
+    if tid <  2u { partials[tid] = partials[tid] + partials[tid +  2u]; }
+    workgroupBarrier();
+    if tid <  1u { partials[tid] = partials[tid] + partials[tid +  1u]; }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -28,6 +28,7 @@ const DEQUANT_Q4_1_SHADER: &str = include_str!("../shaders/dequant_q4_1.wgsl");
 const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
 const DEQUANT_MATVEC_Q4K_SHADER: &str = include_str!("../shaders/dequant_matvec_q4k.wgsl");
 const DEQUANT_MATVEC_Q5K_SHADER: &str = include_str!("../shaders/dequant_matvec_q5k.wgsl");
+const DEQUANT_MATVEC_Q6K_SHADER: &str = include_str!("../shaders/dequant_matvec_q6k.wgsl");
 const DEQUANT_Q5K_SHADER: &str = include_str!("../shaders/dequant_q5k.wgsl");
 const DEQUANT_Q6K_SHADER: &str = include_str!("../shaders/dequant_q6k.wgsl");
 const PREFILL_ATTENTION_SHADER: &str = include_str!("../shaders/prefill_attention.wgsl");
@@ -662,6 +663,72 @@ impl WebGpuBackend {
 
         self.pool.return_storage(weight_buf);
         self.pool.return_storage(input_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused Q6_K dequantize + matrix-vector multiply.
+    ///
+    /// Reads packed Q6_K weight data, dequantizes each 210-byte block on-the-fly,
+    /// and accumulates the dot product with `input` in the same kernel.
+    ///
+    /// - `raw_bytes`: packed GGUF data — `num_rows × num_blocks_per_row × 210` bytes
+    ///   (padded to 4-byte multiple by caller if needed)
+    /// - `input`: f32 input vector of length `num_blocks_per_row × 256`
+    /// - Returns `num_rows` f32 dot products
+    pub fn dequant_matvec_q6k(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * 4;
+
+        // Q6_K blocks are 210 bytes — pad to next multiple of 4 for wgpu.
+        #[allow(clippy::manual_is_multiple_of)]
+        let raw_buf = if raw_bytes.len() % 4 == 0 {
+            self.pool.get_storage(&self.device, &self.queue, raw_bytes)
+        } else {
+            let mut padded = raw_bytes.to_vec();
+            padded.resize((padded.len() + 3) & !3, 0);
+            self.pool.get_storage(&self.device, &self.queue, &padded)
+        };
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_q6k",
+            DEQUANT_MATVEC_Q6K_SHADER,
+            "dequant_matvec_q6k",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
+                // One workgroup per output row.
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
         self.pool.return_output(out_buf);
         self.pool.return_uniform(params_buf);
 
@@ -1920,6 +1987,89 @@ mod tests {
         assert_eq!(result.len(), num_rows);
         for (i, &v) in result.iter().enumerate() {
             assert!((v - 384.0).abs() < 1e-1, "row {i}: got {v}, expected 384.0");
+        }
+    }
+
+    /// Verify Q6_K GPU fused dequant+matvec matches CPU reference (dequant then dot product).
+    ///
+    /// Block setup: d=1.0, scales[0..16]=1 (signed i8), ql all 0x22 (both nibbles = 2),
+    /// qh all 0x00 (upper 2 bits = 0).  This gives raw q = (2 | 0) - 32 = -30 for every
+    /// weight.  With input = 1.0 everywhere, expected = 256 * 1.0 * 1 * (-30) = -7680.0.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q6k_matches_cpu() {
+        use flare_loader::quantize::dequant_q6k_block;
+
+        let mut raw = [0u8; 210];
+        // d = 1.0 as f16 LE at bytes 208-209
+        raw[208] = 0x00;
+        raw[209] = 0x3C;
+        // scales[16] at bytes 192-207 = 1 as signed i8
+        for b in raw[192..208].iter_mut() {
+            *b = 1;
+        }
+        // ql[128] at bytes 0-127 = 0x22: both nibbles = 2
+        for b in raw[0..128].iter_mut() {
+            *b = 0x22;
+        }
+        // qh[64] at bytes 128-191 = 0x00: all upper 2 bits = 0
+
+        // CPU reference: dequant then dot product with all-1 input.
+        let mut dequant_out = [0.0f32; 256];
+        dequant_q6k_block(&raw, &mut dequant_out);
+        let expected: f32 = dequant_out.iter().sum(); // input is all 1.0
+
+        let input = [1.0f32; 256];
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q6k(&raw, &input, 1, 1);
+
+        assert_eq!(result.len(), 1, "expected one output value");
+        assert!(
+            (result[0] - expected).abs() < 1e-1,
+            "dequant_matvec_q6k mismatch: got {}, expected {}",
+            result[0],
+            expected
+        );
+    }
+
+    /// Multi-row test: 3 rows × 1 Q6_K block, input = all 1.0.
+    /// All rows should produce the same dot product as the CPU reference.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q6k_multi_row() {
+        use flare_loader::quantize::dequant_q6k_block;
+
+        let mut block = [0u8; 210];
+        block[208] = 0x00;
+        block[209] = 0x3C; // d = 1.0
+        for b in block[192..208].iter_mut() {
+            *b = 1; // scale = 1
+        }
+        for b in block[0..128].iter_mut() {
+            *b = 0x22; // ql nibbles = 2
+        }
+
+        let mut dequant_out = [0.0f32; 256];
+        dequant_q6k_block(&block, &mut dequant_out);
+        let expected: f32 = dequant_out.iter().sum();
+
+        let num_rows = 3usize;
+        let raw: Vec<u8> = block.iter().copied().cycle().take(210 * num_rows).collect();
+        let input = [1.0f32; 256];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q6k(&raw, &input, num_rows, 1);
+
+        assert_eq!(result.len(), num_rows);
+        for (i, &v) in result.iter().enumerate() {
+            assert!(
+                (v - expected).abs() < 1e-1,
+                "row {i}: got {v}, expected {expected}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds dequant_matvec_q6k.wgsl: fused GPU kernel that dequantizes 210-byte Q6_K blocks and accumulates dot product with f32 input in a single pass
- Adds WebGpuBackend::dequant_matvec_q6k() with 4-byte padding for non-aligned block sizes
- Adds two #[ignore] GPU tests cross-validating against the CPU dequant_q6k_block reference

Completes the K-quant fused matvec family (Q4_K #136, Q5_K #142, Q6_K this PR).

Closes #150

## Test plan
- cargo check --workspace --all-targets passes
- cargo fmt clean
- cargo clippy -p flarellm-gpu clean