### PR TITLE
Add fused Q8_1 dequant+matvec WGSL shader

### DIFF
--- a/flare-gpu/shaders/dequant_matvec_q8_1.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q8_1.wgsl
@@ -1,0 +1,111 @@
+// Fused Q8_1 dequantize + matrix-vector multiply on GPU.
+//
+// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+//
+// Q8_1 block layout (36 bytes = 9 u32 per block, 32 weights per block):
+//   u32[0]     : d (f16 LE, lower 16 bits) + s (f16 LE sum, upper 16 bits — unused)
+//   u32[1..9]  : qs[32] — signed int8 values, 4 per u32 in little-endian order
+//
+// Weight reconstruction: w[i] = d * qs[i], where qs[i] is a signed int8 in [-128, 127].
+//
+// Sign extension: extract byte as u32, shift left 24, then arithmetic-right-shift 24.
+//
+// One workgroup per output row. 64 threads split the blocks in the row;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
+//   binding 0: raw    — packed Q8_1 weight data [num_rows * num_blocks_per_row * 9]
+//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 32]
+//   binding 2: output — f32 result              [num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+@compute @workgroup_size(64)
+fn dequant_matvec_q8_1(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row = wid.x;
+    if row >= params.num_rows {
+        return;
+    }
+
+    let tid = lid.x;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across blocks in this row.
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Base offset for this block in the raw u32 array (9 u32 per block).
+        let raw_base = (row * params.num_blocks_per_row + b) * 9u;
+        // Corresponding start position in the input vector (32 elements per block).
+        let vec_base = b * 32u;
+
+        // d from lower 16 bits of u32[0]; s (upper 16 bits) is ignored.
+        let d = unpack2x16float(raw[raw_base]).x;
+
+        // Process qs[32]: 8 u32s each containing 4 signed bytes.
+        for (var qi = 0u; qi < 8u; qi = qi + 1u) {
+            let q_u32 = raw[raw_base + 1u + qi];
+            for (var bi = 0u; bi < 4u; bi = bi + 1u) {
+                let byte_u = (q_u32 >> (bi * 8u)) & 0xFFu;
+                // Sign-extend from 8 bits to 32 bits via arithmetic right shift.
+                let qs_i = bitcast<i32>(byte_u << 24u) >> 24;
+                let w_i  = d * f32(qs_i);
+                let pos  = qi * 4u + bi;
+                acc = acc + w_i * vec[vec_base + pos];
+            }
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u {
+        partials[tid] = partials[tid] + partials[tid + 32u];
+    }
+    workgroupBarrier();
+    if tid < 16u {
+        partials[tid] = partials[tid] + partials[tid + 16u];
+    }
+    workgroupBarrier();
+    if tid < 8u {
+        partials[tid] = partials[tid] + partials[tid + 8u];
+    }
+    workgroupBarrier();
+    if tid < 4u {
+        partials[tid] = partials[tid] + partials[tid + 4u];
+    }
+    workgroupBarrier();
+    if tid < 2u {
+        partials[tid] = partials[tid] + partials[tid + 2u];
+    }
+    workgroupBarrier();
+    if tid < 1u {
+        partials[tid] = partials[tid] + partials[tid + 1u];
+    }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -27,6 +27,7 @@ const ATTENTION_SHADER: &str = include_str!("../shaders/attention.wgsl");
 const DEQUANT_Q4_1_SHADER: &str = include_str!("../shaders/dequant_q4_1.wgsl");
 const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
 const DEQUANT_MATVEC_Q4_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_1.wgsl");
+const DEQUANT_MATVEC_Q8_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q8_1.wgsl");
 const DEQUANT_MATVEC_Q4K_SHADER: &str = include_str!("../shaders/dequant_matvec_q4k.wgsl");
 const DEQUANT_MATVEC_Q5K_SHADER: &str = include_str!("../shaders/dequant_matvec_q5k.wgsl");
 const DEQUANT_MATVEC_Q6K_SHADER: &str = include_str!("../shaders/dequant_matvec_q6k.wgsl");
@@ -532,6 +533,64 @@ impl WebGpuBackend {
             "dequant_matvec_q4_1",
             DEQUANT_MATVEC_Q4_1_SHADER,
             "dequant_matvec_q4_1",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
+                // One workgroup per output row.
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused Q8_1 dequantize + matrix-vector multiply.
+    ///
+    /// Reads packed Q8_1 weight data, dequantizes each block on-the-fly, and
+    /// accumulates the dot product with `input` in the same kernel — halving
+    /// the effective memory bandwidth compared to a separate dequant + matvec.
+    ///
+    /// - `raw_bytes`: packed GGUF tensor data — `num_rows × num_blocks_per_row × 36` bytes
+    /// - `input`: f32 input vector of length `num_blocks_per_row × 32`
+    /// - Returns `num_rows` f32 dot products
+    pub fn dequant_matvec_q8_1(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * 4;
+
+        let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_q8_1",
+            DEQUANT_MATVEC_Q8_1_SHADER,
+            "dequant_matvec_q8_1",
             &layout_entries,
             |cached| {
                 let bind_group =
@@ -1881,6 +1940,73 @@ mod tests {
                 v
             );
         }
+    }
+
+    /// Verify GPU Q8_1 fused dequant+matvec against CPU reference.
+    ///
+    /// One block: d=1.0, qs[0..32] = [0, 1, 2, ..., 31] (ascending int8).
+    /// Input vector: all 1.0.
+    /// Expected dot product: Σ(d * i * 1.0) for i=0..31 = 0+1+…+31 = 496.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q8_1_matches_cpu() {
+        let mut raw = vec![0u8; 36];
+        // d = 1.0 as f16 LE: 0x3C00 → bytes [0x00, 0x3C]
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // s = 0.0 (already zero, bytes 2-3)
+        // qs[32]: values 0..31
+        for i in 0..32usize {
+            raw[4 + i] = i as u8;
+        }
+
+        let input = vec![1.0f32; 32];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q8_1(&raw, &input, 1, 1);
+
+        assert_eq!(result.len(), 1, "expected 1 output");
+        // Σ i for i=0..31 = 31*32/2 = 496
+        assert!(
+            (result[0] - 496.0).abs() < 1e-2,
+            "dequant_matvec_q8_1 mismatch: got {}, expected 496.0",
+            result[0]
+        );
+    }
+
+    /// Verify GPU Q8_1 fused dequant+matvec with negative int8 values.
+    ///
+    /// One block: d=1.0, qs[32] = [-1i8 as u8; 32] = [0xFF; 32].
+    /// Input vector: all 1.0.
+    /// Expected dot product: 32 × (-1) × 1.0 = -32.0.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q8_1_negative_weights() {
+        let mut raw = vec![0u8; 36];
+        // d = 1.0 as f16 LE
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // qs[32] = -1 as i8 = 0xFF
+        for b in raw[4..36].iter_mut() {
+            *b = 0xFF;
+        }
+
+        let input = vec![1.0f32; 32];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q8_1(&raw, &input, 1, 1);
+
+        assert_eq!(result.len(), 1, "expected 1 output");
+        // 32 × (-1.0) = -32.0
+        assert!(
+            (result[0] - (-32.0)).abs() < 1e-2,
+            "dequant_matvec_q8_1 negative mismatch: got {}, expected -32.0",
+            result[0]
+        );
     }
 
     /// Verify GPU Q4_K dequantization against a known reference.


### PR DESCRIPTION
## Summary

- Adds `flare-gpu/shaders/dequant_matvec_q8_1.wgsl`: fused kernel that dequantizes Q8_1 blocks (int8 weights with scale) on-the-fly and accumulates the dot product in a single GPU pass
- Adds `WebGpuBackend::dequant_matvec_q8_1(raw_bytes, input, num_rows, num_blocks_per_row)` Rust method
- Adds two `#[ignore]` GPU integration tests: ascending int8 values and sign extension for negative weights

**Q8_1 layout** (36 bytes = 9 u32 per block, 32 weights): `d` as f16 in u32[0] low bits, `s` (unused) in high bits, `qs[32]` int8 values in u32[1..9]. Weight: `w[i] = d * qs[i]`.

Sign extension uses WGSL arithmetic right-shift: `bitcast<i32>(byte_u << 24u) >> 24`.

Closes #160

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] `cargo test --workspace` (non-GPU tests) pass
- [ ] `cargo test -p flarellm-gpu -- --ignored` passes (requires GPU adapter)