### PR TITLE
Expose load_raw_weights in WASM API and update browser demo

### DIFF
--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -330,7 +330,9 @@
     }
 
     // ---------- Model loaded ----------
-    async function onModelLoaded(eng, ms) {
+    // rawBytes: optional Uint8Array of the GGUF file — used to load raw
+    // quantized weights for the fused dequant+matvec GPU path.
+    async function onModelLoaded(eng, ms, rawBytes) {
       engine = eng;
       const tmplName = eng.chat_template_name;
       $modelInfo.textContent =
@@ -351,7 +353,24 @@
         $env.textContent = 'WebGPU: initialising…';
         try {
           const gpuOn = await eng.init_gpu();
-          $env.textContent = gpuOn ? 'WebGPU: ✓ active' : 'WebGPU: available but init failed';
+          if (gpuOn) {
+            // Attempt to load raw quantized weights for the fused
+            // dequant+matvec path (reduces memory bandwidth on GPU).
+            if (rawBytes) {
+              try {
+                const rawOk = eng.load_raw_weights(rawBytes);
+                $env.textContent = rawOk
+                  ? 'WebGPU: ✓ active (fused quant kernels)'
+                  : 'WebGPU: ✓ active (f32 path — unsupported quant format)';
+              } catch (_) {
+                $env.textContent = 'WebGPU: ✓ active (f32 path)';
+              }
+            } else {
+              $env.textContent = 'WebGPU: ✓ active';
+            }
+          } else {
+            $env.textContent = 'WebGPU: available but init failed';
+          }
         } catch (e) {
           $env.textContent = 'WebGPU: error — ' + e;
         }
@@ -394,7 +413,8 @@
         await new Promise(r => setTimeout(r, 10));
         const t0 = performance.now();
         clearChat();
-        await onModelLoaded(FlareEngine.load(new Uint8Array(buffer)), performance.now() - t0);
+        const bytes = new Uint8Array(buffer);
+        await onModelLoaded(FlareEngine.load(bytes), performance.now() - t0, bytes);
       } catch (err) {
         $modelInfo.textContent = 'Error: ' + err;
         $modelInfo.classList.add('error');
@@ -464,7 +484,7 @@
         updateProgress(bytes.length, bytes.length, fromCache ? 'Parsing (cached)…' : 'Parsing…');
         await new Promise(r => setTimeout(r, 10)); // yield so progress renders
         const eng = FlareEngine.load(bytes);
-        await onModelLoaded(eng, performance.now() - t0);
+        await onModelLoaded(eng, performance.now() - t0, bytes);
       } catch (err) {
         $modelInfo.textContent = 'Error: ' + err;
         $modelInfo.classList.add('error');

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -171,6 +171,67 @@ impl FlareEngine {
         }
     }
 
+    /// Load raw quantized weights from GGUF bytes so the GPU fused
+    /// dequant+matvec kernels can be used during inference.
+    ///
+    /// Call this **after** `init_gpu()` so the backend is set before the raw
+    /// weights are attached.  The method is a no-op (returns `false`) if a
+    /// layer's weights are in an unsupported quantization format — the engine
+    /// continues to work using the f32 path loaded at `FlareEngine.load()`.
+    ///
+    /// Returns `true` if all layers were loaded successfully, `false` if any
+    /// layer fell back to the f32 path.
+    ///
+    /// ```javascript
+    /// const engine = FlareEngine.load(bytes);
+    /// await engine.init_gpu();
+    /// const ok = engine.load_raw_weights(bytes);
+    /// console.log('Raw weights loaded:', ok);
+    /// ```
+    #[wasm_bindgen]
+    pub fn load_raw_weights(&mut self, gguf_bytes: &[u8]) -> bool {
+        let mut reader = Cursor::new(gguf_bytes);
+        let gguf = match GgufFile::parse_header(&mut reader) {
+            Ok(g) => g,
+            Err(_) => return false,
+        };
+        let num_layers = self.model.config().num_layers;
+        let mut raw_layers = Vec::with_capacity(num_layers);
+        let mut all_ok = true;
+
+        for layer_idx in 0..num_layers {
+            match gguf.load_raw_layer_weights(&mut reader, layer_idx) {
+                Ok(Some(rw)) => raw_layers.push(rw),
+                _ => {
+                    all_ok = false;
+                    // Stop trying — partial raw weights are not supported.
+                    break;
+                }
+            }
+        }
+
+        if raw_layers.len() == num_layers {
+            self.model.set_raw_weights(raw_layers);
+        }
+
+        all_ok
+    }
+
+    /// Clear any previously loaded raw quantized weights.
+    ///
+    /// After calling this the engine uses the f32 dequantized path for all
+    /// matrix operations until `load_raw_weights` is called again.
+    #[wasm_bindgen]
+    pub fn clear_raw_weights(&mut self) {
+        self.model.clear_raw_weights();
+    }
+
+    /// Returns `true` if raw quantized weights are currently loaded.
+    #[wasm_bindgen(getter)]
+    pub fn has_raw_weights(&self) -> bool {
+        self.model.has_raw_weights()
+    }
+
     /// Reset the KV cache (start a new conversation).
     #[wasm_bindgen]
     pub fn reset(&mut self) {


### PR DESCRIPTION
## Summary

- Adds `FlareEngine::load_raw_weights(gguf_bytes)` — accepts the same Uint8Array used in `FlareEngine.load()`, iterates over all layers via `GgufFile::load_raw_layer_weights`, and attaches raw weights to the model via `Model::set_raw_weights`. Returns `true` when all layers loaded successfully.
- Adds `FlareEngine::clear_raw_weights()` and `has_raw_weights` getter for JS completeness
- Updates `flare-web/demo/index.html`: after successful `init_gpu()`, calls `load_raw_weights(bytes)` and reflects the result in the environment status line ("fused quant kernels" vs "f32 path")
- Both file-input and URL-load code paths now pass raw GGUF bytes through to `onModelLoaded`

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` — all existing tests pass
- [x] `cargo fmt --all` — no formatting changes

Closes #170