### PR TITLE
Add fused Q2_K dequant+matvec WGSL shader

### DIFF
--- a/flare-gpu/shaders/dequant_matvec_q2k.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q2k.wgsl
@@ -1,0 +1,129 @@
+// Fused Q2_K dequantize + matrix-vector multiply on GPU.
+//
+// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+//
+// Q2_K block layout (84 bytes = 21 u32 per block, 256 weights per block):
+//   u32[0..16]  : qs[64]    — 2-bit quantized values, 4 weights per byte
+//   u32[16..20] : scales[16]— per-sub-block nibbles: low nibble = scale, high nibble = min
+//   u32[20]     : d (f16 LE, lower 16 bits) + dmin (f16 LE, upper 16 bits)
+//
+// Weight reconstruction: w[i] = d * scale_nibble * q2 − dmin * min_nibble
+//   where:
+//     sub          = i / 16             (sub-block index, 0..15)
+//     scale_nibble = scales[sub] & 0xF
+//     min_nibble   = scales[sub] >> 4
+//     q2           = (qs[i/4] >> ((i % 4) * 2)) & 3
+//
+// One workgroup per output row. 64 threads split the blocks in the row;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
+//   binding 0: raw    — packed Q2_K weight data [num_rows * num_blocks_per_row * 21]
+//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 256]
+//   binding 2: output — f32 result              [num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+@compute @workgroup_size(64)
+fn dequant_matvec_q2k(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row = wid.x;
+    if row >= params.num_rows {
+        return;
+    }
+
+    let tid = lid.x;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across blocks in this row.
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Base offset for this block in the raw u32 array (21 u32 per block).
+        let raw_base = (row * params.num_blocks_per_row + b) * 21u;
+        // Corresponding start in the input vector (256 elements per block).
+        let vec_base = b * 256u;
+
+        // d and dmin packed as two f16 in u32[20].
+        let dm   = unpack2x16float(raw[raw_base + 20u]);
+        let d    = dm.x;
+        let dmin = dm.y;
+
+        // Iterate over 16 sub-blocks; each covers 16 weights from 4 qs bytes.
+        for (var sub = 0u; sub < 16u; sub = sub + 1u) {
+            // scales[16] sit in u32[16..20].
+            // Byte `sub` is at u32[16 + sub/4], bit offset (sub%4)*8.
+            let scale_byte   = (raw[raw_base + 16u + sub / 4u] >> ((sub % 4u) * 8u)) & 0xFFu;
+            let scale_nibble = f32(scale_byte & 0x0Fu);
+            let min_nibble   = f32((scale_byte >> 4u) & 0x0Fu);
+
+            // 4 qs bytes for this sub-block (qs byte indices sub*4 .. sub*4+3).
+            for (var qi = 0u; qi < 4u; qi = qi + 1u) {
+                let k = sub * 4u + qi; // qs byte index (0..63)
+                // qs[64] sit in u32[0..16].
+                // Byte k is at u32[k/4], bit offset (k%4)*8.
+                let qs_val = (raw[raw_base + k / 4u] >> ((k % 4u) * 8u)) & 0xFFu;
+
+                // 4 weights per qs byte; bits 2*bit .. 2*bit+1.
+                for (var bit = 0u; bit < 4u; bit = bit + 1u) {
+                    let q2  = f32((qs_val >> (bit * 2u)) & 3u);
+                    let w   = d * scale_nibble * q2 - dmin * min_nibble;
+                    let idx = sub * 16u + qi * 4u + bit;
+                    acc = acc + w * vec[vec_base + idx];
+                }
+            }
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u {
+        partials[tid] = partials[tid] + partials[tid + 32u];
+    }
+    workgroupBarrier();
+    if tid < 16u {
+        partials[tid] = partials[tid] + partials[tid + 16u];
+    }
+    workgroupBarrier();
+    if tid < 8u {
+        partials[tid] = partials[tid] + partials[tid + 8u];
+    }
+    workgroupBarrier();
+    if tid < 4u {
+        partials[tid] = partials[tid] + partials[tid + 4u];
+    }
+    workgroupBarrier();
+    if tid < 2u {
+        partials[tid] = partials[tid] + partials[tid + 2u];
+    }
+    workgroupBarrier();
+    if tid < 1u {
+        partials[tid] = partials[tid] + partials[tid + 1u];
+    }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -26,6 +26,7 @@ const SOFTMAX_SHADER: &str = include_str!("../shaders/softmax.wgsl");
 const ATTENTION_SHADER: &str = include_str!("../shaders/attention.wgsl");
 const DEQUANT_Q4_1_SHADER: &str = include_str!("../shaders/dequant_q4_1.wgsl");
 const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
+const DEQUANT_MATVEC_Q2K_SHADER: &str = include_str!("../shaders/dequant_matvec_q2k.wgsl");
 const DEQUANT_MATVEC_Q4_0_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_0.wgsl");
 const DEQUANT_MATVEC_Q4_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_1.wgsl");
 const DEQUANT_MATVEC_Q8_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q8_1.wgsl");
@@ -492,6 +493,63 @@ impl WebGpuBackend {
         );
 
         self.pool.return_storage(raw_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused Q2_K dequantize + matrix-vector multiply.
+    ///
+    /// Reads packed Q2_K weight data, dequantizes each block on-the-fly, and
+    /// accumulates the dot product with `input` in the same kernel.
+    ///
+    /// - `raw_bytes`: packed GGUF tensor data — `num_rows × num_blocks_per_row × 84` bytes
+    /// - `input`: f32 input vector of length `num_blocks_per_row × 256`
+    /// - Returns `num_rows` f32 dot products
+    pub fn dequant_matvec_q2k(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * 4;
+
+        let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_q2k",
+            DEQUANT_MATVEC_Q2K_SHADER,
+            "dequant_matvec_q2k",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
+                // One workgroup per output row.
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, 1, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
         self.pool.return_output(out_buf);
         self.pool.return_uniform(params_buf);
 
@@ -1938,6 +1996,86 @@ mod tests {
                 result[i * 2 + 1]
             );
         }
+    }
+
+    /// Verify GPU Q2_K fused dequant+matvec against CPU reference.
+    ///
+    /// One block: d=1.0, dmin=0.0, all scales bytes = 0x01 (scale_nibble=1, min_nibble=0),
+    /// all qs bytes = 0x55 (binary 01010101: each 2-bit group = 1).
+    /// Each weight: d * 1 * 1 − dmin * 0 = 1.0.
+    /// Input vector: all 1.0. Expected dot product: 256 × 1.0 = 256.0.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q2k_matches_cpu() {
+        let mut raw = vec![0u8; 84];
+        // qs[64]: 0x55 = 01010101b → each 2-bit group = 01 = 1
+        for b in raw[0..64].iter_mut() {
+            *b = 0x55;
+        }
+        // scales[16]: scale_nibble=1, min_nibble=0 → byte = 0x01
+        for b in raw[64..80].iter_mut() {
+            *b = 0x01;
+        }
+        // d = 1.0 as f16 LE: 0x3C00 → bytes [0x00, 0x3C]
+        raw[80] = 0x00;
+        raw[81] = 0x3C;
+        // dmin = 0.0 (already zero)
+
+        let input = vec![1.0f32; 256];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q2k(&raw, &input, 1, 1);
+
+        assert_eq!(result.len(), 1, "expected 1 output");
+        // 256 weights each = 1.0 * 1 * 1 - 0 = 1.0; dot with [1]*256 = 256.0
+        assert!(
+            (result[0] - 256.0).abs() < 1e-2,
+            "dequant_matvec_q2k mismatch: got {}, expected 256.0",
+            result[0]
+        );
+    }
+
+    /// Verify GPU Q2_K fused dequant+matvec with non-trivial scales and min.
+    ///
+    /// One block: d=1.0, dmin=1.0, scales[*]=0x12 (scale_nibble=2, min_nibble=1),
+    /// qs[*]=0xAA (binary 10101010: each 2-bit group = 10 = 2).
+    /// weight = d * 2 * 2 − dmin * 1 = 4 − 1 = 3.0.
+    /// Input: all 1.0. Expected: 256 × 3.0 = 768.0.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q2k_with_min() {
+        let mut raw = vec![0u8; 84];
+        // qs[64]: 0xAA = 10101010b → each 2-bit group = 2
+        for b in raw[0..64].iter_mut() {
+            *b = 0xAA;
+        }
+        // scales[16]: scale_nibble=2, min_nibble=1 → byte = 0x12
+        for b in raw[64..80].iter_mut() {
+            *b = 0x12;
+        }
+        // d = 1.0 as f16 LE
+        raw[80] = 0x00;
+        raw[81] = 0x3C;
+        // dmin = 1.0 as f16 LE
+        raw[82] = 0x00;
+        raw[83] = 0x3C;
+
+        let input = vec![1.0f32; 256];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q2k(&raw, &input, 1, 1);
+
+        assert_eq!(result.len(), 1, "expected 1 output");
+        // weight = 1*2*2 - 1*1 = 3.0; dot with [1]*256 = 768.0
+        assert!(
+            (result[0] - 768.0).abs() < 1e-1,
+            "dequant_matvec_q2k with_min mismatch: got {}, expected 768.0",
+            result[0]
+        );
     }
 
     /// Verify GPU Q4_0 fused dequant+matvec against CPU reference.


### PR DESCRIPTION
## Summary

- Adds `flare-gpu/shaders/dequant_matvec_q2k.wgsl`: fused kernel that dequantizes Q2_K blocks on-the-fly and accumulates the dot product in a single GPU pass
- Adds `WebGpuBackend::dequant_matvec_q2k(raw_bytes, input, num_rows, num_blocks_per_row)` Rust method
- Adds two `#[ignore]` GPU integration tests: uniform weights and non-trivial scale+min case

**Q2_K layout** (84 bytes = 21 u32 per block, 256 weights): `qs[64]` (2-bit values, 4/byte) in u32[0..16], `scales[16]` (4-bit nibble pairs) in u32[16..20], `d + dmin` as packed f16 pair in u32[20]. Weight: `w[i] = d * scale_nibble * q2 − dmin * min_nibble`.

84 bytes is u32-aligned, so no byte-offset helpers are needed — all fields accessed directly via u32 indexing.

Closes #162

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] `cargo test --workspace` (non-GPU tests) pass
- [ ] `cargo test -p flarellm-gpu -- --ignored` passes (requires GPU adapter)