### PR TITLE
Add fused Q4_1 dequant+matvec WGSL shader

### DIFF
--- a/flare-gpu/shaders/dequant_matvec_q4_1.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q4_1.wgsl
@@ -1,0 +1,116 @@
+// Fused Q4_1 dequantize + matrix-vector multiply on GPU.
+//
+// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+//
+// Q4_1 block layout (20 bytes = 5 u32 per block, 32 weights per block):
+//   u32[0]     : d (f16 LE, lower 16 bits) + m (f16 LE, upper 16 bits)
+//   u32[1..5]  : qs[16] — 4-bit nibbles; byte k → (weight[2k], weight[2k+1])
+//                          lo nibble = weight[2k], hi nibble = weight[2k+1]
+//
+// Weight reconstruction: w[i] = d * q + m, where q ∈ [0, 15].
+//
+// One workgroup per output row. 64 threads split the blocks in the row;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
+//   binding 0: raw    — packed Q4_1 weight data [num_rows * num_blocks_per_row * 5]
+//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 32]
+//   binding 2: output — f32 result              [num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+@compute @workgroup_size(64)
+fn dequant_matvec_q4_1(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row = wid.x;
+    if row >= params.num_rows {
+        return;
+    }
+
+    let tid = lid.x;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across blocks in this row.
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Base offset for this block in the raw u32 array (5 u32 per block).
+        let raw_base = (row * params.num_blocks_per_row + b) * 5u;
+        // Corresponding start position in the input vector (32 elements per block).
+        let vec_base = b * 32u;
+
+        // d and m packed as two f16 in the first u32.
+        let dm = unpack2x16float(raw[raw_base]);
+        let d  = dm.x;
+        let m  = dm.y;
+
+        // Process qs[16]: 4 u32s each containing 4 bytes = 8 nibble-pairs.
+        for (var qi = 0u; qi < 4u; qi = qi + 1u) {
+            let q_u32 = raw[raw_base + 1u + qi];
+            for (var bi = 0u; bi < 4u; bi = bi + 1u) {
+                let byte_val = (q_u32 >> (bi * 8u)) & 0xFFu;
+                let lo = f32(byte_val & 0x0Fu);
+                let hi = f32((byte_val >> 4u) & 0x0Fu);
+                let pos = qi * 8u + bi * 2u;
+
+                let w_lo = d * lo + m;
+                let w_hi = d * hi + m;
+
+                acc = acc + w_lo * vec[vec_base + pos];
+                acc = acc + w_hi * vec[vec_base + pos + 1u];
+            }
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u {
+        partials[tid] = partials[tid] + partials[tid + 32u];
+    }
+    workgroupBarrier();
+    if tid < 16u {
+        partials[tid] = partials[tid] + partials[tid + 16u];
+    }
+    workgroupBarrier();
+    if tid < 8u {
+        partials[tid] = partials[tid] + partials[tid + 8u];
+    }
+    workgroupBarrier();
+    if tid < 4u {
+        partials[tid] = partials[tid] + partials[tid + 4u];
+    }
+    workgroupBarrier();
+    if tid < 2u {
+        partials[tid] = partials[tid] + partials[tid + 2u];
+    }
+    workgroupBarrier();
+    if tid < 1u {
+        partials[tid] = partials[tid] + partials[tid + 1u];
+    }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -26,6 +26,7 @@ const SOFTMAX_SHADER: &str = include_str!("../shaders/softmax.wgsl");
 const ATTENTION_SHADER: &str = include_str!("../shaders/attention.wgsl");
 const DEQUANT_Q4_1_SHADER: &str = include_str!("../shaders/dequant_q4_1.wgsl");
 const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
+const DEQUANT_MATVEC_Q4_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_1.wgsl");
 const DEQUANT_MATVEC_Q4K_SHADER: &str = include_str!("../shaders/dequant_matvec_q4k.wgsl");
 const DEQUANT_MATVEC_Q5K_SHADER: &str = include_str!("../shaders/dequant_matvec_q5k.wgsl");
 const DEQUANT_MATVEC_Q6K_SHADER: &str = include_str!("../shaders/dequant_matvec_q6k.wgsl");
@@ -496,6 +497,64 @@ impl WebGpuBackend {
     }
 
     /// Fused Q4_K dequantize + matrix-vector multiply.
+    /// Fused Q4_1 dequantize + matrix-vector multiply.
+    ///
+    /// Reads packed Q4_1 weight data, dequantizes each block on-the-fly, and
+    /// accumulates the dot product with `input` in the same kernel — halving
+    /// the effective memory bandwidth compared to a separate dequant + matvec.
+    ///
+    /// - `raw_bytes`: packed GGUF tensor data — `num_rows × num_blocks_per_row × 20` bytes
+    /// - `input`: f32 input vector of length `num_blocks_per_row × 32`
+    /// - Returns `num_rows` f32 dot products
+    pub fn dequant_matvec_q4_1(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * 4;
+
+        let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_q4_1",
+            DEQUANT_MATVEC_Q4_1_SHADER,
+            "dequant_matvec_q4_1",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
+                // One workgroup per output row.
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
     ///
     /// Reads packed Q4_K weight data, dequantizes each block on-the-fly, and
     /// accumulates the dot product with `input` in the same kernel — halving
@@ -1749,6 +1808,77 @@ mod tests {
                 "q4_1 hi mismatch at [{}]: got {}, expected 1.0",
                 i * 2 + 1,
                 result[i * 2 + 1]
+            );
+        }
+    }
+
+    /// Verify GPU Q4_1 fused dequant+matvec against CPU reference.
+    ///
+    /// One block: d=1.0, m=0.0, all qs bytes = 0x12 (lo=2, hi=1).
+    /// Input vector: all 1.0.
+    /// Expected dot product: Σ(d*q+m) × 1.0 for all 32 weights.
+    /// = Σ [2, 1, 2, 1, ... (16 pairs)] = 16×2 + 16×1 = 48.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q4_1_matches_cpu() {
+        let mut raw = vec![0u8; 20];
+        // d = 1.0 as f16 LE: 0x3C00 → bytes [0x00, 0x3C]
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // m = 0.0 (already zero)
+        // qs[16]: lo nibble = 2, hi nibble = 1 → byte = 0x12
+        for b in raw[4..20].iter_mut() {
+            *b = 0x12;
+        }
+
+        let input = vec![1.0f32; 32];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q4_1(&raw, &input, 1, 1);
+
+        assert_eq!(result.len(), 1, "expected 1 output");
+        // weights: [2,1]*16 → dot with [1]*32 = 16*2 + 16*1 = 48
+        assert!(
+            (result[0] - 48.0).abs() < 1e-2,
+            "dequant_matvec_q4_1 mismatch: got {}, expected 48.0",
+            result[0]
+        );
+    }
+
+    /// Verify GPU Q4_1 fused dequant+matvec with multiple rows.
+    ///
+    /// Two rows, same block data. Each output should be 48.0.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q4_1_multi_row() {
+        let mut raw = vec![0u8; 40]; // 2 rows × 1 block × 20 bytes
+        for row in 0..2 {
+            let base = row * 20;
+            // d = 1.0 as f16 LE
+            raw[base] = 0x00;
+            raw[base + 1] = 0x3C;
+            // qs: lo=2, hi=1
+            for b in raw[base + 4..base + 20].iter_mut() {
+                *b = 0x12;
+            }
+        }
+
+        let input = vec![1.0f32; 32];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q4_1(&raw, &input, 2, 1);
+
+        assert_eq!(result.len(), 2, "expected 2 outputs");
+        for (i, &v) in result.iter().enumerate() {
+            assert!(
+                (v - 48.0).abs() < 1e-2,
+                "dequant_matvec_q4_1 multi_row mismatch at row {}: got {}, expected 48.0",
+                i,
+                v
             );
         }
     }


### PR DESCRIPTION
## Summary

- Adds `flare-gpu/shaders/dequant_matvec_q4_1.wgsl`: fused kernel that dequantizes Q4_1 blocks on-the-fly and accumulates the dot product in a single GPU pass
- Adds `WebGpuBackend::dequant_matvec_q4_1(raw_bytes, input, num_rows, num_blocks_per_row)` Rust method wiring the shader
- Adds two `#[ignore]` GPU integration tests: single-row and multi-row correctness checks against known values

**Q4_1 layout** (20 bytes = 5 u32 per block, 32 weights): `d` + `m` as packed f16 pair in u32[0], then `qs[16]` nibbles in u32[1..5]. Weight reconstruction: `w[i] = d * q + m`.

**Performance**: halves effective memory bandwidth vs. separate dequant + matvec by streaming directly from quantized blocks without materializing a full f32 weight tensor.

Closes #156

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] `cargo test --workspace` (non-GPU tests) pass
- [ ] `cargo test -p flarellm-gpu -- --ignored` passes (requires GPU adapter)