### PR TITLE
Add Q8_0 fused dequant+matvec GPU kernel

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -16,6 +16,7 @@ pub enum WeightFormat {
     Q5_0,
     Q5K,
     Q6K,
+    Q8_0,
     Q8_1,
 }
 
@@ -28,7 +29,11 @@ impl WeightFormat {
             | WeightFormat::Q4K
             | WeightFormat::Q5K
             | WeightFormat::Q6K => 256,
-            WeightFormat::Q4_0 | WeightFormat::Q4_1 | WeightFormat::Q5_0 | WeightFormat::Q8_1 => 32,
+            WeightFormat::Q4_0
+            | WeightFormat::Q4_1
+            | WeightFormat::Q5_0
+            | WeightFormat::Q8_0
+            | WeightFormat::Q8_1 => 32,
         }
     }
 }

--- a/flare-gpu/shaders/dequant_matvec_q8_0.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q8_0.wgsl
@@ -1,0 +1,118 @@
+// Fused Q8_0 dequantize + batched matrix-vector multiply on GPU.
+//
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
+//
+// Q8_0 block layout (34 bytes per block, 32 weights per block):
+//   bytes  0-1:  scale (f16 LE)
+//   bytes  2-33: qs[32] — signed int8 quantized values
+//
+// Weight reconstruction: w[i] = scale * i32(qs[i])
+//
+// 34 bytes is not u32-aligned.  The Rust caller pads the raw byte buffer to the
+// nearest 4-byte multiple before upload.  Weights are accessed via byte-offset
+// helpers that extract individual bytes from the u32 storage array.
+//
+// One workgroup per (output row, batch item). 64 threads stride over blocks;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings:
+//   binding 0: raw    — packed Q8_0 weight data [num_rows * num_blocks_per_row * 34 bytes, padded]
+//   binding 1: vec    — f32 input matrix        [batch_size * num_blocks_per_row * 32]
+//   binding 2: output — f32 result              [batch_size * num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+    batch_size:         u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+@compute @workgroup_size(64)
+fn dequant_matvec_q8_0(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
+        return;
+    }
+
+    let tid = lid.x;
+    let in_cols = params.num_blocks_per_row * 32u;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across blocks in this row.
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Absolute byte offset of this block in the raw buffer (34 bytes per block).
+        let bb = (row * params.num_blocks_per_row + b) * 34u;
+        // Corresponding start position in the input vector for this batch item.
+        let vec_base = batch * in_cols + b * 32u;
+
+        // Scale: f16 LE at bytes 0-1 of the block.
+        let scale_bits = read_byte(bb) | (read_byte(bb + 1u) << 8u);
+        let scale = unpack2x16float(scale_bits).x;
+
+        // qs[32]: signed int8 values at bytes 2-33 of the block.
+        // Sign-extend the byte into a 32-bit signed integer via arithmetic right-shift.
+        for (var k = 0u; k < 32u; k = k + 1u) {
+            let byte_val = read_byte(bb + 2u + k);
+            let q = i32(byte_val << 24u) >> 24;
+            acc = acc + scale * f32(q) * vec[vec_base + k];
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u {
+        partials[tid] = partials[tid] + partials[tid + 32u];
+    }
+    workgroupBarrier();
+    if tid < 16u {
+        partials[tid] = partials[tid] + partials[tid + 16u];
+    }
+    workgroupBarrier();
+    if tid < 8u {
+        partials[tid] = partials[tid] + partials[tid + 8u];
+    }
+    workgroupBarrier();
+    if tid < 4u {
+        partials[tid] = partials[tid] + partials[tid + 4u];
+    }
+    workgroupBarrier();
+    if tid < 2u {
+        partials[tid] = partials[tid] + partials[tid + 2u];
+    }
+    workgroupBarrier();
+    if tid < 1u {
+        partials[tid] = partials[tid] + partials[tid + 1u];
+    }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[batch * params.num_rows + row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -31,6 +31,7 @@ const DEQUANT_MATVEC_Q3K_SHADER: &str = include_str!("../shaders/dequant_matvec_
 const DEQUANT_MATVEC_Q4_0_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_0.wgsl");
 const DEQUANT_MATVEC_Q4_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_1.wgsl");
 const DEQUANT_MATVEC_Q5_0_SHADER: &str = include_str!("../shaders/dequant_matvec_q5_0.wgsl");
+const DEQUANT_MATVEC_Q8_0_SHADER: &str = include_str!("../shaders/dequant_matvec_q8_0.wgsl");
 const DEQUANT_MATVEC_Q8_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q8_1.wgsl");
 const DEQUANT_MATVEC_Q4K_SHADER: &str = include_str!("../shaders/dequant_matvec_q4k.wgsl");
 const DEQUANT_MATVEC_Q5K_SHADER: &str = include_str!("../shaders/dequant_matvec_q5k.wgsl");
@@ -670,6 +671,75 @@ impl WebGpuBackend {
                 let bind_group =
                     self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
                 // One workgroup per output row.
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, batch as u32, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused Q8_0 dequantize + batched matrix-vector multiply.
+    ///
+    /// Reads packed Q8_0 weight data, dequantizes each 34-byte block on-the-fly,
+    /// and accumulates the dot products with `input` in the same kernel.
+    ///
+    /// Q8_0 blocks are 34 bytes each (not u32-aligned). The raw bytes are
+    /// padded to the nearest 4-byte multiple before upload.
+    ///
+    /// - `raw_bytes`: packed GGUF data — `num_rows × num_blocks_per_row × 34` bytes
+    ///   (padded to 4-byte multiple by caller if needed)
+    /// - `input`: f32 input matrix of length `batch × num_blocks_per_row × 32`
+    /// - Returns `batch × num_rows` f32 dot products
+    pub fn dequant_matvec_q8_0(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * batch as u64 * 4;
+
+        // Q8_0 blocks are 34 bytes — pad to next multiple of 4 for wgpu.
+        #[allow(clippy::manual_is_multiple_of)]
+        let raw_buf = if raw_bytes.len() % 4 == 0 {
+            self.pool.get_storage(&self.device, &self.queue, raw_bytes)
+        } else {
+            let mut padded = raw_bytes.to_vec();
+            padded.resize((padded.len() + 3) & !3, 0);
+            self.pool.get_storage(&self.device, &self.queue, &padded)
+        };
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_q8_0",
+            DEQUANT_MATVEC_Q8_0_SHADER,
+            "dequant_matvec_q8_0",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
                 self.dispatch_and_readback(
                     &cached.pipeline,
                     &bind_group,
@@ -2017,6 +2087,13 @@ impl ComputeBackend for WebGpuBackend {
                 weight.blocks_per_row,
                 batch,
             ),
+            WeightFormat::Q8_0 => self.dequant_matvec_q8_0(
+                &weight.data,
+                input,
+                num_rows,
+                weight.blocks_per_row,
+                batch,
+            ),
             WeightFormat::Q8_1 => self.dequant_matvec_q8_1(
                 &weight.data,
                 input,
@@ -2414,6 +2491,70 @@ mod tests {
                 v
             );
         }
+    }
+
+    /// Verify GPU Q8_0 fused dequant+matvec matches CPU reference dequantization.
+    ///
+    /// One block: scale=1.0, qs = [0, 1, 2, ..., 31] (ascending int8).
+    /// Input: all 1.0. Expected dot product = 0+1+…+31 = 496.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q8_0_matches_cpu() {
+        use flare_loader::quantize::dequant_q8_0_block;
+
+        let mut raw = [0u8; 34];
+        // scale = 1.0 as f16 LE
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // qs[32] = 0, 1, 2, ..., 31
+        for i in 0..32usize {
+            raw[2 + i] = i as u8;
+        }
+
+        let mut dequant_out = [0.0f32; 32];
+        dequant_q8_0_block(&raw, &mut dequant_out);
+        let expected: f32 = dequant_out.iter().sum();
+
+        let input = [1.0f32; 32];
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q8_0(&raw, &input, 1, 1, 1);
+
+        assert_eq!(result.len(), 1, "expected one output value");
+        assert!(
+            (result[0] - expected).abs() < 1e-3,
+            "dequant_matvec_q8_0 mismatch: got {}, expected {}",
+            result[0],
+            expected
+        );
+    }
+
+    /// Verify GPU Q8_0 fused dequant+matvec handles negative weights correctly.
+    ///
+    /// All qs = -1 (0xFF as u8), scale = 1.0. Expected dot product = -1 * 32 = -32.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q8_0_negative_weights() {
+        let mut raw = [0u8; 34];
+        raw[0] = 0x00;
+        raw[1] = 0x3C; // scale = 1.0
+        for b in raw[2..34].iter_mut() {
+            *b = 0xFF; // -1 as i8
+        }
+
+        let input = [1.0f32; 32];
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q8_0(&raw, &input, 1, 1, 1);
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            (result[0] - (-32.0f32)).abs() < 1e-3,
+            "expected -32.0, got {}",
+            result[0]
+        );
     }
 
     /// Verify GPU Q8_1 fused dequant+matvec against CPU reference.

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -417,6 +417,7 @@ fn quant_to_weight_format(q: QuantFormat) -> Option<WeightFormat> {
         QuantFormat::Q8_1 => Some(WeightFormat::Q8_1),
         QuantFormat::Q4_0 => Some(WeightFormat::Q4_0),
         QuantFormat::Q5_0 => Some(WeightFormat::Q5_0),
+        QuantFormat::Q8_0 => Some(WeightFormat::Q8_0),
         QuantFormat::Q2K => Some(WeightFormat::Q2K),
         QuantFormat::Q3K => Some(WeightFormat::Q3K),
         QuantFormat::Q4K => Some(WeightFormat::Q4K),


### PR DESCRIPTION
## Summary

- Adds `WeightFormat::Q8_0` to `flare-core` with `weights_per_block = 32`
- Adds `flare-gpu/shaders/dequant_matvec_q8_0.wgsl`: batched fused shader for 34-byte Q8_0 blocks. Uses arithmetic right-shift to sign-extend int8 values (`i32(byte << 24) >> 24`). Uses `read_byte()` helper since 34 bytes is not u32-aligned.
- Adds `dequant_matvec_q8_0()` dispatch method to `WebGpuBackend` with 4-byte padding
- Wires Q8_0 into `batched_dequant_matmul` match arm and `quant_to_weight_format()` in `flare-loader`
- Adds GPU-ignored correctness tests: ascending weights (0..31, expects dot=496) and all-negative weights (-1, expects dot=-32)

Closes #178

## Test plan

- [ ] `cargo check --workspace` — clean
- [ ] `cargo test --workspace` — all tests pass
- [ ] GPU-ignored tests: `cargo test -p flarellm-gpu -- --ignored test_dequant_matvec_q8_0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)