### PR TITLE
Wire quantized weights into forward pass (fused dequant+matvec)

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -2,6 +2,57 @@ use crate::config::{Architecture, ModelConfig};
 use crate::kv_cache::KvCache;
 use crate::tensor::Tensor;
 
+/// Identifies the quantization format for a raw weight tensor stored on the GPU path.
+///
+/// Only formats with a corresponding fused dequant+matvec GPU kernel are listed here.
+/// Other quantization formats must be dequantized to f32 at load time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WeightFormat {
+    Q2K,
+    Q4_0,
+    Q4_1,
+    Q4K,
+    Q5K,
+    Q6K,
+    Q8_1,
+}
+
+impl WeightFormat {
+    /// Number of weights per block for this format.
+    pub fn weights_per_block(self) -> usize {
+        match self {
+            WeightFormat::Q2K | WeightFormat::Q4K | WeightFormat::Q5K | WeightFormat::Q6K => 256,
+            WeightFormat::Q4_0 | WeightFormat::Q4_1 | WeightFormat::Q8_1 => 32,
+        }
+    }
+}
+
+/// Raw (undequantized) weight tensor for GPU fused dequant+matvec.
+///
+/// Stores the original GGUF bytes alongside the metadata needed to dispatch
+/// the correct GPU shader.  Memory footprint is ~4× smaller than the
+/// equivalent f32 `Tensor` for 4-bit quantized weights.
+pub struct RawWeight {
+    pub data: Vec<u8>,
+    pub format: WeightFormat,
+    /// Number of output rows (size of the output vector for a single matvec).
+    pub num_rows: usize,
+    /// Number of quantized blocks per row.
+    pub blocks_per_row: usize,
+}
+
+/// Per-layer raw quantized weights.  Mirrors `LayerWeights` but stores bytes
+/// instead of f32 tensors for the projection matrices.
+pub struct RawLayerWeights {
+    pub wq: RawWeight,
+    pub wk: RawWeight,
+    pub wv: RawWeight,
+    pub wo: RawWeight,
+    pub w_gate: RawWeight,
+    pub w_up: RawWeight,
+    pub w_down: RawWeight,
+}
+
 /// Trait for compute backends (WebGPU, SIMD, native wgpu).
 /// Each backend implements these fundamental operations.
 pub trait ComputeBackend: Send + Sync {
@@ -254,6 +305,35 @@ pub trait ComputeBackend: Send + Sync {
         }
         output
     }
+
+    /// Returns `true` if this backend can execute `batched_dequant_matmul`.
+    ///
+    /// The default CPU backend returns `false`; GPU backends override to `true`.
+    fn supports_dequant_matmul(&self) -> bool {
+        false
+    }
+
+    /// Fused dequantize + batched matrix-vector multiply for a raw weight tensor.
+    ///
+    /// For each batch item `b` in `0..batch`:
+    /// ```text
+    /// output[b * weight.num_rows .. (b+1) * weight.num_rows]
+    ///   = dequant_matvec(weight, input[b * in_cols .. (b+1) * in_cols])
+    /// ```
+    /// where `in_cols = weight.blocks_per_row × weight.format.weights_per_block()`.
+    ///
+    /// The default implementation panics — override in GPU backends.
+    fn batched_dequant_matmul(
+        &self,
+        _weight: &RawWeight,
+        _input: &[f32],
+        _batch: usize,
+    ) -> Vec<f32> {
+        panic!(
+            "batched_dequant_matmul is not implemented for this backend; \
+             call Model::set_backend with a GPU backend before using quantized weights"
+        )
+    }
 }
 
 /// Default CPU compute backend. Uses optimized scalar loops.
