### PR TITLE
GPU-batched RMSNorm in forward_prefill

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -201,6 +201,30 @@ pub trait ComputeBackend: Send + Sync {
         }
         output
     }
+
+    /// Apply RMSNorm to every row in `input` using the given `weight` vector.
+    ///
+    /// - `input`:  f32 batch `[batch × dim]`, row-major
+    /// - `weight`: f32 norm weights `[dim]`
+    /// - Returns:  f32 result `[batch × dim]`, row-major
+    ///
+    /// GPU backends override this for a single kernel dispatch;
+    /// the default loops over rows and calls the scalar `rmsnorm`.
+    fn batched_rmsnorm(
+        &self,
+        input: &[f32],
+        weight: &[f32],
+        dim: usize,
+        batch: usize,
+        eps: f32,
+    ) -> Vec<f32> {
+        (0..batch)
+            .flat_map(|b| {
+                let row = &input[b * dim..(b + 1) * dim];
+                rmsnorm(row, weight, eps)
+            })
+            .collect()
+    }
 }
 
 /// Default CPU compute backend. Uses optimized scalar loops.
@@ -602,15 +626,16 @@ impl Model {
         for layer_idx in 0..num_layers {
             // --- Attention block ---
 
-            // RMSNorm all rows
+            // RMSNorm all rows — single GPU dispatch.
             let normed_batch: Vec<f32> = {
                 let attn_norm: Vec<f32> = self.weights.layers[layer_idx].attn_norm.data().to_vec();
-                (0..seq_len)
-                    .flat_map(|t| {
-                        let row = &x_batch[t * dim..(t + 1) * dim];
-                        rmsnorm(row, &attn_norm, config.rms_norm_eps)
-                    })
-                    .collect()
+                self.backend.batched_rmsnorm(
+                    &x_batch,
+                    &attn_norm,
+                    dim,
+                    seq_len,
+                    config.rms_norm_eps,
+                )
             };
 
             // Q/K/V projections: single batched dispatch per matrix, then per-token bias+RoPE.
@@ -714,12 +739,8 @@ impl Model {
             // --- FFN block ---
             let normed_batch2: Vec<f32> = {
                 let ffn_norm: Vec<f32> = self.weights.layers[layer_idx].ffn_norm.data().to_vec();
-                (0..seq_len)
-                    .flat_map(|t| {
-                        let row = &x_batch[t * dim..(t + 1) * dim];
-                        rmsnorm(row, &ffn_norm, config.rms_norm_eps)
-                    })
-                    .collect()
+                self.backend
+                    .batched_rmsnorm(&x_batch, &ffn_norm, dim, seq_len, config.rms_norm_eps)
             };
 
             {

--- a/flare-gpu/shaders/batched_rmsnorm.wgsl
+++ b/flare-gpu/shaders/batched_rmsnorm.wgsl
@@ -1,0 +1,84 @@
+// Batched RMSNorm.
+//
+// Computes for each token t in 0..batch:
+//   rms   = sqrt(mean_squares(input[t, :]) + eps)
+//   output[t, i] = input[t, i] / rms * weight[i]
+//
+// Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
+//   binding 0: input  — f32 batch [batch * dim], row-major
+//   binding 1: weight — f32 norm weights [dim]
+//   binding 2: output — f32 result [batch * dim], row-major
+//   binding 3: params — uniform
+//
+// One workgroup per batch item. 64 threads compute partial sums via tree reduction
+// to obtain the mean-square; then each thread writes its normalised + scaled outputs.
+// Dispatch: [batch, 1, 1].
+
+@group(0) @binding(0) var<storage, read> inp: array<f32>;
+@group(0) @binding(1) var<storage, read> weight: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    dim:   u32,
+    batch: u32,
+    eps:   f32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+@compute @workgroup_size(64)
+fn batched_rmsnorm(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let tok = wid.x;
+    if tok >= params.batch {
+        return;
+    }
+
+    let tid  = lid.x;
+    let base = tok * params.dim;
+
+    // Each thread strides across the row accumulating its partial sum of squares.
+    var ss: f32 = 0.0;
+    var i: u32 = tid;
+    loop {
+        if i >= params.dim {
+            break;
+        }
+        let v = inp[base + i];
+        ss = ss + v * v;
+        i = i + 64u;
+    }
+
+    partials[tid] = ss;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u { partials[tid] = partials[tid] + partials[tid + 32u]; }
+    workgroupBarrier();
+    if tid < 16u { partials[tid] = partials[tid] + partials[tid + 16u]; }
+    workgroupBarrier();
+    if tid <  8u { partials[tid] = partials[tid] + partials[tid +  8u]; }
+    workgroupBarrier();
+    if tid <  4u { partials[tid] = partials[tid] + partials[tid +  4u]; }
+    workgroupBarrier();
+    if tid <  2u { partials[tid] = partials[tid] + partials[tid +  2u]; }
+    workgroupBarrier();
+    if tid <  1u { partials[tid] = partials[tid] + partials[tid +  1u]; }
+    workgroupBarrier();
+
+    let rms_inv = 1.0 / sqrt(partials[0u] / f32(params.dim) + params.eps);
+
+    // Write normalised + scaled outputs.
+    var j: u32 = tid;
+    loop {
+        if j >= params.dim {
+            break;
+        }
+        output[base + j] = inp[base + j] * rms_inv * weight[j];
+        j = j + 64u;
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -34,6 +34,7 @@ const DEQUANT_Q6K_SHADER: &str = include_str!("../shaders/dequant_q6k.wgsl");
 const PREFILL_ATTENTION_SHADER: &str = include_str!("../shaders/prefill_attention.wgsl");
 const DEQUANT_Q3K_SHADER: &str = include_str!("../shaders/dequant_q3k.wgsl");
 const BATCHED_MATVEC_SHADER: &str = include_str!("../shaders/batched_matvec.wgsl");
+const BATCHED_RMSNORM_SHADER: &str = include_str!("../shaders/batched_rmsnorm.wgsl");
 
 /// WebGPU/wgpu compute backend.
 ///
@@ -729,6 +730,66 @@ impl WebGpuBackend {
 
         self.pool.return_storage(raw_buf);
         self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Apply RMSNorm to every row in `input` using the given `weight` vector.
+    ///
+    /// - `input`:  f32 batch `[batch × dim]`, row-major
+    /// - `weight`: f32 norm weights `[dim]`
+    /// - Returns:  f32 result `[batch × dim]`, row-major
+    ///
+    /// Dispatches one workgroup per batch row; 64 threads compute a parallel
+    /// sum-of-squares via tree reduction, then each thread writes its outputs.
+    pub fn batched_rmsnorm(
+        &self,
+        input: &[f32],
+        weight: &[f32],
+        dim: usize,
+        batch: usize,
+        eps: f32,
+    ) -> Vec<f32> {
+        let output_size = (batch * dim) as u64 * 4;
+
+        let inp_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let wt_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(weight));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 3] = [dim as u32, batch as u32, eps.to_bits()];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "batched_rmsnorm",
+            BATCHED_RMSNORM_SHADER,
+            "batched_rmsnorm",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &inp_buf, &wt_buf, &out_buf, &params_buf);
+                // One workgroup per batch row.
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [batch as u32, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(inp_buf);
+        self.pool.return_storage(wt_buf);
         self.pool.return_output(out_buf);
         self.pool.return_uniform(params_buf);
 
@@ -1460,6 +1521,17 @@ impl ComputeBackend for WebGpuBackend {
     ) -> Vec<f32> {
         self.batched_matvec(weight, input, out_rows, in_cols, batch)
     }
+
+    fn batched_rmsnorm(
+        &self,
+        input: &[f32],
+        weight: &[f32],
+        dim: usize,
+        batch: usize,
+        eps: f32,
+    ) -> Vec<f32> {
+        WebGpuBackend::batched_rmsnorm(self, input, weight, dim, batch, eps)
+    }
 }
 
 // WASM is single-threaded; wgpu's JS-backed types don't impl Send/Sync but it's
@@ -2069,6 +2141,46 @@ mod tests {
             assert!(
                 (v - expected).abs() < 1e-1,
                 "row {i}: got {v}, expected {expected}"
+            );
+        }
+    }
+
+    /// Verify GPU batched_rmsnorm matches CPU rmsnorm for a 3-row × 4-dim batch.
+    ///
+    /// Input rows: [1,2,3,4], [2,2,2,2], [3,3,3,3].
+    /// Weight: [1,1,1,1] (identity scaling).
+    /// Expected: each row normalised to unit RMS.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_batched_rmsnorm_matches_cpu() {
+        use flare_core::model::rmsnorm;
+
+        let dim = 4usize;
+        let batch = 3usize;
+        let eps = 1e-5f32;
+        let weight = [1.0f32; 4];
+
+        let input: Vec<f32> = vec![
+            1.0, 2.0, 3.0, 4.0, // row 0
+            2.0, 2.0, 2.0, 2.0, // row 1
+            3.0, 3.0, 3.0, 3.0, // row 2
+        ];
+
+        // CPU reference.
+        let expected: Vec<f32> = (0..batch)
+            .flat_map(|b| rmsnorm(&input[b * dim..(b + 1) * dim], &weight, eps))
+            .collect();
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.batched_rmsnorm(&input, &weight, dim, batch, eps);
+
+        assert_eq!(result.len(), batch * dim);
+        for (i, (&got, &exp)) in result.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (got - exp).abs() < 1e-4,
+                "index {i}: got {got}, expected {exp}"
             );
         }
     }


### PR DESCRIPTION
Add batched_rmsnorm WGSL shader (64-thread workgroup with tree reduction) and ComputeBackend method. Replace the two per-token CPU rmsnorm loops in forward_prefill with single GPU dispatches per norm pass. For a 512-token prefill this cuts norm overhead from 2*512 CPU calls to 2 GPU dispatches per layer.

Closes #154