### PR TITLE
Batched GPU fused dequant+matvec: single dispatch for all batch items

### DIFF
--- a/flare-gpu/shaders/dequant_matvec_q2k.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q2k.wgsl
@@ -1,6 +1,7 @@
-// Fused Q2_K dequantize + matrix-vector multiply on GPU.
+// Fused Q2_K dequantize + batched matrix-vector multiply on GPU.
 //
-// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
 //
 // Q2_K block layout (84 bytes = 21 u32 per block, 256 weights per block):
 //   u32[0..16]  : qs[64]    — 2-bit quantized values, 4 weights per byte
@@ -14,13 +15,13 @@
 //     min_nibble   = scales[sub] >> 4
 //     q2           = (qs[i/4] >> ((i % 4) * 2)) & 3
 //
-// One workgroup per output row. 64 threads split the blocks in the row;
+// One workgroup per (output row, batch item). 64 threads split the blocks;
 // a tree reduction over workgroup-shared memory accumulates partial sums.
 //
 // Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
 //   binding 0: raw    — packed Q2_K weight data [num_rows * num_blocks_per_row * 21]
-//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 256]
-//   binding 2: output — f32 result              [num_rows]
+//   binding 1: vec    — f32 input matrix        [batch_size * num_blocks_per_row * 256]
+//   binding 2: output — f32 result              [batch_size * num_rows]
 //   binding 3: params — uniform
 
 @group(0) @binding(0) var<storage, read> raw: array<u32>;
@@ -30,6 +31,7 @@
 struct Params {
     num_rows:           u32,
     num_blocks_per_row: u32,
+    batch_size:         u32,
 }
 @group(0) @binding(3) var<uniform> params: Params;
 