@@ -362,6 +442,13 @@ pub struct ModelWeights {
 pub struct Model {
     config: ModelConfig,
     weights: ModelWeights,
+    /// Optional raw (quantized) layer weights for GPU fused dequant+matvec.
+    ///
+    /// When set alongside a backend that supports `batched_dequant_matmul`,
+    /// `forward_prefill` uses the fused GPU kernels instead of the f32 weights,
+    /// reducing memory bandwidth.  The f32 weights are still kept to support
+    /// the single-token `forward` path and CPU fallback.
+    raw_weights: Option<Vec<RawLayerWeights>>,
     kv_cache: KvCache,
     backend: Box<dyn ComputeBackend>,
 }
@@ -377,9 +464,29 @@ impl Model {
         Self {
             config,
             weights,
+            raw_weights: None,
             kv_cache,
             backend: Box::new(CpuBackend),
         }
+    }
+
+    /// Attach raw quantized weights for GPU fused-kernel inference.
+    ///
+    /// When a GPU backend is set and `raw_weights` is `Some`, `forward_prefill`
+    /// will use the fused dequant+matvec shaders instead of the f32 projection
+    /// matrices, saving memory bandwidth.
+    pub fn set_raw_weights(&mut self, raw: Vec<RawLayerWeights>) {
+        self.raw_weights = Some(raw);
+    }
+
+    /// Remove raw weights, reverting to the f32 weight path.
+    pub fn clear_raw_weights(&mut self) {
+        self.raw_weights = None;
+    }
+
+    /// Returns `true` if raw quantized weights have been set.
+    pub fn has_raw_weights(&self) -> bool {
+        self.raw_weights.is_some()
     }
 
     /// Replace the compute backend (e.g. with a GPU backend).
@@ -668,11 +775,11 @@ impl Model {
             };
 
             // Q/K/V projections: single batched dispatch per matrix, then per-token bias+RoPE.
+            // When raw quantized weights are available and the backend supports fused
+            // dequant+matvec, use that path to reduce memory bandwidth.
+            let use_raw = self.backend.supports_dequant_matmul() && self.raw_weights.is_some();
             let mut q_batch = vec![0.0f32; seq_len * q_dim];
             {
-                let wq: Vec<f32> = self.weights.layers[layer_idx].wq.data().to_vec();
-                let wk: Vec<f32> = self.weights.layers[layer_idx].wk.data().to_vec();
-                let wv: Vec<f32> = self.weights.layers[layer_idx].wv.data().to_vec();
                 let q_bias: Option<Vec<f32>> = self.weights.layers[layer_idx]
                     .attn_q_bias
                     .as_ref()
@@ -687,15 +794,34 @@ impl Model {
                     .map(|t| t.data().to_vec());
 
                 // Three GPU dispatches instead of 3 × seq_len individual matvec calls.
-                let q_proj = self
-                    .backend
-                    .batched_matmul(&wq, &normed_batch, q_dim, dim, seq_len);
-                let k_proj = self
-                    .backend
-                    .batched_matmul(&wk, &normed_batch, kv_dim, dim, seq_len);
-                let v_proj = self
-                    .backend
-                    .batched_matmul(&wv, &normed_batch, kv_dim, dim, seq_len);
+                // Use fused dequant+matvec when raw quantized weights are available.
+                let q_proj = if use_raw {
+                    let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                    self.backend
+                        .batched_dequant_matmul(&rw.wq, &normed_batch, seq_len)
+                } else {
+                    let wq: Vec<f32> = self.weights.layers[layer_idx].wq.data().to_vec();
+                    self.backend
+                        .batched_matmul(&wq, &normed_batch, q_dim, dim, seq_len)
+                };
+                let k_proj = if use_raw {
+                    let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                    self.backend
+                        .batched_dequant_matmul(&rw.wk, &normed_batch, seq_len)
+                } else {
+                    let wk: Vec<f32> = self.weights.layers[layer_idx].wk.data().to_vec();
+                    self.backend
+                        .batched_matmul(&wk, &normed_batch, kv_dim, dim, seq_len)
+                };
+                let v_proj = if use_raw {
+                    let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                    self.backend
+                        .batched_dequant_matmul(&rw.wv, &normed_batch, seq_len)
+                } else {
+                    let wv: Vec<f32> = self.weights.layers[layer_idx].wv.data().to_vec();
+                    self.backend
+                        .batched_matmul(&wv, &normed_batch, kv_dim, dim, seq_len)
+                };
 
                 // Apply biases in-place (CPU broadcast, cheap; rare in most models).
                 let mut q_proj = q_proj;
@@ -767,16 +893,21 @@ impl Model {
 
             // Output projection + optional post-attention norm + residual
             {
-                let wo: Vec<f32> = self.weights.layers[layer_idx].wo.data().to_vec();
                 let post_attn_norm: Option<Vec<f32>> = self.weights.layers[layer_idx]
                     .post_attn_norm
                     .as_ref()
                     .map(|t| t.data().to_vec());
 
                 // Single batched dispatch replaces one matvec per token.
-                let proj_batch =
+                let proj_batch = if use_raw {
+                    let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
                     self.backend
-                        .batched_matmul(&wo, &attn_out_batch, dim, q_dim, seq_len);
+                        .batched_dequant_matmul(&rw.wo, &attn_out_batch, seq_len)
+                } else {
+                    let wo: Vec<f32> = self.weights.layers[layer_idx].wo.data().to_vec();
+                    self.backend
+                        .batched_matmul(&wo, &attn_out_batch, dim, q_dim, seq_len)
+                };
 
                 for t in 0..seq_len {
                     let proj = proj_batch[t * dim..(t + 1) * dim].to_vec();
@@ -798,9 +929,6 @@ impl Model {
             };
 
             {
-                let w_gate: Vec<f32> = self.weights.layers[layer_idx].w_gate.data().to_vec();
-                let w_up: Vec<f32> = self.weights.layers[layer_idx].w_up.data().to_vec();
-                let w_down: Vec<f32> = self.weights.layers[layer_idx].w_down.data().to_vec();
                 let inter = config.intermediate_dim;
                 let post_ffn_norm: Option<Vec<f32>> = self.weights.layers[layer_idx]
                     .post_ffn_norm
@@ -808,12 +936,24 @@ impl Model {
                     .map(|t| t.data().to_vec());
 
                 // Single batched dispatch for gate and up projections.
-                let gate_batch =
+                let gate_batch = if use_raw {
+                    let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
                     self.backend
-                        .batched_matmul(&w_gate, &normed_batch2, inter, dim, seq_len);
-                let up_batch =
+                        .batched_dequant_matmul(&rw.w_gate, &normed_batch2, seq_len)
+                } else {
+                    let w_gate: Vec<f32> = self.weights.layers[layer_idx].w_gate.data().to_vec();
                     self.backend
-                        .batched_matmul(&w_up, &normed_batch2, inter, dim, seq_len);
+                        .batched_matmul(&w_gate, &normed_batch2, inter, dim, seq_len)
+                };
+                let up_batch = if use_raw {
+                    let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                    self.backend
+                        .batched_dequant_matmul(&rw.w_up, &normed_batch2, seq_len)
+                } else {
+                    let w_up: Vec<f32> = self.weights.layers[layer_idx].w_up.data().to_vec();
+                    self.backend
+                        .batched_matmul(&w_up, &normed_batch2, inter, dim, seq_len)
+                };
 
                 // Per-token silu_mul / gelu_mul (CPU arithmetic, no GPU dispatch).
                 let ffn_hidden_batch: Vec<f32> = (0..seq_len)
@@ -829,9 +969,15 @@ impl Model {
                     .collect();
 
                 // Single batched dispatch for the down projection.
-                let down_batch =
+                let down_batch = if use_raw {
+                    let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
                     self.backend
-                        .batched_matmul(&w_down, &ffn_hidden_batch, dim, inter, seq_len);
+                        .batched_dequant_matmul(&rw.w_down, &ffn_hidden_batch, seq_len)
+                } else {
+                    let w_down: Vec<f32> = self.weights.layers[layer_idx].w_down.data().to_vec();
+                    self.backend
+                        .batched_matmul(&w_down, &ffn_hidden_batch, dim, inter, seq_len)
+                };
 
                 for t in 0..seq_len {
                     let down = down_batch[t * dim..(t + 1) * dim].to_vec();

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 
-use flare_core::model::ComputeBackend;
+use flare_core::model::{ComputeBackend, RawWeight, WeightFormat};
 use flare_core::tensor::Tensor;
 use thiserror::Error;
 
@@ -1853,6 +1853,71 @@ impl ComputeBackend for WebGpuBackend {
         theta: f32,
     ) -> Vec<f32> {
         WebGpuBackend::batched_rope(self, inp, num_heads, head_dim, seq_len, start_pos, theta)
+    }
+
+    fn supports_dequant_matmul(&self) -> bool {
+        true
+    }
+
+    fn batched_dequant_matmul(&self, weight: &RawWeight, input: &[f32], batch: usize) -> Vec<f32> {
+        let weights_per_block = weight.format.weights_per_block();
+        let in_cols = weight.blocks_per_row * weights_per_block;
+        let num_rows = weight.num_rows;
+        let mut out = Vec::with_capacity(batch * num_rows);
+
+        // Compute per-row block size in bytes to slice raw weight data per row.
+        let row_bytes = weight.data.len() / num_rows;
+
+        for b in 0..batch {
+            let vec_slice = &input[b * in_cols..(b + 1) * in_cols];
+            let row_result = match weight.format {
+                WeightFormat::Q4_1 => self.dequant_matvec_q4_1(
+                    &weight.data,
+                    vec_slice,
+                    num_rows,
+                    weight.blocks_per_row,
+                ),
+                WeightFormat::Q8_1 => self.dequant_matvec_q8_1(
+                    &weight.data,
+                    vec_slice,
+                    num_rows,
+                    weight.blocks_per_row,
+                ),
+                WeightFormat::Q4_0 => self.dequant_matvec_q4_0(
+                    &weight.data,
+                    vec_slice,
+                    num_rows,
+                    weight.blocks_per_row,
+                ),
+                WeightFormat::Q2K => self.dequant_matvec_q2k(
+                    &weight.data,
+                    vec_slice,
+                    num_rows,
+                    weight.blocks_per_row,
+                ),
+                WeightFormat::Q4K => self.dequant_matvec_q4k(
+                    &weight.data,
+                    vec_slice,
+                    num_rows,
+                    weight.blocks_per_row,
+                ),
+                WeightFormat::Q5K => self.dequant_matvec_q5k(
+                    &weight.data,
+                    vec_slice,
+                    num_rows,
+                    weight.blocks_per_row,
+                ),
+                WeightFormat::Q6K => self.dequant_matvec_q6k(
+                    &weight.data,
+                    vec_slice,
+                    num_rows,
+                    weight.blocks_per_row,
+                ),
+            };
+            let _ = row_bytes; // suppress unused warning
+            out.extend_from_slice(&row_result);
+        }
+        out
     }
 }
 

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 
 use crate::quantize::{self, QuantFormat};
 use flare_core::config::{Architecture, ModelConfig};
+use flare_core::model::{RawLayerWeights, RawWeight, WeightFormat};
 use flare_core::tensor::Tensor;
 
 const GGUF_MAGIC: u32 = 0x46554747; // "GGUF" as little-endian u32 (bytes: 47 47 55 46)
@@ -329,6 +330,97 @@ impl GgufFile {
             tensors.insert(info.name.clone(), tensor);
         }
         Ok(tensors)
+    }
+
+    /// Read a single tensor's raw bytes without dequantizing, along with its
+    /// shape and quantization format.
+    ///
+    /// Returns `None` if the tensor name is not found or the format is not one
+    /// of the GPU-accelerated formats supported by `WeightFormat`.
+    pub fn read_raw_weight<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        name: &str,
+    ) -> Result<Option<RawWeight>, GgufError> {
+        let info = match self.tensors.iter().find(|t| t.name == name) {
+            Some(i) => i,
+            None => return Ok(None),
+        };
+        let format = match quant_to_weight_format(info.dtype) {
+            Some(f) => f,
+            None => return Ok(None),
+        };
+
+        let absolute_offset = self.tensor_data_offset + info.offset;
+        reader.seek(SeekFrom::Start(absolute_offset))?;
+
+        let byte_size = info.byte_size() as usize;
+        let mut raw = vec![0u8; byte_size];
+        reader.read_exact(&mut raw)?;
+
+        // Determine tensor shape: dimensions[0] is num_rows, product of
+        // remaining dimensions gives the flat column count.
+        let num_rows = info.dimensions.first().copied().unwrap_or(1) as usize;
+        let weights_per_block = format.weights_per_block();
+        let col_elements = info.dimensions.iter().skip(1).product::<u64>().max(1) as usize;
+        let blocks_per_row = col_elements.div_ceil(weights_per_block);
+
+        Ok(Some(RawWeight {
+            data: raw,
+            format,
+            num_rows,
+            blocks_per_row,
+        }))
+    }
+
+    /// Load raw (non-dequantized) layer weights for a single transformer layer.
+    ///
+    /// Returns `None` if any of the seven required weight tensors (wq, wk, wv,
+    /// wo, w_gate, w_up, w_down) is missing or uses an unsupported format.
+    /// This allows callers to gracefully fall back to the f32 dequantized path
+    /// for models that mix quantization formats.
+    pub fn load_raw_layer_weights<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        layer_idx: usize,
+    ) -> Result<Option<RawLayerWeights>, GgufError> {
+        let i = layer_idx;
+        let wq = self.read_raw_weight(reader, &format!("blk.{i}.attn_q.weight"))?;
+        let wk = self.read_raw_weight(reader, &format!("blk.{i}.attn_k.weight"))?;
+        let wv = self.read_raw_weight(reader, &format!("blk.{i}.attn_v.weight"))?;
+        let wo = self.read_raw_weight(reader, &format!("blk.{i}.attn_output.weight"))?;
+        let w_gate = self.read_raw_weight(reader, &format!("blk.{i}.ffn_gate.weight"))?;
+        let w_up = self.read_raw_weight(reader, &format!("blk.{i}.ffn_up.weight"))?;
+        let w_down = self.read_raw_weight(reader, &format!("blk.{i}.ffn_down.weight"))?;
+
+        match (wq, wk, wv, wo, w_gate, w_up, w_down) {
+            (Some(wq), Some(wk), Some(wv), Some(wo), Some(w_gate), Some(w_up), Some(w_down)) => {
+                Ok(Some(RawLayerWeights {
+                    wq,
+                    wk,
+                    wv,
+                    wo,
+                    w_gate,
+                    w_up,
+                    w_down,
+                }))
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+/// Map a `QuantFormat` to a GPU-accelerated `WeightFormat`, if one exists.
+fn quant_to_weight_format(q: QuantFormat) -> Option<WeightFormat> {
+    match q {
+        QuantFormat::Q4_1 => Some(WeightFormat::Q4_1),
+        QuantFormat::Q8_1 => Some(WeightFormat::Q8_1),
+        QuantFormat::Q4_0 => Some(WeightFormat::Q4_0),
+        QuantFormat::Q2K => Some(WeightFormat::Q2K),
+        QuantFormat::Q4K => Some(WeightFormat::Q4K),
+        QuantFormat::Q5K => Some(WeightFormat::Q5K),
+        QuantFormat::Q6K => Some(WeightFormat::Q6K),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Introduces `WeightFormat`, `RawWeight`, and `RawLayerWeights` types in `flare-core` for carrying raw quantized weight bytes through the inference pipeline
- Extends `ComputeBackend` with `supports_dequant_matmul()` / `batched_dequant_matmul()` — the default CPU implementation returns `false` / panics; `WebGpuBackend` overrides both
- `WebGpuBackend::batched_dequant_matmul` dispatches by `WeightFormat` to the existing GPU kernels (Q4_0, Q4_1, Q8_1, Q2K, Q4K, Q5K, Q6K)
- All seven weight matrices in `forward_prefill` (wq, wk, wv, wo, w_gate, w_up, w_down) now take the fused path when a GPU backend is active and raw weights are loaded
- `GgufFile::read_raw_weight` / `load_raw_layer_weights` added to `flare-loader` so callers can load raw bytes without upfront dequantization

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo test --workspace` — all existing tests pass (79 unit + 71 loader + 11 server tests)
- [ ] `cargo fmt --all` — no formatting changes
- [ ] Manual smoke test with a quantized GGUF model using the native CLI

Closes #163