### PR TITLE
Add fused Q4_0 dequant+matvec WGSL shader

### DIFF
--- a/flare-gpu/shaders/dequant_matvec_q4_0.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q4_0.wgsl
@@ -1,0 +1,121 @@
+// Fused Q4_0 dequantize + matrix-vector multiply on GPU.
+//
+// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+//
+// Q4_0 block layout (18 bytes per block, 32 weights per block):
+//   bytes 0-1:  scale (f16 LE)
+//   bytes 2-17: qs[16] — 4-bit nibbles; byte k → (weight[2k], weight[2k+1])
+//                         lo nibble = weight[2k], hi nibble = weight[2k+1]
+//
+// Weight reconstruction: w[i] = scale * (q - 8), where q ∈ [0, 15].
+// The nibbles are unsigned in [0,15]; subtracting 8 centers them at zero.
+//
+// 18 bytes is not u32-aligned.  The Rust caller pads the raw byte buffer to
+// the nearest 4-byte multiple before upload.  Weights are accessed via
+// byte-offset helpers that extract individual bytes from the u32 storage array.
+//
+// One workgroup per output row. 64 threads split the blocks in the row;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
+//   binding 0: raw    — packed Q4_0 weight data [num_rows * num_blocks_per_row * 18 bytes, padded]
+//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 32]
+//   binding 2: output — f32 result              [num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+@compute @workgroup_size(64)
+fn dequant_matvec_q4_0(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row = wid.x;
+    if row >= params.num_rows {
+        return;
+    }
+
+    let tid = lid.x;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across blocks in this row.
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Absolute byte offset of this block in the raw buffer (18 bytes per block).
+        let bb = (row * params.num_blocks_per_row + b) * 18u;
+        // Corresponding start in the input vector (32 elements per block).
+        let vec_base = b * 32u;
+
+        // Scale: f16 LE at bytes 0-1 of the block.
+        // Read as a u16 from two consecutive bytes, then reinterpret as f16.
+        let scale_bits = read_byte(bb) | (read_byte(bb + 1u) << 8u);
+        let scale = unpack2x16float(scale_bits).x;
+
+        // Process qs[16]: bytes 2-17 of the block.
+        for (var k = 0u; k < 16u; k = k + 1u) {
+            let byte_val = read_byte(bb + 2u + k);
+            // Unsigned nibbles centered at 8: subtract 8 → signed range [-8, 7].
+            let lo_i = i32(byte_val & 0x0Fu) - 8;
+            let hi_i = i32((byte_val >> 4u) & 0x0Fu) - 8;
+            let w_lo = scale * f32(lo_i);
+            let w_hi = scale * f32(hi_i);
+            acc = acc + w_lo * vec[vec_base + k * 2u];
+            acc = acc + w_hi * vec[vec_base + k * 2u + 1u];
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u {
+        partials[tid] = partials[tid] + partials[tid + 32u];
+    }
+    workgroupBarrier();
+    if tid < 16u {
+        partials[tid] = partials[tid] + partials[tid + 16u];
+    }
+    workgroupBarrier();
+    if tid < 8u {
+        partials[tid] = partials[tid] + partials[tid + 8u];
+    }
+    workgroupBarrier();
+    if tid < 4u {
+        partials[tid] = partials[tid] + partials[tid + 4u];
+    }
+    workgroupBarrier();
+    if tid < 2u {
+        partials[tid] = partials[tid] + partials[tid + 2u];
+    }
+    workgroupBarrier();
+    if tid < 1u {
+        partials[tid] = partials[tid] + partials[tid + 1u];
+    }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -26,6 +26,7 @@ const SOFTMAX_SHADER: &str = include_str!("../shaders/softmax.wgsl");
 const ATTENTION_SHADER: &str = include_str!("../shaders/attention.wgsl");
 const DEQUANT_Q4_1_SHADER: &str = include_str!("../shaders/dequant_q4_1.wgsl");
 const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
+const DEQUANT_MATVEC_Q4_0_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_0.wgsl");
 const DEQUANT_MATVEC_Q4_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_1.wgsl");
 const DEQUANT_MATVEC_Q8_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q8_1.wgsl");
 const DEQUANT_MATVEC_Q4K_SHADER: &str = include_str!("../shaders/dequant_matvec_q4k.wgsl");
@@ -497,7 +498,75 @@ impl WebGpuBackend {
         result
     }
 
-    /// Fused Q4_K dequantize + matrix-vector multiply.
+    /// Fused Q4_0 dequantize + matrix-vector multiply.
+    ///
+    /// Reads packed Q4_0 weight data, dequantizes each block on-the-fly, and
+    /// accumulates the dot product with `input` in the same kernel.
+    ///
+    /// Q4_0 blocks are 18 bytes each (not u32-aligned). The raw bytes are
+    /// padded to the nearest 4-byte multiple before upload so that the wgpu
+    /// storage buffer size requirement is satisfied.
+    ///
+    /// - `raw_bytes`: packed GGUF tensor data — `num_rows × num_blocks_per_row × 18` bytes
+    /// - `input`: f32 input vector of length `num_blocks_per_row × 32`
+    /// - Returns `num_rows` f32 dot products
+    pub fn dequant_matvec_q4_0(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * 4;
+
+        // Q4_0 blocks are 18 bytes — pad to next multiple of 4 for wgpu.
+        #[allow(clippy::manual_is_multiple_of)]
+        let raw_buf = if raw_bytes.len() % 4 == 0 {
+            self.pool.get_storage(&self.device, &self.queue, raw_bytes)
+        } else {
+            let mut padded = raw_bytes.to_vec();
+            padded.resize((padded.len() + 3) & !3, 0);
+            self.pool.get_storage(&self.device, &self.queue, &padded)
+        };
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_q4_0",
+            DEQUANT_MATVEC_Q4_0_SHADER,
+            "dequant_matvec_q4_0",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
+                // One workgroup per output row.
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
     /// Fused Q4_1 dequantize + matrix-vector multiply.
     ///
     /// Reads packed Q4_1 weight data, dequantizes each block on-the-fly, and
@@ -1869,6 +1938,72 @@ mod tests {
                 result[i * 2 + 1]
             );
         }
+    }
+
+    /// Verify GPU Q4_0 fused dequant+matvec against CPU reference.
+    ///
+    /// One block: scale=1.0, all qs bytes = 0x88 (lo=8, hi=8).
+    /// lo−8=0, hi−8=0 → all weights = 0.0.
+    /// Input vector: all 1.0. Expected dot product: 0.0.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q4_0_zero_weights() {
+        let mut raw = vec![0u8; 18];
+        // scale = 1.0 as f16 LE: 0x3C00 → bytes [0x00, 0x3C]
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // qs[16]: lo=8, hi=8 → byte = 0x88; weight = (q-8)*scale = 0
+        for b in raw[2..18].iter_mut() {
+            *b = 0x88;
+        }
+
+        let input = vec![1.0f32; 32];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q4_0(&raw, &input, 1, 1);
+
+        assert_eq!(result.len(), 1, "expected 1 output");
+        assert!(
+            result[0].abs() < 1e-3,
+            "dequant_matvec_q4_0 zero mismatch: got {}, expected 0.0",
+            result[0]
+        );
+    }
+
+    /// Verify GPU Q4_0 fused dequant+matvec with non-zero weights.
+    ///
+    /// One block: scale=1.0, all qs bytes = 0x9A (lo=10, hi=9).
+    /// weight[lo] = (10−8)*1.0 = 2.0, weight[hi] = (9−8)*1.0 = 1.0.
+    /// Input: all 1.0.
+    /// Expected: 16×2.0 + 16×1.0 = 48.0.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q4_0_nonzero() {
+        let mut raw = vec![0u8; 18];
+        // scale = 1.0 as f16 LE
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // qs: lo nibble = 10 (A), hi nibble = 9 → byte = 0x9A
+        for b in raw[2..18].iter_mut() {
+            *b = 0x9A;
+        }
+
+        let input = vec![1.0f32; 32];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q4_0(&raw, &input, 1, 1);
+
+        assert_eq!(result.len(), 1, "expected 1 output");
+        // 16 pairs: w_lo = 2.0, w_hi = 1.0 → dot = 16*2 + 16*1 = 48
+        assert!(
+            (result[0] - 48.0).abs() < 1e-2,
+            "dequant_matvec_q4_0 nonzero mismatch: got {}, expected 48.0",
+            result[0]
+        );
     }
 
     /// Verify GPU Q4_1 fused dequant+matvec against CPU reference.


### PR DESCRIPTION
## Summary

- Adds `flare-gpu/shaders/dequant_matvec_q4_0.wgsl`: fused kernel that dequantizes Q4_0 blocks on-the-fly and accumulates the dot product in a single GPU pass
- Adds `WebGpuBackend::dequant_matvec_q4_0(raw_bytes, input, num_rows, num_blocks_per_row)` Rust method
- Adds two `#[ignore]` GPU integration tests: zero-weight case and non-zero weights

**Q4_0 layout** (18 bytes per block, 32 weights): `scale` as f16 in bytes 0-1, `qs[16]` nibbles in bytes 2-17. Weight reconstruction: `w[i] = scale * (q − 8)` where q ∈ [0,15] (unsigned nibbles centered at 8).

**Non-alignment**: 18 bytes is not u32-aligned. The Rust method pads the buffer to a multiple of 4 bytes before GPU upload (same pattern as Q6_K). The WGSL shader uses byte-offset helpers (`read_byte(byte_offset)`) to extract scale and nibbles at absolute byte positions.

Closes #161

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] `cargo test --workspace` (non-GPU tests) pass
- [ ] `cargo test -p flarellm-gpu -- --ignored` passes (requires GPU adapter)