@@ -41,12 +43,14 @@ fn dequant_matvec_q2k(
     @builtin(local_invocation_id) lid: vec3<u32>,
     @builtin(workgroup_id)        wid: vec3<u32>,
 ) {
-    let row = wid.x;
-    if row >= params.num_rows {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
         return;
     }
 
     let tid = lid.x;
+    let in_cols = params.num_blocks_per_row * 256u;
     var acc: f32 = 0.0;
 
     // Each thread strides across blocks in this row.
@@ -58,8 +62,8 @@ fn dequant_matvec_q2k(
 
         // Base offset for this block in the raw u32 array (21 u32 per block).
         let raw_base = (row * params.num_blocks_per_row + b) * 21u;
-        // Corresponding start in the input vector (256 elements per block).
-        let vec_base = b * 256u;
+        // Corresponding start position in the input matrix for this batch item.
+        let vec_base = batch * in_cols + b * 256u;
 
         // d and dmin packed as two f16 in u32[20].
         let dm   = unpack2x16float(raw[raw_base + 20u]);
@@ -124,6 +128,6 @@ fn dequant_matvec_q2k(
     workgroupBarrier();
 
     if tid == 0u {
-        output[row] = partials[0u];
+        output[batch * params.num_rows + row] = partials[0u];
     }
 }

--- a/flare-gpu/shaders/dequant_matvec_q4_0.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q4_0.wgsl
@@ -1,6 +1,7 @@
-// Fused Q4_0 dequantize + matrix-vector multiply on GPU.
+// Fused Q4_0 dequantize + batched matrix-vector multiply on GPU.
 //
-// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
 //
 // Q4_0 block layout (18 bytes per block, 32 weights per block):
 //   bytes 0-1:  scale (f16 LE)
@@ -14,13 +15,13 @@
 // the nearest 4-byte multiple before upload.  Weights are accessed via
 // byte-offset helpers that extract individual bytes from the u32 storage array.
 //
-// One workgroup per output row. 64 threads split the blocks in the row;
+// One workgroup per (output row, batch item). 64 threads split the blocks;
 // a tree reduction over workgroup-shared memory accumulates partial sums.
 //
 // Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
 //   binding 0: raw    — packed Q4_0 weight data [num_rows * num_blocks_per_row * 18 bytes, padded]
-//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 32]
-//   binding 2: output — f32 result              [num_rows]
+//   binding 1: vec    — f32 input matrix        [batch_size * num_blocks_per_row * 32]
+//   binding 2: output — f32 result              [batch_size * num_rows]
 //   binding 3: params — uniform
 
 @group(0) @binding(0) var<storage, read> raw: array<u32>;
@@ -30,6 +31,7 @@
 struct Params {
     num_rows:           u32,
     num_blocks_per_row: u32,
+    batch_size:         u32,
 }
 @group(0) @binding(3) var<uniform> params: Params;
 
@@ -46,12 +48,14 @@ fn dequant_matvec_q4_0(
     @builtin(local_invocation_id) lid: vec3<u32>,
     @builtin(workgroup_id)        wid: vec3<u32>,
 ) {
-    let row = wid.x;
-    if row >= params.num_rows {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
         return;
     }
 
     let tid = lid.x;
+    let in_cols = params.num_blocks_per_row * 32u;
     var acc: f32 = 0.0;
 
     // Each thread strides across blocks in this row.
@@ -63,8 +67,8 @@ fn dequant_matvec_q4_0(
 
         // Absolute byte offset of this block in the raw buffer (18 bytes per block).
         let bb = (row * params.num_blocks_per_row + b) * 18u;
-        // Corresponding start in the input vector (32 elements per block).
-        let vec_base = b * 32u;
+        // Corresponding start position in the input matrix for this batch item.
+        let vec_base = batch * in_cols + b * 32u;
 
         // Scale: f16 LE at bytes 0-1 of the block.
         // Read as a u16 from two consecutive bytes, then reinterpret as f16.
@@ -116,6 +120,6 @@ fn dequant_matvec_q4_0(
     workgroupBarrier();
 
     if tid == 0u {
-        output[row] = partials[0u];
+        output[batch * params.num_rows + row] = partials[0u];
     }
 }

--- a/flare-gpu/shaders/dequant_matvec_q4_1.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q4_1.wgsl
@@ -1,6 +1,7 @@
-// Fused Q4_1 dequantize + matrix-vector multiply on GPU.
+// Fused Q4_1 dequantize + batched matrix-vector multiply on GPU.
 //
-// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
 //
 // Q4_1 block layout (20 bytes = 5 u32 per block, 32 weights per block):
 //   u32[0]     : d (f16 LE, lower 16 bits) + m (f16 LE, upper 16 bits)
@@ -9,13 +10,13 @@
 //
 // Weight reconstruction: w[i] = d * q + m, where q ∈ [0, 15].
 //
-// One workgroup per output row. 64 threads split the blocks in the row;
+// One workgroup per (output row, batch item). 64 threads split the blocks;
 // a tree reduction over workgroup-shared memory accumulates partial sums.
 //
 // Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
 //   binding 0: raw    — packed Q4_1 weight data [num_rows * num_blocks_per_row * 5]
-//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 32]
-//   binding 2: output — f32 result              [num_rows]
+//   binding 1: vec    — f32 input matrix        [batch_size * num_blocks_per_row * 32]
+//   binding 2: output — f32 result              [batch_size * num_rows]
 //   binding 3: params — uniform
 
 @group(0) @binding(0) var<storage, read> raw: array<u32>;
@@ -25,6 +26,7 @@
 struct Params {
     num_rows:           u32,
     num_blocks_per_row: u32,
+    batch_size:         u32,
 }
 @group(0) @binding(3) var<uniform> params: Params;
 
@@ -36,12 +38,14 @@ fn dequant_matvec_q4_1(
     @builtin(local_invocation_id) lid: vec3<u32>,
     @builtin(workgroup_id)        wid: vec3<u32>,
 ) {
-    let row = wid.x;
-    if row >= params.num_rows {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
         return;
     }
 
     let tid = lid.x;
+    let in_cols = params.num_blocks_per_row * 32u;
     var acc: f32 = 0.0;
 
     // Each thread strides across blocks in this row.
@@ -53,8 +57,8 @@ fn dequant_matvec_q4_1(
 
         // Base offset for this block in the raw u32 array (5 u32 per block).
         let raw_base = (row * params.num_blocks_per_row + b) * 5u;
-        // Corresponding start position in the input vector (32 elements per block).
-        let vec_base = b * 32u;
+        // Corresponding start position in the input matrix for this batch item.
+        let vec_base = batch * in_cols + b * 32u;
 
         // d and m packed as two f16 in the first u32.
         let dm = unpack2x16float(raw[raw_base]);
@@ -111,6 +115,6 @@ fn dequant_matvec_q4_1(
     workgroupBarrier();
 
     if tid == 0u {
-        output[row] = partials[0u];
+        output[batch * params.num_rows + row] = partials[0u];
     }
 }

--- a/flare-gpu/shaders/dequant_matvec_q4k.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q4k.wgsl
@@ -1,6 +1,7 @@
-// Fused Q4_K dequantize + matrix-vector multiply on GPU.
+// Fused Q4_K dequantize + batched matrix-vector multiply on GPU.
 //
-// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
 //
 // Q4_K block layout (144 bytes = 36 u32 per block, 256 weights per block):
 //   u32[0]     : d (f16 LE, lower 16 bits) + dmin (f16 LE, upper 16 bits)
@@ -17,13 +18,13 @@
 // Weight reconstruction: w[j]     = d * sc[j/32]   * lo_nibble - dmin * mn[j/32]
 //                         w[j+128] = d * sc[j/32+4] * hi_nibble - dmin * mn[j/32+4]
 //
-// One workgroup per output row. 64 threads split the blocks in the row;
+// One workgroup per (output row, batch item). 64 threads split the blocks;
 // a tree reduction over workgroup-shared memory accumulates partial sums.
 //
-// Bindings match the standard 4-entry layout (2 read-only, 1 read-write, 1 uniform):
-//   binding 0: raw   — packed Q4_K weight data [num_rows * num_blocks_per_row * 36]
-//   binding 1: vec   — f32 input vector        [num_blocks_per_row * 256]
-//   binding 2: output — f32 result             [num_rows]
+// Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
+//   binding 0: raw    — packed Q4_K weight data [num_rows * num_blocks_per_row * 36]
+//   binding 1: vec    — f32 input matrix        [batch_size * num_blocks_per_row * 256]
+//   binding 2: output — f32 result              [batch_size * num_rows]
 //   binding 3: params — uniform
 
 @group(0) @binding(0) var<storage, read> raw: array<u32>;
@@ -31,8 +32,9 @@
 @group(0) @binding(2) var<storage, read_write> output: array<f32>;
 
 struct Params {
-    num_rows: u32,
+    num_rows:           u32,
     num_blocks_per_row: u32,
+    batch_size:         u32,
 }
 @group(0) @binding(3) var<uniform> params: Params;
 
@@ -44,12 +46,14 @@ fn dequant_matvec_q4k(
     @builtin(local_invocation_id) lid: vec3<u32>,
     @builtin(workgroup_id) wid: vec3<u32>,
 ) {
-    let row = wid.x;
-    if row >= params.num_rows {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
         return;
     }
 
     let tid = lid.x;
+    let in_cols = params.num_blocks_per_row * 256u;
     var acc: f32 = 0.0;
 
     // Each thread strides across blocks in this row.
@@ -61,8 +65,8 @@ fn dequant_matvec_q4k(
 
         // Base offset for this block in the raw u32 array (36 u32 per block).
         let raw_base = (row * params.num_blocks_per_row + b) * 36u;
-        // Corresponding start position in the input vector (256 elements per block).
-        let vec_base = b * 256u;
+        // Corresponding start position in the input matrix for this batch item.
+        let vec_base = batch * in_cols + b * 256u;
 
         // d and dmin packed as two f16 in the first u32 of the block.
         let dm = unpack2x16float(raw[raw_base]);
@@ -131,6 +135,6 @@ fn dequant_matvec_q4k(
     workgroupBarrier();
 
     if tid == 0u {
-        output[row] = partials[0u];
+        output[batch * params.num_rows + row] = partials[0u];
     }
 }

--- a/flare-gpu/shaders/dequant_matvec_q5k.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q5k.wgsl
@@ -1,6 +1,7 @@
-// Fused Q5_K dequantize + matrix-vector multiply on GPU.
+// Fused Q5_K dequantize + batched matrix-vector multiply on GPU.
 //
-// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
 //
 // Q5_K block layout (176 bytes = 44 u32 per block, 256 weights per block):
 //   u32[0]      : d (f16 LE, lower 16 bits) + dmin (f16 LE, upper 16 bits)
@@ -23,13 +24,13 @@
 //   w[j]     = d * sc[j/32]   * q_lo - dmin * mn[j/32]
 //   w[j+128] = d * sc[j/32+4] * q_hi - dmin * mn[j/32+4]
 //
-// One workgroup per output row. 64 threads stride across blocks in the row;
+// One workgroup per (output row, batch item). 64 threads stride across blocks;
 // a tree reduction over workgroup-shared memory accumulates partial sums.
 //
 // Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
 //   binding 0: raw    — packed Q5_K weight data [num_rows * num_blocks_per_row * 44]
-//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 256]
-//   binding 2: output — f32 result              [num_rows]
+//   binding 1: vec    — f32 input matrix        [batch_size * num_blocks_per_row * 256]
+//   binding 2: output — f32 result              [batch_size * num_rows]
 //   binding 3: params — uniform
 
 @group(0) @binding(0) var<storage, read> raw: array<u32>;
@@ -39,6 +40,7 @@
 struct Params {
     num_rows:           u32,
     num_blocks_per_row: u32,
+    batch_size:         u32,
 }
 @group(0) @binding(3) var<uniform> params: Params;
 
@@ -50,12 +52,14 @@ fn dequant_matvec_q5k(
     @builtin(local_invocation_id) lid: vec3<u32>,
     @builtin(workgroup_id)        wid: vec3<u32>,
 ) {
-    let row = wid.x;
-    if row >= params.num_rows {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
         return;
     }
 
     let tid = lid.x;
+    let in_cols = params.num_blocks_per_row * 256u;
     var acc: f32 = 0.0;
 
     // Each thread strides across blocks in this row (64-thread stride).
@@ -67,8 +71,8 @@ fn dequant_matvec_q5k(
 
         // Base offset for this block in the raw u32 array (44 u32 per block).
         let raw_base = (row * params.num_blocks_per_row + b) * 44u;
-        // Corresponding start position in the input vector (256 elements per block).
-        let vec_base = b * 256u;
+        // Corresponding start position in the input matrix for this batch item.
+        let vec_base = batch * in_cols + b * 256u;
 
         // d and dmin packed as two f16 in the first u32.
         let dm   = unpack2x16float(raw[raw_base]);
@@ -140,6 +144,6 @@ fn dequant_matvec_q5k(
     workgroupBarrier();
 
     if tid == 0u {
-        output[row] = partials[0u];
+        output[batch * params.num_rows + row] = partials[0u];
     }
 }

--- a/flare-gpu/shaders/dequant_matvec_q6k.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q6k.wgsl
@@ -1,6 +1,7 @@
-// Fused Q6_K dequantize + matrix-vector multiply on GPU.
+// Fused Q6_K dequantize + batched matrix-vector multiply on GPU.
 //
-// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
 //
 // Q6_K block layout (210 bytes per block, 256 weights per block):
 //   bytes   0-127: ql[128] — lower 4 bits of 6-bit weights (two interleaved groups of 64)
@@ -23,18 +24,18 @@
 //       q4 =  (ql_b >> 4)  | (((qh_b >> 6) & 3) << 4) − 32
 //       is = l / 16
 //       sc1..sc4 = sign_extend(scales[sc_off+is+{0,2,4,6}])
-//       acc += d*sc1*q1 * vec[b*256 + y_off+l]
-//            + d*sc2*q2 * vec[b*256 + y_off+l+32]
-//            + d*sc3*q3 * vec[b*256 + y_off+l+64]
-//            + d*sc4*q4 * vec[b*256 + y_off+l+96]
+//       acc += d*sc1*q1 * vec[batch*in_cols + y_off+l]
+//            + d*sc2*q2 * vec[batch*in_cols + y_off+l+32]
+//            + d*sc3*q3 * vec[batch*in_cols + y_off+l+64]
+//            + d*sc4*q4 * vec[batch*in_cols + y_off+l+96]
 //
-// One workgroup per output row. 64 threads stride across blocks;
+// One workgroup per (output row, batch item). 64 threads stride across blocks;
 // a tree reduction over workgroup-shared memory accumulates partial sums.
 //
 // Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
 //   binding 0: raw    — packed Q6_K weight data [num_rows * num_blocks_per_row * 210 bytes, padded]
-//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 256]
-//   binding 2: output — f32 result              [num_rows]
+//   binding 1: vec    — f32 input matrix        [batch_size * num_blocks_per_row * 256]
+//   binding 2: output — f32 result              [batch_size * num_rows]
 //   binding 3: params — uniform
 
 @group(0) @binding(0) var<storage, read> raw: array<u32>;
@@ -44,6 +45,7 @@
 struct Params {
     num_rows:           u32,
     num_blocks_per_row: u32,
+    batch_size:         u32,
 }
 @group(0) @binding(3) var<uniform> params: Params;
 
@@ -65,12 +67,14 @@ fn dequant_matvec_q6k(
     @builtin(local_invocation_id) lid: vec3<u32>,
     @builtin(workgroup_id)        wid: vec3<u32>,
 ) {
-    let row = wid.x;
-    if row >= params.num_rows {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
         return;
     }
 
     let tid = lid.x;
+    let in_cols = params.num_blocks_per_row * 256u;
     var acc: f32 = 0.0;
 
     // Each thread strides across blocks in this row (64-thread stride).
@@ -82,8 +86,8 @@ fn dequant_matvec_q6k(
 
         // Byte offset for this block's start in the raw data (210 bytes per block).
         let bb = (row * params.num_blocks_per_row + b) * 210u;
-        // Start position in the input vector (256 elements per block).
-        let vec_base = b * 256u;
+        // Start position in the input matrix for this batch item (256 elements per block).
+        let vec_base = batch * in_cols + b * 256u;
 
         // d at bytes 208-209 of this block (LE f16).
         let d_packed = read_byte(bb + 208u) | (read_byte(bb + 209u) << 8u);
@@ -142,6 +146,6 @@ fn dequant_matvec_q6k(
     workgroupBarrier();
 
     if tid == 0u {
-        output[row] = partials[0u];
+        output[batch * params.num_rows + row] = partials[0u];
     }
 }

--- a/flare-gpu/shaders/dequant_matvec_q8_1.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q8_1.wgsl
@@ -1,6 +1,7 @@
-// Fused Q8_1 dequantize + matrix-vector multiply on GPU.
+// Fused Q8_1 dequantize + batched matrix-vector multiply on GPU.
 //
-// Computes: output[row] = Σ_j  dequant(raw[row, j]) * vec[j]
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
 //
 // Q8_1 block layout (36 bytes = 9 u32 per block, 32 weights per block):
 //   u32[0]     : d (f16 LE, lower 16 bits) + s (f16 LE sum, upper 16 bits — unused)
@@ -10,13 +11,13 @@
 //
 // Sign extension: extract byte as u32, shift left 24, then arithmetic-right-shift 24.
 //
-// One workgroup per output row. 64 threads split the blocks in the row;
+// One workgroup per (output row, batch item). 64 threads split the blocks;
 // a tree reduction over workgroup-shared memory accumulates partial sums.
 //
 // Bindings (standard 4-entry layout: 2 read-only, 1 read-write, 1 uniform):
 //   binding 0: raw    — packed Q8_1 weight data [num_rows * num_blocks_per_row * 9]
-//   binding 1: vec    — f32 input vector        [num_blocks_per_row * 32]
-//   binding 2: output — f32 result              [num_rows]
+//   binding 1: vec    — f32 input matrix        [batch_size * num_blocks_per_row * 32]
+//   binding 2: output — f32 result              [batch_size * num_rows]
 //   binding 3: params — uniform
 
 @group(0) @binding(0) var<storage, read> raw: array<u32>;
@@ -26,6 +27,7 @@
 struct Params {
     num_rows:           u32,
     num_blocks_per_row: u32,
+    batch_size:         u32,
 }
 @group(0) @binding(3) var<uniform> params: Params;
 
@@ -37,12 +39,14 @@ fn dequant_matvec_q8_1(
     @builtin(local_invocation_id) lid: vec3<u32>,
     @builtin(workgroup_id)        wid: vec3<u32>,
 ) {
-    let row = wid.x;
-    if row >= params.num_rows {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
         return;
     }
 
     let tid = lid.x;
+    let in_cols = params.num_blocks_per_row * 32u;
     var acc: f32 = 0.0;
 
     // Each thread strides across blocks in this row.
@@ -54,8 +58,8 @@ fn dequant_matvec_q8_1(
 
         // Base offset for this block in the raw u32 array (9 u32 per block).
         let raw_base = (row * params.num_blocks_per_row + b) * 9u;
-        // Corresponding start position in the input vector (32 elements per block).
-        let vec_base = b * 32u;
+        // Corresponding start position in the input matrix for this batch item.
+        let vec_base = batch * in_cols + b * 32u;
 
         // d from lower 16 bits of u32[0]; s (upper 16 bits) is ignored.
         let d = unpack2x16float(raw[raw_base]).x;
@@ -106,6 +110,6 @@ fn dequant_matvec_q8_1(
     workgroupBarrier();
 
     if tid == 0u {
-        output[row] = partials[0u];
+        output[batch * params.num_rows + row] = partials[0u];
     }
 }

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -513,8 +513,9 @@ impl WebGpuBackend {
         input: &[f32],
         num_rows: usize,
         num_blocks_per_row: usize,
+        batch: usize,
     ) -> Vec<f32> {
-        let output_size = num_rows as u64 * 4;
+        let output_size = num_rows as u64 * batch as u64 * 4;
 
         let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
         let vec_buf = self
@@ -522,7 +523,7 @@ impl WebGpuBackend {
             .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
         let out_buf = self.pool.get_output(&self.device, output_size);
 
-        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
         let params_buf =
             self.pool
                 .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
@@ -541,7 +542,7 @@ impl WebGpuBackend {
                 self.dispatch_and_readback(
                     &cached.pipeline,
                     &bind_group,
-                    [num_rows as u32, 1, 1],
+                    [num_rows as u32, batch as u32, 1],
                     &out_buf,
                     output_size,
                 )
@@ -574,8 +575,9 @@ impl WebGpuBackend {
         input: &[f32],
         num_rows: usize,
         num_blocks_per_row: usize,
+        batch: usize,
     ) -> Vec<f32> {
-        let output_size = num_rows as u64 * 4;
+        let output_size = num_rows as u64 * batch as u64 * 4;
 
         // Q4_0 blocks are 18 bytes — pad to next multiple of 4 for wgpu.
         #[allow(clippy::manual_is_multiple_of)]
@@ -591,7 +593,7 @@ impl WebGpuBackend {
             .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
         let out_buf = self.pool.get_output(&self.device, output_size);
 
-        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
         let params_buf =
             self.pool
                 .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
@@ -610,7 +612,7 @@ impl WebGpuBackend {
                 self.dispatch_and_readback(
                     &cached.pipeline,
                     &bind_group,
-                    [num_rows as u32, 1, 1],
+                    [num_rows as u32, batch as u32, 1],
                     &out_buf,
                     output_size,
                 )
@@ -640,8 +642,9 @@ impl WebGpuBackend {
         input: &[f32],
         num_rows: usize,
         num_blocks_per_row: usize,
+        batch: usize,
     ) -> Vec<f32> {
-        let output_size = num_rows as u64 * 4;
+        let output_size = num_rows as u64 * batch as u64 * 4;
 
         let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
         let vec_buf = self
@@ -649,7 +652,7 @@ impl WebGpuBackend {
             .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
         let out_buf = self.pool.get_output(&self.device, output_size);
 
-        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
         let params_buf =
             self.pool
                 .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
@@ -668,7 +671,7 @@ impl WebGpuBackend {
                 self.dispatch_and_readback(
                     &cached.pipeline,
                     &bind_group,
-                    [num_rows as u32, 1, 1],
+                    [num_rows as u32, batch as u32, 1],
                     &out_buf,
                     output_size,
                 )
@@ -698,8 +701,9 @@ impl WebGpuBackend {
         input: &[f32],
         num_rows: usize,
         num_blocks_per_row: usize,
+        batch: usize,
     ) -> Vec<f32> {
-        let output_size = num_rows as u64 * 4;
+        let output_size = num_rows as u64 * batch as u64 * 4;
 
         let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
         let vec_buf = self
@@ -707,7 +711,7 @@ impl WebGpuBackend {
             .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
         let out_buf = self.pool.get_output(&self.device, output_size);
 
-        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
         let params_buf =
             self.pool
                 .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
@@ -726,7 +730,7 @@ impl WebGpuBackend {
                 self.dispatch_and_readback(
                     &cached.pipeline,
                     &bind_group,
-                    [num_rows as u32, 1, 1],
+                    [num_rows as u32, batch as u32, 1],
                     &out_buf,
                     output_size,
                 )
@@ -755,8 +759,9 @@ impl WebGpuBackend {
         input: &[f32],
         num_rows: usize,
         num_blocks_per_row: usize,
+        batch: usize,
     ) -> Vec<f32> {
-        let output_size = num_rows as u64 * 4;
+        let output_size = num_rows as u64 * batch as u64 * 4;
 
         let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
         let vec_buf = self
@@ -764,7 +769,7 @@ impl WebGpuBackend {
             .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
         let out_buf = self.pool.get_output(&self.device, output_size);
 
-        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
         let params_buf =
             self.pool
                 .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
@@ -783,7 +788,7 @@ impl WebGpuBackend {
                 self.dispatch_and_readback(
                     &cached.pipeline,
                     &bind_group,
-                    [num_rows as u32, 1, 1],
+                    [num_rows as u32, batch as u32, 1],
                     &out_buf,
                     output_size,
                 )
@@ -812,8 +817,9 @@ impl WebGpuBackend {
         input: &[f32],
         num_rows: usize,
         num_blocks_per_row: usize,
+        batch: usize,
     ) -> Vec<f32> {
-        let output_size = num_rows as u64 * 4;
+        let output_size = num_rows as u64 * batch as u64 * 4;
 
         let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
         let vec_buf = self
@@ -821,7 +827,7 @@ impl WebGpuBackend {
             .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
         let out_buf = self.pool.get_output(&self.device, output_size);
 
-        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
         let params_buf =
             self.pool
                 .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
@@ -840,7 +846,7 @@ impl WebGpuBackend {
                 self.dispatch_and_readback(
                     &cached.pipeline,
                     &bind_group,
-                    [num_rows as u32, 1, 1],
+                    [num_rows as u32, batch as u32, 1],
                     &out_buf,
                     output_size,
                 )
@@ -995,8 +1001,9 @@ impl WebGpuBackend {
         input: &[f32],
         num_rows: usize,
         num_blocks_per_row: usize,
+        batch: usize,
     ) -> Vec<f32> {
-        let output_size = num_rows as u64 * 4;
+        let output_size = num_rows as u64 * batch as u64 * 4;
 
         // Q6_K blocks are 210 bytes — pad to next multiple of 4 for wgpu.
         #[allow(clippy::manual_is_multiple_of)]
@@ -1012,7 +1019,7 @@ impl WebGpuBackend {
             .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
         let out_buf = self.pool.get_output(&self.device, output_size);
 
-        let params: [u32; 2] = [num_rows as u32, num_blocks_per_row as u32];
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
         let params_buf =
             self.pool
                 .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
@@ -1031,7 +1038,7 @@ impl WebGpuBackend {
                 self.dispatch_and_readback(
                     &cached.pipeline,
                     &bind_group,
-                    [num_rows as u32, 1, 1],
+                    [num_rows as u32, batch as u32, 1],
                     &out_buf,
                     output_size,
                 )
@@ -1860,64 +1867,43 @@ impl ComputeBackend for WebGpuBackend {
     }
 
     fn batched_dequant_matmul(&self, weight: &RawWeight, input: &[f32], batch: usize) -> Vec<f32> {
-        let weights_per_block = weight.format.weights_per_block();
-        let in_cols = weight.blocks_per_row * weights_per_block;
         let num_rows = weight.num_rows;
-        let mut out = Vec::with_capacity(batch * num_rows);
 
-        // Compute per-row block size in bytes to slice raw weight data per row.
-        let row_bytes = weight.data.len() / num_rows;
-
-        for b in 0..batch {
-            let vec_slice = &input[b * in_cols..(b + 1) * in_cols];
-            let row_result = match weight.format {
-                WeightFormat::Q4_1 => self.dequant_matvec_q4_1(
-                    &weight.data,
-                    vec_slice,
-                    num_rows,
-                    weight.blocks_per_row,
-                ),
-                WeightFormat::Q8_1 => self.dequant_matvec_q8_1(
-                    &weight.data,
-                    vec_slice,
-                    num_rows,
-                    weight.blocks_per_row,
-                ),
-                WeightFormat::Q4_0 => self.dequant_matvec_q4_0(
-                    &weight.data,
-                    vec_slice,
-                    num_rows,
-                    weight.blocks_per_row,
-                ),
-                WeightFormat::Q2K => self.dequant_matvec_q2k(
-                    &weight.data,
-                    vec_slice,
-                    num_rows,
-                    weight.blocks_per_row,
-                ),
-                WeightFormat::Q4K => self.dequant_matvec_q4k(
-                    &weight.data,
-                    vec_slice,
-                    num_rows,
-                    weight.blocks_per_row,
-                ),
-                WeightFormat::Q5K => self.dequant_matvec_q5k(
-                    &weight.data,
-                    vec_slice,
-                    num_rows,
-                    weight.blocks_per_row,
-                ),
-                WeightFormat::Q6K => self.dequant_matvec_q6k(
-                    &weight.data,
-                    vec_slice,
-                    num_rows,
-                    weight.blocks_per_row,
-                ),
-            };
-            let _ = row_bytes; // suppress unused warning
-            out.extend_from_slice(&row_result);
+        match weight.format {
+            WeightFormat::Q4_1 => self.dequant_matvec_q4_1(
+                &weight.data,
+                input,
+                num_rows,
+                weight.blocks_per_row,
+                batch,
+            ),
+            WeightFormat::Q8_1 => self.dequant_matvec_q8_1(
+                &weight.data,
+                input,
+                num_rows,
+                weight.blocks_per_row,
+                batch,
+            ),
+            WeightFormat::Q4_0 => self.dequant_matvec_q4_0(
+                &weight.data,
+                input,
+                num_rows,
+                weight.blocks_per_row,
+                batch,
+            ),
+            WeightFormat::Q2K => {
+                self.dequant_matvec_q2k(&weight.data, input, num_rows, weight.blocks_per_row, batch)
+            }
+            WeightFormat::Q4K => {
+                self.dequant_matvec_q4k(&weight.data, input, num_rows, weight.blocks_per_row, batch)
+            }
+            WeightFormat::Q5K => {
+                self.dequant_matvec_q5k(&weight.data, input, num_rows, weight.blocks_per_row, batch)
+            }
+            WeightFormat::Q6K => {
+                self.dequant_matvec_q6k(&weight.data, input, num_rows, weight.blocks_per_row, batch)
+            }
         }
-        out
     }
 }
 
@@ -2091,7 +2077,7 @@ mod tests {
         let input = vec![1.0f32; 256];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q2k(&raw, &input, 1, 1);
+        let result = backend.dequant_matvec_q2k(&raw, &input, 1, 1, 1);
 
         assert_eq!(result.len(), 1, "expected 1 output");
         // 256 weights each = 1.0 * 1 * 1 - 0 = 1.0; dot with [1]*256 = 256.0
@@ -2132,7 +2118,7 @@ mod tests {
         let input = vec![1.0f32; 256];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q2k(&raw, &input, 1, 1);
+        let result = backend.dequant_matvec_q2k(&raw, &input, 1, 1, 1);
 
         assert_eq!(result.len(), 1, "expected 1 output");
         // weight = 1*2*2 - 1*1 = 3.0; dot with [1]*256 = 768.0
@@ -2165,7 +2151,7 @@ mod tests {
         let input = vec![1.0f32; 32];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q4_0(&raw, &input, 1, 1);
+        let result = backend.dequant_matvec_q4_0(&raw, &input, 1, 1, 1);
 
         assert_eq!(result.len(), 1, "expected 1 output");
         assert!(
@@ -2198,7 +2184,7 @@ mod tests {
         let input = vec![1.0f32; 32];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q4_0(&raw, &input, 1, 1);
+        let result = backend.dequant_matvec_q4_0(&raw, &input, 1, 1, 1);
 
         assert_eq!(result.len(), 1, "expected 1 output");
         // 16 pairs: w_lo = 2.0, w_hi = 1.0 → dot = 16*2 + 16*1 = 48
@@ -2233,7 +2219,7 @@ mod tests {
         let input = vec![1.0f32; 32];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q4_1(&raw, &input, 1, 1);
+        let result = backend.dequant_matvec_q4_1(&raw, &input, 1, 1, 1);
 
         assert_eq!(result.len(), 1, "expected 1 output");
         // weights: [2,1]*16 → dot with [1]*32 = 16*2 + 16*1 = 48
@@ -2267,7 +2253,7 @@ mod tests {
         let input = vec![1.0f32; 32];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q4_1(&raw, &input, 2, 1);
+        let result = backend.dequant_matvec_q4_1(&raw, &input, 2, 1, 1);
 
         assert_eq!(result.len(), 2, "expected 2 outputs");
         for (i, &v) in result.iter().enumerate() {
@@ -2303,7 +2289,7 @@ mod tests {
         let input = vec![1.0f32; 32];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q8_1(&raw, &input, 1, 1);
+        let result = backend.dequant_matvec_q8_1(&raw, &input, 1, 1, 1);
 
         assert_eq!(result.len(), 1, "expected 1 output");
         // Σ i for i=0..31 = 31*32/2 = 496
@@ -2336,7 +2322,7 @@ mod tests {
         let input = vec![1.0f32; 32];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q8_1(&raw, &input, 1, 1);
+        let result = backend.dequant_matvec_q8_1(&raw, &input, 1, 1, 1);
 
         assert_eq!(result.len(), 1, "expected 1 output");
         // 32 × (-1.0) = -32.0
@@ -2426,7 +2412,7 @@ mod tests {
         let input = [1.0f32; 256];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q4k(&raw, &input, 1, 1);
+        let result = backend.dequant_matvec_q4k(&raw, &input, 1, 1, 1);
 
         assert_eq!(result.len(), 1, "expected one output value");
         // 128 weights of 2.0 and 128 of 1.0, all dotted with 1.0
@@ -2460,7 +2446,7 @@ mod tests {
         let input = [1.0f32; 256];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q4k(&raw, &input, num_rows, 1);
+        let result = backend.dequant_matvec_q4k(&raw, &input, num_rows, 1, 1);
 
         assert_eq!(result.len(), num_rows);
         for (i, &v) in result.iter().enumerate() {
@@ -2735,7 +2721,7 @@ mod tests {
         let expected = 128.0 * 2.0 + 128.0 * 1.0; // 384.0
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q5k(&raw, &input, 1, 1);
+        let result = backend.dequant_matvec_q5k(&raw, &input, 1, 1, 1);
 
         assert_eq!(result.len(), 1, "expected one output value");
         assert!(
@@ -2768,7 +2754,7 @@ mod tests {
         let input = [1.0f32; 256];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q5k(&raw, &input, num_rows, 1);
+        let result = backend.dequant_matvec_q5k(&raw, &input, num_rows, 1, 1);
 
         assert_eq!(result.len(), num_rows);
         for (i, &v) in result.iter().enumerate() {
@@ -2809,7 +2795,7 @@ mod tests {
 
         let input = [1.0f32; 256];
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q6k(&raw, &input, 1, 1);
+        let result = backend.dequant_matvec_q6k(&raw, &input, 1, 1, 1);
 
         assert_eq!(result.len(), 1, "expected one output value");
         assert!(
@@ -2848,7 +2834,7 @@ mod tests {
         let input = [1.0f32; 256];
 
         let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
-        let result = backend.dequant_matvec_q6k(&raw, &input, num_rows, 1);
+        let result = backend.dequant_matvec_q6k(&raw, &input, num_rows, 1, 1);
 
         assert_eq!(result.len(), num_rows);
         for (i, &v) in result.iter().enumerate() {


### PR DESCRIPTION
## Summary

The previous `batched_dequant_matmul` implementation looped over batch items, calling one GPU kernel per token per weight matrix. For a seq_len=512 prefill this caused up to 512×7×32=114,688 GPU round-trips.

This PR adds a true batch dimension to all 7 dequant+matvec WGSL shaders and their Rust wrappers:

- **Shader changes**: Add `batch_size: u32` to `Params`, use `wid.y` for batch index, dispatch `[num_rows, batch, 1]`, read input as `input[batch * in_cols + offset]`, write output as `output[batch * num_rows + row]`
- **Rust method changes**: Add `batch: usize` parameter to all 7 `dequant_matvec_qX` methods; output buffer is `num_rows × batch × 4` bytes
- **`batched_dequant_matmul`**: Single match dispatch passes full batched input; no more per-token loop

Formats covered: Q4_1, Q8_1, Q4_0, Q2_K, Q4_K, Q5_K, Q6_K

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` — all existing tests pass
- [x] `cargo fmt --all` — no formatting changes
- [x] 14 existing test call sites updated to pass `batch=1`

Closes #174