### PR TITLE
Add BF16 (bfloat16) weight format support with fused GPU kernel

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -8,6 +8,7 @@ use crate::tensor::Tensor;
 /// Other quantization formats must be dequantized to f32 at load time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WeightFormat {
+    BF16,
     Q2K,
     Q3K,
     Q4_0,
@@ -36,6 +37,7 @@ impl WeightFormat {
             | WeightFormat::Q5_1
             | WeightFormat::Q8_0
             | WeightFormat::Q8_1 => 32,
+            WeightFormat::BF16 => 1,
         }
     }
 }

--- a/flare-gpu/shaders/dequant_matvec_bf16.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_bf16.wgsl
@@ -1,0 +1,120 @@
+// Fused BF16 dequantize + batched matrix-vector multiply on GPU.
+//
+// Computes: output[b * num_rows + row] = Σ_j  bf16_to_f32(raw[row, j]) * vec[b * num_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
+//
+// BF16 layout (2 bytes per weight, no block structure):
+//   Each weight is a 16-bit bfloat16 value stored in little-endian order.
+//   BF16 shares the same exponent and sign bits as F32; conversion is a
+//   left-shift by 16: f32_bits = bf16_bits << 16.
+//
+// For a matrix of shape [num_rows, num_cols]:
+//   - Total bytes = num_rows × num_cols × 2
+//   - The shader param `num_blocks_per_row` carries `num_cols` (weights_per_block = 1)
+//   - Byte offset of weight (row, j) = (row × num_cols + j) × 2
+//
+// 2 bytes per weight is not always u32-aligned.  The Rust caller pads the raw
+// byte buffer to the nearest 4-byte multiple before upload.  Individual bytes
+// are extracted from u32 words via the `read_byte()` helper.
+//
+// One workgroup per (output row, batch item).  64 threads stride over columns;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings:
+//   binding 0: raw    — BF16 weight data [num_rows × num_cols × 2 bytes, padded]
+//   binding 1: vec    — f32 input matrix [batch_size × num_cols]
+//   binding 2: output — f32 result       [batch_size × num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32, // = num_cols (one "block" per weight for BF16)
+    batch_size:         u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+/// Convert a BF16 value (LE u16 bits) to f32.
+/// BF16 is the top 16 bits of F32, so conversion is a left-shift by 16.
+fn bf16_to_f32(bf16_bits: u32) -> f32 {
+    return bitcast<f32>(bf16_bits << 16u);
+}
+
+@compute @workgroup_size(64)
+fn dequant_matvec_bf16(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
+        return;
+    }
+
+    let tid      = lid.x;
+    let num_cols = params.num_blocks_per_row;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across columns in this row.
+    var j: u32 = tid;
+    loop {
+        if j >= num_cols {
+            break;
+        }
+
+        // BF16 weight at (row, j): byte offset = (row * num_cols + j) * 2
+        let byte_off  = (row * num_cols + j) * 2u;
+        let lo        = read_byte(byte_off);
+        let hi        = read_byte(byte_off + 1u);
+        let bf16_bits = lo | (hi << 8u);
+        let w         = bf16_to_f32(bf16_bits);
+
+        acc = acc + w * vec[batch * num_cols + j];
+
+        j = j + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u {
+        partials[tid] = partials[tid] + partials[tid + 32u];
+    }
+    workgroupBarrier();
+    if tid < 16u {
+        partials[tid] = partials[tid] + partials[tid + 16u];
+    }
+    workgroupBarrier();
+    if tid < 8u {
+        partials[tid] = partials[tid] + partials[tid + 8u];
+    }
+    workgroupBarrier();
+    if tid < 4u {
+        partials[tid] = partials[tid] + partials[tid + 4u];
+    }
+    workgroupBarrier();
+    if tid < 2u {
+        partials[tid] = partials[tid] + partials[tid + 2u];
+    }
+    workgroupBarrier();
+    if tid < 1u {
+        partials[tid] = partials[tid] + partials[tid + 1u];
+    }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[batch * params.num_rows + row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -26,6 +26,7 @@ const SOFTMAX_SHADER: &str = include_str!("../shaders/softmax.wgsl");
 const ATTENTION_SHADER: &str = include_str!("../shaders/attention.wgsl");
 const DEQUANT_Q4_1_SHADER: &str = include_str!("../shaders/dequant_q4_1.wgsl");
 const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
+const DEQUANT_MATVEC_BF16_SHADER: &str = include_str!("../shaders/dequant_matvec_bf16.wgsl");
 const DEQUANT_MATVEC_Q2K_SHADER: &str = include_str!("../shaders/dequant_matvec_q2k.wgsl");
 const DEQUANT_MATVEC_Q3K_SHADER: &str = include_str!("../shaders/dequant_matvec_q3k.wgsl");
 const DEQUANT_MATVEC_Q4_0_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_0.wgsl");
@@ -796,6 +797,74 @@ impl WebGpuBackend {
             "dequant_matvec_q8_0",
             DEQUANT_MATVEC_Q8_0_SHADER,
             "dequant_matvec_q8_0",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, batch as u32, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused BF16 dequantize + batched matrix-vector multiply.
+    ///
+    /// Reads packed BF16 weight data, converts each value to f32 on-the-fly
+    /// (BF16 = upper 16 bits of F32, so conversion is a left-shift by 16),
+    /// and accumulates the dot products with `input` in the same kernel.
+    ///
+    /// - `raw_bytes`: BF16 weight data — `num_rows × num_cols × 2` bytes
+    ///   (padded to 4-byte multiple by caller if needed)
+    /// - `input`: f32 input matrix of length `batch × num_cols`
+    /// - `num_blocks_per_row`: equals `num_cols` (weights_per_block = 1 for BF16)
+    /// - Returns `batch × num_rows` f32 dot products
+    pub fn dequant_matvec_bf16(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * batch as u64 * 4;
+
+        // BF16 data may not be u32-aligned — pad to next multiple of 4.
+        #[allow(clippy::manual_is_multiple_of)]
+        let raw_buf = if raw_bytes.len() % 4 == 0 {
+            self.pool.get_storage(&self.device, &self.queue, raw_bytes)
+        } else {
+            let mut padded = raw_bytes.to_vec();
+            padded.resize((padded.len() + 3) & !3, 0);
+            self.pool.get_storage(&self.device, &self.queue, &padded)
+        };
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_bf16",
+            DEQUANT_MATVEC_BF16_SHADER,
+            "dequant_matvec_bf16",
             &layout_entries,
             |cached| {
                 let bind_group =
@@ -2140,6 +2209,13 @@ impl ComputeBackend for WebGpuBackend {
         let num_rows = weight.num_rows;
 
         match weight.format {
+            WeightFormat::BF16 => self.dequant_matvec_bf16(
+                &weight.data,
+                input,
+                num_rows,
+                weight.blocks_per_row,
+                batch,
+            ),
             WeightFormat::Q4_1 => self.dequant_matvec_q4_1(
                 &weight.data,
                 input,
@@ -3524,5 +3600,61 @@ mod tests {
                 "q3k mismatch at [{j}]: gpu={gpu}, cpu={cpu}"
             );
         }
+    }
+
+    /// Verify GPU BF16 fused dequant+matvec against CPU reference.
+    ///
+    /// One row, 4 BF16 weights: 1.0, 2.0, 3.0, 4.0.
+    /// BF16 bit representation (same as upper 16 bits of F32):
+    ///   1.0 = 0x3F80, 2.0 = 0x4000, 3.0 = 0x4040, 4.0 = 0x4080
+    /// Input vector: all 1.0. Expected dot product = 1+2+3+4 = 10.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_bf16_matches_cpu() {
+        // 4 BF16 values: 1.0, 2.0, 3.0, 4.0 (LE u16)
+        // BF16 1.0 = 0x3F80 → bytes [0x80, 0x3F]
+        // BF16 2.0 = 0x4000 → bytes [0x00, 0x40]
+        // BF16 3.0 = 0x4040 → bytes [0x40, 0x40]
+        // BF16 4.0 = 0x4080 → bytes [0x80, 0x40]
+        let raw: Vec<u8> = vec![0x80, 0x3F, 0x00, 0x40, 0x40, 0x40, 0x80, 0x40];
+        let input = vec![1.0f32; 4];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        // num_rows=1, num_blocks_per_row=4 (num_cols), batch=1
+        let result = backend.dequant_matvec_bf16(&raw, &input, 1, 4, 1);
+
+        assert_eq!(result.len(), 1, "expected 1 output");
+        assert!(
+            (result[0] - 10.0).abs() < 1e-3,
+            "dequant_matvec_bf16 mismatch: got {}, expected 10.0",
+            result[0]
+        );
+    }
+
+    /// Verify GPU BF16 fused dequant+matvec with negative values.
+    ///
+    /// One row, 2 BF16 weights: -1.0, -2.0.
+    /// BF16 -1.0 = 0xBF80 → bytes [0x80, 0xBF]
+    /// BF16 -2.0 = 0xC000 → bytes [0x00, 0xC0]
+    /// Input: all 1.0. Expected: -1 + -2 = -3.
+    ///
+    /// Requires a GPU adapter; run with: `cargo test -p flarellm-gpu -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_dequant_matvec_bf16_negative_weights() {
+        let raw: Vec<u8> = vec![0x80, 0xBF, 0x00, 0xC0];
+        let input = vec![1.0f32; 2];
+
+        let backend = pollster::block_on(WebGpuBackend::new()).expect("GPU backend unavailable");
+        let result = backend.dequant_matvec_bf16(&raw, &input, 1, 2, 1);
+
+        assert_eq!(result.len(), 1, "expected 1 output");
+        assert!(
+            (result[0] - (-3.0)).abs() < 1e-3,
+            "dequant_matvec_bf16 negative mismatch: got {}, expected -3.0",
+            result[0]
+        );
     }
 }

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -413,6 +413,7 @@ impl GgufFile {
 /// Map a `QuantFormat` to a GPU-accelerated `WeightFormat`, if one exists.
 fn quant_to_weight_format(q: QuantFormat) -> Option<WeightFormat> {
     match q {
+        QuantFormat::BF16 => Some(WeightFormat::BF16),
         QuantFormat::Q4_1 => Some(WeightFormat::Q4_1),
         QuantFormat::Q8_1 => Some(WeightFormat::Q8_1),
         QuantFormat::Q4_0 => Some(WeightFormat::Q4_0),
@@ -443,6 +444,14 @@ fn dequantize_tensor(raw: &[u8], dtype: QuantFormat, numel: usize) -> Result<Vec
             for (i, chunk) in raw.chunks_exact(2).enumerate() {
                 let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
                 data[i] = quantize::f16_to_f32(bits);
+            }
+            Ok(data)
+        }
+        QuantFormat::BF16 => {
+            let mut data = vec![0.0f32; numel];
+            for (i, chunk) in raw.chunks_exact(2).enumerate() {
+                let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
+                data[i] = quantize::bf16_to_f32(bits);
             }
             Ok(data)
         }

--- a/flare-loader/src/quantize.rs
+++ b/flare-loader/src/quantize.rs
@@ -3,6 +3,7 @@
 pub enum QuantFormat {
     F32,
     F16,
+    BF16,
     Q4_0,
     Q4_1,
     Q5_0,
@@ -22,6 +23,7 @@ impl QuantFormat {
         match type_id {
             0 => QuantFormat::F32,
             1 => QuantFormat::F16,
+            32 => QuantFormat::BF16,
             2 => QuantFormat::Q4_0,
             3 => QuantFormat::Q4_1,
             6 => QuantFormat::Q5_0,
@@ -41,7 +43,7 @@ impl QuantFormat {
     pub fn bits_per_weight(&self) -> f32 {
         match self {
             QuantFormat::F32 => 32.0,
-            QuantFormat::F16 => 16.0,
+            QuantFormat::F16 | QuantFormat::BF16 => 16.0,
             QuantFormat::Q4_0 | QuantFormat::Q4_1 | QuantFormat::Q4K => 4.5,
             QuantFormat::Q5_0 | QuantFormat::Q5_1 | QuantFormat::Q5K => 5.5,
             QuantFormat::Q8_0 | QuantFormat::Q8_1 => 8.5,
@@ -55,7 +57,7 @@ impl QuantFormat {
     /// Block size for quantized formats (number of weights per block).
     pub fn block_size(&self) -> usize {
         match self {
-            QuantFormat::F32 | QuantFormat::F16 => 1,
+            QuantFormat::F32 | QuantFormat::F16 | QuantFormat::BF16 => 1,
             QuantFormat::Q4_0 | QuantFormat::Q4_1 => 32,
             QuantFormat::Q5_0 | QuantFormat::Q5_1 => 32,
             QuantFormat::Q8_0 | QuantFormat::Q8_1 => 32,
@@ -72,7 +74,7 @@ impl QuantFormat {
     pub fn block_bytes(&self) -> usize {
         match self {
             QuantFormat::F32 => 4,
-            QuantFormat::F16 => 2,
+            QuantFormat::F16 | QuantFormat::BF16 => 2,
             QuantFormat::Q4_0 => 18, // 2 (scale) + 16 (nibbles)
             QuantFormat::Q4_1 => 20, // 2 (scale) + 2 (min) + 16 (nibbles)
             QuantFormat::Q5_0 => 22, // 2 (scale) + 4 (high bits) + 16 (nibbles)
@@ -463,6 +465,14 @@ pub fn f16_to_f32(bits: u16) -> f32 {
     let exp = (exp + 127 - 15) & 0xFF;
     let mant = mant << 13;
     f32::from_bits((sign << 31) | (exp << 23) | mant)
+}
+
+/// Convert bfloat16 (as u16 bits) to f32.
+///
+/// BF16 shares the same exponent and sign layout as F32, but has only 7
+/// mantissa bits (vs 23 in F32). Conversion is a simple left-shift by 16.
+pub fn bf16_to_f32(bits: u16) -> f32 {
+    f32::from_bits((bits as u32) << 16)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #184

## Summary
- Adds `QuantFormat::BF16` (GGUF type ID 32) to `flare-loader` with `block_size=1`, `block_bytes=2`, and CPU dequantization via `bf16_to_f32()` (left-shift by 16)
- Adds `WeightFormat::BF16` to `flare-core` with `weights_per_block=1`
- New fused WGSL shader `dequant_matvec_bf16.wgsl`: reads 2-byte LE BF16 weights, converts to F32 via `bitcast<f32>(bf16_bits << 16u)`, accumulates dot product with input vector
- Wires BF16 into `quant_to_weight_format()` and the `batched_dequant_matmul` dispatch match in `flare-gpu`

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] `cargo test --workspace` passes (79 + 76 tests, 0 failures)
- [ ] GPU tests marked `#[ignore]` and runnable manually: `test_dequant_matvec_bf16_matches_cpu`, `test_dequant_matvec_bf16_negative_weights`