### PR TITLE
Add F16 (half-precision) weight format with fused GPU kernel

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -9,6 +9,7 @@ use crate::tensor::Tensor;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WeightFormat {
     BF16,
+    F16,
     Q2K,
     Q3K,
     Q4_0,
@@ -37,7 +38,7 @@ impl WeightFormat {
             | WeightFormat::Q5_1
             | WeightFormat::Q8_0
             | WeightFormat::Q8_1 => 32,
-            WeightFormat::BF16 => 1,
+            WeightFormat::BF16 | WeightFormat::F16 => 1,
         }
     }
 }

--- a/flare-gpu/shaders/dequant_matvec_f16.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_f16.wgsl
@@ -1,0 +1,120 @@
+// Fused F16 dequantize + batched matrix-vector multiply on GPU.
+//
+// Computes: output[b * num_rows + row] = Σ_j  f16_to_f32(raw[row, j]) * vec[b * num_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
+//
+// F16 layout (2 bytes per weight, no block structure):
+//   Each weight is a 16-bit IEEE 754 half-precision float in little-endian byte order.
+//   Conversion to F32 uses the WGSL built-in unpack2x16float(), which interprets
+//   the lower 16 bits of a u32 as an F16 value and returns the F32 equivalent.
+//
+// For a matrix of shape [num_rows, num_cols]:
+//   - Total bytes = num_rows × num_cols × 2
+//   - The shader param `num_blocks_per_row` carries `num_cols` (weights_per_block = 1)
+//   - Byte offset of weight (row, j) = (row × num_cols + j) × 2
+//
+// 2 bytes per weight may not be u32-aligned for odd num_cols.  The Rust caller
+// pads the raw byte buffer to the nearest 4-byte multiple before upload.
+// Individual bytes are extracted from u32 words via the `read_byte()` helper.
+//
+// One workgroup per (output row, batch item).  64 threads stride over columns;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings:
+//   binding 0: raw    — F16 weight data [num_rows × num_cols × 2 bytes, padded]
+//   binding 1: vec    — f32 input matrix [batch_size × num_cols]
+//   binding 2: output — f32 result       [batch_size × num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32, // = num_cols (one "block" per weight for F16)
+    batch_size:         u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+/// Convert an F16 value (LE u16 bits packed in low 16 bits of a u32) to f32.
+/// unpack2x16float interprets bits[0:15] as an F16 and returns it as f32.
+fn f16_to_f32(f16_bits: u32) -> f32 {
+    return unpack2x16float(f16_bits).x;
+}
+
+@compute @workgroup_size(64)
+fn dequant_matvec_f16(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
+        return;
+    }
+
+    let tid      = lid.x;
+    let num_cols = params.num_blocks_per_row;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across columns in this row.
+    var j: u32 = tid;
+    loop {
+        if j >= num_cols {
+            break;
+        }
+
+        // F16 weight at (row, j): byte offset = (row * num_cols + j) * 2
+        let byte_off  = (row * num_cols + j) * 2u;
+        let lo        = read_byte(byte_off);
+        let hi        = read_byte(byte_off + 1u);
+        let f16_bits  = lo | (hi << 8u);
+        let w         = f16_to_f32(f16_bits);
+
+        acc = acc + w * vec[batch * num_cols + j];
+
+        j = j + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u {
+        partials[tid] = partials[tid] + partials[tid + 32u];
+    }
+    workgroupBarrier();
+    if tid < 16u {
+        partials[tid] = partials[tid] + partials[tid + 16u];
+    }
+    workgroupBarrier();
+    if tid < 8u {
+        partials[tid] = partials[tid] + partials[tid + 8u];
+    }
+    workgroupBarrier();
+    if tid < 4u {
+        partials[tid] = partials[tid] + partials[tid + 4u];
+    }
+    workgroupBarrier();
+    if tid < 2u {
+        partials[tid] = partials[tid] + partials[tid + 2u];
+    }
+    workgroupBarrier();
+    if tid < 1u {
+        partials[tid] = partials[tid] + partials[tid + 1u];
+    }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[batch * params.num_rows + row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -27,6 +27,7 @@ const ATTENTION_SHADER: &str = include_str!("../shaders/attention.wgsl");
 const DEQUANT_Q4_1_SHADER: &str = include_str!("../shaders/dequant_q4_1.wgsl");
 const DEQUANT_Q4K_SHADER: &str = include_str!("../shaders/dequant_q4k.wgsl");
 const DEQUANT_MATVEC_BF16_SHADER: &str = include_str!("../shaders/dequant_matvec_bf16.wgsl");
+const DEQUANT_MATVEC_F16_SHADER: &str = include_str!("../shaders/dequant_matvec_f16.wgsl");
 const DEQUANT_MATVEC_Q2K_SHADER: &str = include_str!("../shaders/dequant_matvec_q2k.wgsl");
 const DEQUANT_MATVEC_Q3K_SHADER: &str = include_str!("../shaders/dequant_matvec_q3k.wgsl");
 const DEQUANT_MATVEC_Q4_0_SHADER: &str = include_str!("../shaders/dequant_matvec_q4_0.wgsl");
@@ -544,6 +545,74 @@ impl WebGpuBackend {
                 let bind_group =
                     self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
                 // One workgroup per output row.
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, batch as u32, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused F16 dequantize + batched matrix-vector multiply.
+    ///
+    /// Reads packed F16 (IEEE 754 half-precision) weight data, converts each
+    /// value to F32 on-the-fly using WGSL's `unpack2x16float`, and accumulates
+    /// the dot products with `input` in the same kernel.
+    ///
+    /// - `raw_bytes`: F16 weight data — `num_rows × num_cols × 2` bytes
+    ///   (padded to 4-byte multiple by caller if needed)
+    /// - `input`: f32 input matrix of length `batch × num_cols`
+    /// - `num_blocks_per_row`: equals `num_cols` (weights_per_block = 1 for F16)
+    /// - Returns `batch × num_rows` f32 dot products
+    pub fn dequant_matvec_f16(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * batch as u64 * 4;
+
+        // F16 data may not be u32-aligned — pad to next multiple of 4.
+        #[allow(clippy::manual_is_multiple_of)]
+        let raw_buf = if raw_bytes.len() % 4 == 0 {
+            self.pool.get_storage(&self.device, &self.queue, raw_bytes)
+        } else {
+            let mut padded = raw_bytes.to_vec();
+            padded.resize((padded.len() + 3) & !3, 0);
+            self.pool.get_storage(&self.device, &self.queue, &padded)
+        };
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_f16",
+            DEQUANT_MATVEC_F16_SHADER,
+            "dequant_matvec_f16",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
                 self.dispatch_and_readback(
                     &cached.pipeline,
                     &bind_group,
@@ -2216,6 +2285,9 @@ impl ComputeBackend for WebGpuBackend {
                 weight.blocks_per_row,
                 batch,
             ),
+            WeightFormat::F16 => {
+                self.dequant_matvec_f16(&weight.data, input, num_rows, weight.blocks_per_row, batch)
+            }
             WeightFormat::Q4_1 => self.dequant_matvec_q4_1(
                 &weight.data,
                 input,

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -414,6 +414,7 @@ impl GgufFile {
 fn quant_to_weight_format(q: QuantFormat) -> Option<WeightFormat> {
     match q {
         QuantFormat::BF16 => Some(WeightFormat::BF16),
+        QuantFormat::F16 => Some(WeightFormat::F16),
         QuantFormat::Q4_1 => Some(WeightFormat::Q4_1),
         QuantFormat::Q8_1 => Some(WeightFormat::Q8_1),
         QuantFormat::Q4_0 => Some(WeightFormat::Q4_0),


### PR DESCRIPTION
Closes #189

## Summary
- Adds `WeightFormat::F16` to `flare-core` with `weights_per_block = 1`
- New `dequant_matvec_f16.wgsl` shader uses `unpack2x16float(f16_bits).x` for clean F16→F32 conversion
- `dequant_matvec_f16` dispatch method in `flare-gpu/src/backend.rs` (same padding logic as BF16)
- `QuantFormat::F16 => Some(WeightFormat::F16)` wired into `quant_to_weight_format()`

F16 GGUF models (type 1) now run the fused GPU path instead of the CPU dequantization fallback.

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] `cargo test --workspace` passes (79 + 76 tests, 0 failures)
- [ ] GPU test `test_dequant_matvec_f16_matches_cpu` runnable with `cargo test -p flarellm-gpu -- --ignored`