### PR TITLE
GPU-batched RoPE in forward_prefill

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -225,6 +225,35 @@ pub trait ComputeBackend: Send + Sync {
             })
             .collect()
     }
+
+    /// Apply RoPE to every token in `inp` (laid out as `[seq_len × num_heads × head_dim]`).
+    ///
+    /// Token `t` gets position `start_pos + t`.  Returns a new buffer of the same shape.
+    ///
+    /// GPU backends override this for a single kernel dispatch;
+    /// the default loops over tokens and calls `apply_rope`.
+    fn batched_rope(
+        &self,
+        inp: &[f32],
+        num_heads: usize,
+        head_dim: usize,
+        seq_len: usize,
+        start_pos: usize,
+        theta: f32,
+    ) -> Vec<f32> {
+        let stride = num_heads * head_dim;
+        let mut output = inp.to_vec();
+        for t in 0..seq_len {
+            apply_rope(
+                &mut output[t * stride..(t + 1) * stride],
+                num_heads,
+                head_dim,
+                start_pos + t,
+                theta,
+            );
+        }
+        output
+    }
 }
 
 /// Default CPU compute backend. Uses optimized scalar loops.
@@ -668,34 +697,59 @@ impl Model {
                     .backend
                     .batched_matmul(&wv, &normed_batch, kv_dim, dim, seq_len);
 
-                for t in 0..seq_len {
-                    let mut q = q_proj[t * q_dim..(t + 1) * q_dim].to_vec();
-                    let mut k = k_proj[t * kv_dim..(t + 1) * kv_dim].to_vec();
-                    let mut v = v_proj[t * kv_dim..(t + 1) * kv_dim].to_vec();
-
-                    if let Some(ref b) = q_bias {
-                        for (qi, &bi) in q.iter_mut().zip(b.iter()) {
+                // Apply biases in-place (CPU broadcast, cheap; rare in most models).
+                let mut q_proj = q_proj;
+                let mut k_proj = k_proj;
+                let mut v_proj = v_proj;
+                if let Some(ref b) = q_bias {
+                    for t in 0..seq_len {
+                        let row = &mut q_proj[t * q_dim..(t + 1) * q_dim];
+                        for (qi, &bi) in row.iter_mut().zip(b.iter()) {
                             *qi += bi;
                         }
                     }
-                    if let Some(ref b) = k_bias {
-                        for (ki, &bi) in k.iter_mut().zip(b.iter()) {
+                }
+                if let Some(ref b) = k_bias {
+                    for t in 0..seq_len {
+                        let row = &mut k_proj[t * kv_dim..(t + 1) * kv_dim];
+                        for (ki, &bi) in row.iter_mut().zip(b.iter()) {
                             *ki += bi;
                         }
                     }
-                    if let Some(ref b) = v_bias {
-                        for (vi, &bi) in v.iter_mut().zip(b.iter()) {
+                }
+                if let Some(ref b) = v_bias {
+                    for t in 0..seq_len {
+                        let row = &mut v_proj[t * kv_dim..(t + 1) * kv_dim];
+                        for (vi, &bi) in row.iter_mut().zip(b.iter()) {
                             *vi += bi;
                         }
                     }
+                }
 
-                    // RoPE at absolute position t (position within the prompt)
-                    apply_rope(&mut q, num_heads, head_dim, t, config.rope_theta);
-                    apply_rope(&mut k, num_kv_heads, head_dim, t, config.rope_theta);
+                // RoPE: single GPU dispatch instead of 2 × seq_len CPU calls.
+                let q_roped = self.backend.batched_rope(
+                    &q_proj,
+                    num_heads,
+                    head_dim,
+                    seq_len,
+                    0,
+                    config.rope_theta,
+                );
+                let k_roped = self.backend.batched_rope(
+                    &k_proj,
+                    num_kv_heads,
+                    head_dim,
+                    seq_len,
+                    0,
+                    config.rope_theta,
+                );
 
-                    q_batch[t * q_dim..(t + 1) * q_dim].copy_from_slice(&q);
-                    k_all[layer_idx][t * kv_dim..(t + 1) * kv_dim].copy_from_slice(&k);
-                    v_all[layer_idx][t * kv_dim..(t + 1) * kv_dim].copy_from_slice(&v);
+                q_batch.copy_from_slice(&q_roped);
+                for t in 0..seq_len {
+                    k_all[layer_idx][t * kv_dim..(t + 1) * kv_dim]
+                        .copy_from_slice(&k_roped[t * kv_dim..(t + 1) * kv_dim]);
+                    v_all[layer_idx][t * kv_dim..(t + 1) * kv_dim]
+                        .copy_from_slice(&v_proj[t * kv_dim..(t + 1) * kv_dim]);
                 }
             }
 

--- a/flare-gpu/shaders/batched_rope.wgsl
+++ b/flare-gpu/shaders/batched_rope.wgsl
@@ -1,0 +1,60 @@
+// Batched Rotary Position Embedding (RoPE).
+//
+// Applies RoPE to a batch of token vectors. Each token t in 0..seq_len
+// gets position (start_pos + t).
+//
+// The input is laid out as [seq_len * num_heads * head_dim], row-major.
+// Each thread handles one (element, head, token) rotation pair:
+//   idx = t * num_heads * head_dim + h * head_dim + i
+//   idx + half = t * num_heads * head_dim + h * head_dim + i + half_dim
+//
+// Bindings (3-entry layout: 1 read-only, 1 read-write, 1 uniform):
+//   binding 0: inp    — f32 input  [seq_len * num_heads * head_dim]
+//   binding 1: output — f32 result [seq_len * num_heads * head_dim]
+//   binding 2: params — uniform
+//
+// Dispatch: [seq_len * num_heads * head_dim / 2, 1, 1].
+
+@group(0) @binding(0) var<storage, read>       inp:    array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_heads: u32,
+    head_dim:  u32,
+    seq_len:   u32,
+    start_pos: u32,
+    theta:     f32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(64)
+fn batched_rope(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+    let half = params.head_dim / 2u;
+    let stride = params.num_heads * params.head_dim;
+
+    // Thread gid.x covers one rotation pair: element i within head h of token t.
+    let i = gid.x % half;
+    let h = (gid.x / half) % params.num_heads;
+    let t = gid.x / (params.num_heads * half);
+
+    if t >= params.seq_len {
+        return;
+    }
+
+    let pos  = params.start_pos + t;
+    let freq = 1.0 / pow(params.theta, f32(2u * i) / f32(params.head_dim));
+    let angle = f32(pos) * freq;
+    let cos_val = cos(angle);
+    let sin_val = sin(angle);
+
+    let base = t * stride + h * params.head_dim;
+    let idx0  = base + i;
+    let idx1  = base + i + half;
+
+    let v0 = inp[idx0];
+    let v1 = inp[idx1];
+    output[idx0] = v0 * cos_val - v1 * sin_val;
+    output[idx1] = v0 * sin_val + v1 * cos_val;
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -35,6 +35,7 @@ const PREFILL_ATTENTION_SHADER: &str = include_str!("../shaders/prefill_attentio
 const DEQUANT_Q3K_SHADER: &str = include_str!("../shaders/dequant_q3k.wgsl");
 const BATCHED_MATVEC_SHADER: &str = include_str!("../shaders/batched_matvec.wgsl");
 const BATCHED_RMSNORM_SHADER: &str = include_str!("../shaders/batched_rmsnorm.wgsl");
+const BATCHED_ROPE_SHADER: &str = include_str!("../shaders/batched_rope.wgsl");
 
 /// WebGPU/wgpu compute backend.
 ///
@@ -664,6 +665,70 @@ impl WebGpuBackend {
 
         self.pool.return_storage(weight_buf);
         self.pool.return_storage(input_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Apply RoPE to a batch of token vectors.
+    ///
+    /// `inp` is laid out as `[seq_len × num_heads × head_dim]`. Token `t` gets
+    /// position `start_pos + t`. Returns a new buffer with the same shape.
+    ///
+    /// Dispatches `seq_len × num_heads × head_dim/2` threads; each thread
+    /// handles one rotation pair (element i, i + head_dim/2) for one token.
+    pub fn batched_rope(
+        &self,
+        inp: &[f32],
+        num_heads: usize,
+        head_dim: usize,
+        seq_len: usize,
+        start_pos: usize,
+        theta: f32,
+    ) -> Vec<f32> {
+        let total = seq_len * num_heads * head_dim;
+        let output_size = total as u64 * 4;
+
+        let inp_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(inp));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 5] = [
+            num_heads as u32,
+            head_dim as u32,
+            seq_len as u32,
+            start_pos as u32,
+            theta.to_bits(),
+        ];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::single_input_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "batched_rope",
+            BATCHED_ROPE_SHADER,
+            "batched_rope",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_single_input_bind_group(cached, &inp_buf, &out_buf, &params_buf);
+                let half = (head_dim / 2) as u32;
+                let dispatch_x = (seq_len as u32 * num_heads as u32 * half).div_ceil(64);
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [dispatch_x, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(inp_buf);
         self.pool.return_output(out_buf);
         self.pool.return_uniform(params_buf);
 
@@ -1532,6 +1597,18 @@ impl ComputeBackend for WebGpuBackend {
     ) -> Vec<f32> {
         WebGpuBackend::batched_rmsnorm(self, input, weight, dim, batch, eps)
     }
+
+    fn batched_rope(
+        &self,
+        inp: &[f32],
+        num_heads: usize,
+        head_dim: usize,
+        seq_len: usize,
+        start_pos: usize,
+        theta: f32,
+    ) -> Vec<f32> {
+        WebGpuBackend::batched_rope(self, inp, num_heads, head_dim, seq_len, start_pos, theta)
+    }
 }
 
 // WASM is single-threaded; wgpu's JS-backed types don't impl Send/Sync but it's
@@ -1912,6 +1989,49 @@ mod tests {
 
     /// Verify GPU batched prefill attention matches the CPU reference.
     ///
+    /// Verify GPU batched_rope matches CPU apply_rope for seq_len=3, num_heads=2, head_dim=4.
+    ///
+    /// Input: constant 1.0 across all elements. Checks that each token's rotation
+    /// matches the per-token CPU reference.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_batched_rope_matches_cpu() {
+        use flare_core::model::apply_rope;
+
+        let seq_len = 3usize;
+        let num_heads = 2usize;
+        let head_dim = 4usize;
+        let theta = 10000.0f32;
+        let stride = num_heads * head_dim;
+
+        let inp = vec![1.0f32; seq_len * stride];
+
+        // CPU reference: apply_rope per token.
+        let mut expected = inp.clone();
+        for t in 0..seq_len {
+            apply_rope(
+                &mut expected[t * stride..(t + 1) * stride],
+                num_heads,
+                head_dim,
+                t,
+                theta,
+            );
+        }
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.batched_rope(&inp, num_heads, head_dim, seq_len, 0, theta);
+
+        assert_eq!(result.len(), seq_len * stride);
+        for (i, (&got, &exp)) in result.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (got - exp).abs() < 1e-5,
+                "index {i}: got {got}, expected {exp}"
+            );
+        }
+    }
+
     /// Uses a 3-position, 2-head, head_dim=4 setup:
     ///   Q = K = V = identity-like pattern (ones on diagonal per head).
     ///   Compares GPU output against `cpu_grouped_query_attention` per position.


### PR DESCRIPTION
Add batched_rope WGSL shader (one thread per rotation pair per token) and ComputeBackend method. Replace 2*seq_len per-token apply_rope CPU calls in forward_prefill with 2 GPU dispatches. Biases remain as cheap in-place CPU adds before RoPE.

Closes #155