### PR TITLE
Add Q5_1 fused dequant+matvec GPU kernel

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -14,6 +14,7 @@ pub enum WeightFormat {
     Q4_1,
     Q4K,
     Q5_0,
+    Q5_1,
     Q5K,
     Q6K,
     Q8_0,
@@ -32,6 +33,7 @@ impl WeightFormat {
             WeightFormat::Q4_0
             | WeightFormat::Q4_1
             | WeightFormat::Q5_0
+            | WeightFormat::Q5_1
             | WeightFormat::Q8_0
             | WeightFormat::Q8_1 => 32,
         }

--- a/flare-gpu/shaders/dequant_matvec_q5_1.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_q5_1.wgsl
@@ -1,0 +1,148 @@
+// Fused Q5_1 dequantize + batched matrix-vector multiply on GPU.
+//
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
+//
+// Q5_1 block layout (24 bytes = 6 u32 per block, 32 weights per block):
+//   bytes  0-1:  d (f16 LE) — scale
+//   bytes  2-3:  m (f16 LE) — min offset
+//   bytes  4-7:  qh (u32 LE) — high bits for all 32 weights
+//                  bits  0-15: high bit for weight j        (j in 0..16, low nibbles)
+//                  bits 16-31: high bit for weight j+16     (j in 0..16, high nibbles)
+//   bytes  8-23: qs[16] — 4-bit nibbles, 2 weights per byte
+//                  byte k: lo nibble = weight k, hi nibble = weight k+16
+//
+// 24 bytes is u32-aligned, so no padding is required.  Direct u32 reads are used.
+//
+// Weight reconstruction:
+//   for j in 0..16:
+//     lo_nibble = qs[j] & 0x0F
+//     hi_nibble = (qs[j] >> 4) & 0x0F
+//     xh_0 = (qh >> j)      & 1
+//     xh_1 = (qh >> (j+16)) & 1
+//     q5_0 = lo_nibble | (xh_0 << 4)   → range [0, 31]
+//     q5_1 = hi_nibble | (xh_1 << 4)   → range [0, 31]
+//     w[j]    = d * f32(q5_0) + m
+//     w[j+16] = d * f32(q5_1) + m
+//
+// u32 layout of a block at raw[base .. base+6]:
+//   raw[base+0]: bits[15:0]=d, bits[31:16]=m  → unpack2x16float gives (d, m)
+//   raw[base+1]: qh
+//   raw[base+2..5]: qs[16] as 4 bytes per u32, 4 qs entries per u32
+//
+// One workgroup per (output row, batch item). 64 threads stride over blocks;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings:
+//   binding 0: raw    — packed Q5_1 weight data [num_rows * num_blocks_per_row * 6 u32]
+//   binding 1: vec    — f32 input matrix        [batch_size * num_blocks_per_row * 32]
+//   binding 2: output — f32 result              [batch_size * num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+    batch_size:         u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+@compute @workgroup_size(64)
+fn dequant_matvec_q5_1(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
+        return;
+    }
+
+    let tid = lid.x;
+    let in_cols = params.num_blocks_per_row * 32u;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across blocks in this row.
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Base offset in the u32 array (6 u32 per block).
+        let base = (row * params.num_blocks_per_row + b) * 6u;
+        // Corresponding start position in the input vector for this batch item.
+        let vec_base = batch * in_cols + b * 32u;
+
+        // d and m packed as two f16 in raw[base+0]: unpack gives (d, m).
+        let dm = unpack2x16float(raw[base]);
+        let d  = dm.x;
+        let m  = dm.y;
+
+        // qh at raw[base+1].
+        let qh = raw[base + 1u];
+
+        // qs[16] at raw[base+2..5]: 4 bytes per u32, packed as 2 nibbles per byte.
+        for (var j = 0u; j < 16u; j = j + 1u) {
+            // qs[j] is byte j within raw[base+2 .. base+5].
+            let qs_word = raw[base + 2u + j / 4u];
+            let qs_byte = (qs_word >> ((j % 4u) * 8u)) & 0xFFu;
+
+            let lo_nibble = qs_byte & 0x0Fu;
+            let hi_nibble = (qs_byte >> 4u) & 0x0Fu;
+
+            let xh_0 = (qh >> j) & 1u;
+            let xh_1 = (qh >> (j + 16u)) & 1u;
+
+            let q5_0 = f32(lo_nibble | (xh_0 << 4u));
+            let q5_1 = f32(hi_nibble | (xh_1 << 4u));
+
+            let w0 = d * q5_0 + m;
+            let w1 = d * q5_1 + m;
+
+            acc = acc + w0 * vec[vec_base + j];
+            acc = acc + w1 * vec[vec_base + j + 16u];
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u {
+        partials[tid] = partials[tid] + partials[tid + 32u];
+    }
+    workgroupBarrier();
+    if tid < 16u {
+        partials[tid] = partials[tid] + partials[tid + 16u];
+    }
+    workgroupBarrier();
+    if tid < 8u {
+        partials[tid] = partials[tid] + partials[tid + 8u];
+    }
+    workgroupBarrier();
+    if tid < 4u {
+        partials[tid] = partials[tid] + partials[tid + 4u];
+    }
+    workgroupBarrier();
+    if tid < 2u {
+        partials[tid] = partials[tid] + partials[tid + 2u];
+    }
+    workgroupBarrier();
+    if tid < 1u {
+        partials[tid] = partials[tid] + partials[tid + 1u];
+    }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[batch * params.num_rows + row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -31,6 +31,7 @@ const DEQUANT_MATVEC_Q3K_SHADER: &str = include_str!("../shaders/dequant_matvec_
 const DEQUANT_MATVEC_Q4_0_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_0.wgsl");
 const DEQUANT_MATVEC_Q4_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_1.wgsl");
 const DEQUANT_MATVEC_Q5_0_SHADER: &str = include_str!("../shaders/dequant_matvec_q5_0.wgsl");
+const DEQUANT_MATVEC_Q5_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q5_1.wgsl");
 const DEQUANT_MATVEC_Q8_0_SHADER: &str = include_str!("../shaders/dequant_matvec_q8_0.wgsl");
 const DEQUANT_MATVEC_Q8_1_SHADER: &str = include_str!("../shaders/dequant_matvec_q8_1.wgsl");
 const DEQUANT_MATVEC_Q4K_SHADER: &str = include_str!("../shaders/dequant_matvec_q4k.wgsl");
@@ -671,6 +672,65 @@ impl WebGpuBackend {
                 let bind_group =
                     self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
                 // One workgroup per output row.
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, batch as u32, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused Q5_1 dequantize + batched matrix-vector multiply.
+    ///
+    /// Reads packed Q5_1 weight data, dequantizes each 24-byte block on-the-fly,
+    /// and accumulates the dot products with `input` in the same kernel.
+    ///
+    /// Q5_1 blocks are 24 bytes (u32-aligned — no padding needed).
+    ///
+    /// - `raw_bytes`: packed GGUF data — `num_rows × num_blocks_per_row × 24` bytes
+    /// - `input`: f32 input matrix of length `batch × num_blocks_per_row × 32`
+    /// - Returns `batch × num_rows` f32 dot products
+    pub fn dequant_matvec_q5_1(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * batch as u64 * 4;
+
+        let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_q5_1",
+            DEQUANT_MATVEC_Q5_1_SHADER,
+            "dequant_matvec_q5_1",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
                 self.dispatch_and_readback(
                     &cached.pipeline,
                     &bind_group,
@@ -2115,6 +2175,13 @@ impl ComputeBackend for WebGpuBackend {
                 weight.blocks_per_row,
                 batch,
             ),
+            WeightFormat::Q5_1 => self.dequant_matvec_q5_1(
+                &weight.data,
+                input,
+                num_rows,
+                weight.blocks_per_row,
+                batch,
+            ),
             WeightFormat::Q2K => {
                 self.dequant_matvec_q2k(&weight.data, input, num_rows, weight.blocks_per_row, batch)
             }
@@ -3297,6 +3364,74 @@ mod tests {
                 "row {i}: got {v}, expected {expected}"
             );
         }
+    }
+
+    /// Verify GPU Q5_1 fused dequant+matvec matches CPU reference.
+    ///
+    /// One block: d=1.0, m=0.0, qh=0 (all high bits clear → range [0,15]),
+    /// qs all 0x55 → lo nibble=5, hi nibble=5.
+    /// Expected: w[j] = 1.0*5 + 0 = 5.0 for all 32 weights. Dot with all-1 input = 5*32 = 160.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q5_1_matches_cpu() {
+        // Build a Q5_1 block manually (24 bytes = 6 u32s, LE)
+        let mut raw = [0u8; 24];
+        // d = 1.0 as f16: bytes 0-1 = [0x00, 0x3C]
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // m = 0.0 as f16: bytes 2-3 = [0x00, 0x00] (already zero)
+        // qh = 0: bytes 4-7 = 0 (all high bits clear, q5 range [0, 15])
+        // qs[16] = 0x55: lo nibble = 5, hi nibble = 5 → all q5 = 5
+        for b in raw[8..24].iter_mut() {
+            *b = 0x55;
+        }
+
+        let expected = 5.0f32 * 32.0; // d * 5 + 0 = 5.0 per weight, 32 weights
+        let input = [1.0f32; 32];
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q5_1(&raw, &input, 1, 1, 1);
+
+        assert_eq!(result.len(), 1, "expected one output value");
+        assert!(
+            (result[0] - expected).abs() < 1e-3,
+            "dequant_matvec_q5_1 mismatch: got {}, expected {}",
+            result[0],
+            expected
+        );
+    }
+
+    /// Verify GPU Q5_1 handles non-zero min (m > 0) correctly.
+    ///
+    /// d=1.0, m=1.0, all q5=0 (qs=0, qh=0) → w[i] = 1.0*0 + 1.0 = 1.0.
+    /// Dot with all-1 input = 32.0.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_q5_1_nonzero_min() {
+        let mut raw = [0u8; 24];
+        // d = 1.0 as f16: bytes 0-1
+        raw[0] = 0x00;
+        raw[1] = 0x3C;
+        // m = 1.0 as f16: bytes 2-3 = [0x00, 0x3C]
+        raw[2] = 0x00;
+        raw[3] = 0x3C;
+        // qh = 0, qs = 0 → all q5 = 0; w[i] = 1.0*0 + 1.0 = 1.0
+
+        let expected = 32.0f32;
+        let input = [1.0f32; 32];
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_q5_1(&raw, &input, 1, 1, 1);
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            (result[0] - expected).abs() < 1e-3,
+            "dequant_matvec_q5_1 min test: got {}, expected {}",
+            result[0],
+            expected
+        );
     }
 
     /// Verify GPU batched_rmsnorm matches CPU rmsnorm for a 3-row × 4-dim batch.

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -417,6 +417,7 @@ fn quant_to_weight_format(q: QuantFormat) -> Option<WeightFormat> {
         QuantFormat::Q8_1 => Some(WeightFormat::Q8_1),
         QuantFormat::Q4_0 => Some(WeightFormat::Q4_0),
         QuantFormat::Q5_0 => Some(WeightFormat::Q5_0),
+        QuantFormat::Q5_1 => Some(WeightFormat::Q5_1),
         QuantFormat::Q8_0 => Some(WeightFormat::Q8_0),
         QuantFormat::Q2K => Some(WeightFormat::Q2K),
         QuantFormat::Q3K => Some(WeightFormat::Q3K),


### PR DESCRIPTION
## Summary

- Adds `WeightFormat::Q5_1` to `flare-core` with `weights_per_block = 32`
- Adds `flare-gpu/shaders/dequant_matvec_q5_1.wgsl`: batched fused shader for 24-byte Q5_1 blocks. Q5_1 is u32-aligned (24 = 6×4), so no padding needed. Reads d/m via `unpack2x16float`, qh for high bits, reconstructs `w = d * q5 + m`.
- Adds `dequant_matvec_q5_1()` dispatch method to `WebGpuBackend`
- Wires Q5_1 into `batched_dequant_matmul` and `quant_to_weight_format()`
- Adds GPU-ignored tests: scale-only case (q5=5, m=0 → 160.0) and non-zero min (q5=0, m=1 → 32.0)

Closes #179

## Test plan

- [ ] `cargo check --workspace` — clean
- [ ] `cargo test --workspace` — all tests pass
- [ ] GPU-ignored: `cargo test -p flarellm-gpu -- --ignored test_dequant_matvec_q5_1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)