### PR TITLE
Add IQ4_NL fused dequant+matvec GPU kernel (#190)

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -21,6 +21,7 @@ pub enum WeightFormat {
     Q6K,
     Q8_0,
     Q8_1,
+    IQ4NL,
 }
 
 impl WeightFormat {
@@ -37,7 +38,8 @@ impl WeightFormat {
             | WeightFormat::Q5_0
             | WeightFormat::Q5_1
             | WeightFormat::Q8_0
-            | WeightFormat::Q8_1 => 32,
+            | WeightFormat::Q8_1
+            | WeightFormat::IQ4NL => 32,
             WeightFormat::BF16 | WeightFormat::F16 => 1,
         }
     }

--- a/flare-gpu/shaders/dequant_matvec_iq4nl.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_iq4nl.wgsl
@@ -1,0 +1,132 @@
+// Fused IQ4_NL dequantize + batched matrix-vector multiply on GPU.
+//
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
+//
+// IQ4_NL block layout (18 bytes per block, 32 weights per block):
+//   bytes 0-1:  scale (f16 LE)
+//   bytes 2-17: qs[16] — 4-bit nibbles; byte k → (weight[2k], weight[2k+1])
+//                         lo nibble = weight[2k], hi nibble = weight[2k+1]
+//
+// Weight reconstruction: w[i] = scale * kvalues_iq4nl[nibble]
+// where kvalues_iq4nl is the 16-entry signed lookup table from llama.cpp.
+//
+// Unlike Q4_0 (which uses `q - 8`), IQ4_NL uses a neural-network-optimized
+// non-uniform codebook for better quality at the same bit width.
+//
+// 18 bytes is not u32-aligned.  The Rust caller pads the raw byte buffer to
+// the nearest 4-byte multiple before upload.  Weights are accessed via
+// byte-offset helpers that extract individual bytes from the u32 storage array.
+//
+// One workgroup per (output row, batch item). 64 threads split the blocks;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings:
+//   binding 0: raw    — packed IQ4_NL weight data [num_rows * num_blocks_per_row * 18 bytes, padded]
+//   binding 1: vec    — f32 input matrix           [batch_size * num_blocks_per_row * 32]
+//   binding 2: output — f32 result                 [batch_size * num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+    batch_size:         u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+/// IQ4_NL lookup table: maps a 4-bit nibble [0, 15] to a signed quantized value.
+/// Source: llama.cpp kvalues_iq4nl.
+const KVALUES_IQ4NL: array<i32, 16> = array<i32, 16>(
+    -127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113
+);
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+@compute @workgroup_size(64)
+fn dequant_matvec_iq4nl(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
+        return;
+    }
+
+    let tid = lid.x;
+    let in_cols = params.num_blocks_per_row * 32u;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across blocks in this row.
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Absolute byte offset of this block in the raw buffer (18 bytes per block).
+        let bb = (row * params.num_blocks_per_row + b) * 18u;
+        // Corresponding start position in the input matrix for this batch item.
+        let vec_base = batch * in_cols + b * 32u;
+
+        // Scale: f16 LE at bytes 0-1 of the block.
+        let scale_bits = read_byte(bb) | (read_byte(bb + 1u) << 8u);
+        let scale = unpack2x16float(scale_bits).x;
+
+        // Process qs[16]: bytes 2-17 of the block.
+        for (var k = 0u; k < 16u; k = k + 1u) {
+            let byte_val = read_byte(bb + 2u + k);
+            let lo_nibble = byte_val & 0x0Fu;
+            let hi_nibble = (byte_val >> 4u) & 0x0Fu;
+            let w_lo = scale * f32(KVALUES_IQ4NL[lo_nibble]);
+            let w_hi = scale * f32(KVALUES_IQ4NL[hi_nibble]);
+            acc = acc + w_lo * vec[vec_base + k * 2u];
+            acc = acc + w_hi * vec[vec_base + k * 2u + 1u];
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u {
+        partials[tid] = partials[tid] + partials[tid + 32u];
+    }
+    workgroupBarrier();
+    if tid < 16u {
+        partials[tid] = partials[tid] + partials[tid + 16u];
+    }
+    workgroupBarrier();
+    if tid < 8u {
+        partials[tid] = partials[tid] + partials[tid + 8u];
+    }
+    workgroupBarrier();
+    if tid < 4u {
+        partials[tid] = partials[tid] + partials[tid + 4u];
+    }
+    workgroupBarrier();
+    if tid < 2u {
+        partials[tid] = partials[tid] + partials[tid + 2u];
+    }
+    workgroupBarrier();
+    if tid < 1u {
+        partials[tid] = partials[tid] + partials[tid + 1u];
+    }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[batch * params.num_rows + row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -39,6 +39,7 @@ const DEQUANT_MATVEC_Q8_1_SHADER: &str = include_str!("../shaders/dequant_matvec
 const DEQUANT_MATVEC_Q4K_SHADER: &str = include_str!("../shaders/dequant_matvec_q4k.wgsl");
 const DEQUANT_MATVEC_Q5K_SHADER: &str = include_str!("../shaders/dequant_matvec_q5k.wgsl");
 const DEQUANT_MATVEC_Q6K_SHADER: &str = include_str!("../shaders/dequant_matvec_q6k.wgsl");
+const DEQUANT_MATVEC_IQ4NL_SHADER: &str = include_str!("../shaders/dequant_matvec_iq4nl.wgsl");
 const DEQUANT_Q5K_SHADER: &str = include_str!("../shaders/dequant_q5k.wgsl");
 const DEQUANT_Q6K_SHADER: &str = include_str!("../shaders/dequant_q6k.wgsl");
 const PREFILL_ATTENTION_SHADER: &str = include_str!("../shaders/prefill_attention.wgsl");
@@ -683,6 +684,73 @@ impl WebGpuBackend {
                 let bind_group =
                     self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
                 // One workgroup per output row.
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, batch as u32, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused IQ4_NL dequantize + batched matrix-vector multiply.
+    ///
+    /// IQ4_NL uses a 16-entry neural-network-optimized lookup table instead of
+    /// the simple `q - 8` mapping used by Q4_0, giving better quality at the
+    /// same 4-bit width.  Block layout is identical to Q4_0: 18 bytes per block
+    /// of 32 weights (2 bytes f16 scale + 16 bytes packed nibbles).
+    ///
+    /// - `raw_bytes`: packed GGUF tensor data — `num_rows × num_blocks_per_row × 18` bytes
+    /// - `input`: f32 input matrix of length `batch × num_blocks_per_row × 32`
+    /// - Returns `batch × num_rows` f32 dot products
+    pub fn dequant_matvec_iq4nl(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * batch as u64 * 4;
+
+        // IQ4_NL blocks are 18 bytes — pad to next multiple of 4 for wgpu.
+        #[allow(clippy::manual_is_multiple_of)]
+        let raw_buf = if raw_bytes.len() % 4 == 0 {
+            self.pool.get_storage(&self.device, &self.queue, raw_bytes)
+        } else {
+            let mut padded = raw_bytes.to_vec();
+            padded.resize((padded.len() + 3) & !3, 0);
+            self.pool.get_storage(&self.device, &self.queue, &padded)
+        };
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_iq4nl",
+            DEQUANT_MATVEC_IQ4NL_SHADER,
+            "dequant_matvec_iq4nl",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
                 self.dispatch_and_readback(
                     &cached.pipeline,
                     &bind_group,
@@ -2345,6 +2413,13 @@ impl ComputeBackend for WebGpuBackend {
             WeightFormat::Q6K => {
                 self.dequant_matvec_q6k(&weight.data, input, num_rows, weight.blocks_per_row, batch)
             }
+            WeightFormat::IQ4NL => self.dequant_matvec_iq4nl(
+                &weight.data,
+                input,
+                num_rows,
+                weight.blocks_per_row,
+                batch,
+            ),
         }
     }
 }

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -426,6 +426,7 @@ fn quant_to_weight_format(q: QuantFormat) -> Option<WeightFormat> {
         QuantFormat::Q4K => Some(WeightFormat::Q4K),
         QuantFormat::Q5K => Some(WeightFormat::Q5K),
         QuantFormat::Q6K => Some(WeightFormat::Q6K),
+        QuantFormat::IQ4NL => Some(WeightFormat::IQ4NL),
         _ => None,
     }
 }
@@ -491,6 +492,19 @@ fn dequantize_tensor(raw: &[u8], dtype: QuantFormat, numel: usize) -> Result<Vec
                 let block = &raw[b * block_bytes..(b + 1) * block_bytes];
                 let mut out = [0.0f32; 32];
                 quantize::dequant_q4_0_block(block, &mut out);
+                data[b * block_size..(b + 1) * block_size].copy_from_slice(&out);
+            }
+            Ok(data)
+        }
+        QuantFormat::IQ4NL => {
+            let block_size = 32;
+            let block_bytes = 18; // 2 (scale) + 16 (nibbles), same layout as Q4_0
+            let num_blocks = numel.div_ceil(block_size);
+            let mut data = vec![0.0f32; numel];
+            for b in 0..num_blocks {
+                let block = &raw[b * block_bytes..(b + 1) * block_bytes];
+                let mut out = [0.0f32; 32];
+                quantize::dequant_iq4nl_block(block, &mut out);
                 data[b * block_size..(b + 1) * block_size].copy_from_slice(&out);
             }
             Ok(data)

--- a/flare-loader/src/quantize.rs
+++ b/flare-loader/src/quantize.rs
@@ -79,7 +79,7 @@ impl QuantFormat {
             QuantFormat::F32 => 4,
             QuantFormat::F16 | QuantFormat::BF16 => 2,
             QuantFormat::Q4_0 | QuantFormat::IQ4NL => 18, // 2 (scale) + 16 (nibbles)
-            QuantFormat::Q4_1 => 20, // 2 (scale) + 2 (min) + 16 (nibbles)
+            QuantFormat::Q4_1 => 20,                      // 2 (scale) + 2 (min) + 16 (nibbles)
             QuantFormat::Q5_0 => 22, // 2 (scale) + 4 (high bits) + 16 (nibbles)
             QuantFormat::Q5_1 => 24, // 2 (scale) + 2 (min) + 4 (high bits) + 16 (nibbles)
             QuantFormat::Q8_0 => 34, // 2 (scale) + 32 (int8)

--- a/flare-loader/src/quantize.rs
+++ b/flare-loader/src/quantize.rs
@@ -15,6 +15,7 @@ pub enum QuantFormat {
     Q4K,
     Q5K,
     Q6K,
+    IQ4NL,
     Unknown(u32),
 }
 
@@ -35,6 +36,7 @@ impl QuantFormat {
             12 => QuantFormat::Q4K,
             13 => QuantFormat::Q5K,
             14 => QuantFormat::Q6K,
+            20 => QuantFormat::IQ4NL,
             other => QuantFormat::Unknown(other),
         }
     }
@@ -50,6 +52,7 @@ impl QuantFormat {
             QuantFormat::Q2K => 2.6,
             QuantFormat::Q3K => 3.4,
             QuantFormat::Q6K => 6.6,
+            QuantFormat::IQ4NL => 4.5, // 4 bits + 2-byte scale per 32 weights
             QuantFormat::Unknown(_) => 32.0, // assume worst case
         }
     }
@@ -58,7 +61,7 @@ impl QuantFormat {
     pub fn block_size(&self) -> usize {
         match self {
             QuantFormat::F32 | QuantFormat::F16 | QuantFormat::BF16 => 1,
-            QuantFormat::Q4_0 | QuantFormat::Q4_1 => 32,
+            QuantFormat::Q4_0 | QuantFormat::Q4_1 | QuantFormat::IQ4NL => 32,
             QuantFormat::Q5_0 | QuantFormat::Q5_1 => 32,
             QuantFormat::Q8_0 | QuantFormat::Q8_1 => 32,
             QuantFormat::Q2K
@@ -75,7 +78,7 @@ impl QuantFormat {
         match self {
             QuantFormat::F32 => 4,
             QuantFormat::F16 | QuantFormat::BF16 => 2,
-            QuantFormat::Q4_0 => 18, // 2 (scale) + 16 (nibbles)
+            QuantFormat::Q4_0 | QuantFormat::IQ4NL => 18, // 2 (scale) + 16 (nibbles)
             QuantFormat::Q4_1 => 20, // 2 (scale) + 2 (min) + 16 (nibbles)
             QuantFormat::Q5_0 => 22, // 2 (scale) + 4 (high bits) + 16 (nibbles)
             QuantFormat::Q5_1 => 24, // 2 (scale) + 2 (min) + 4 (high bits) + 16 (nibbles)
@@ -100,6 +103,28 @@ impl QuantFormat {
         }
         let num_blocks = elements.div_ceil(bs);
         num_blocks * bb
+    }
+}
+
+/// Lookup table for IQ4_NL dequantization (from llama.cpp).
+/// Maps a 4-bit nibble [0, 15] to a signed quantized value.
+pub const KVALUES_IQ4NL: [i8; 16] = [
+    -127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113,
+];
+
+/// Dequantize an IQ4_NL block: 32 weights via 16-entry lookup + f16 scale.
+/// Layout: 2 bytes scale (f16) + 16 bytes qs (32 packed 4-bit nibbles). 18 bytes total.
+pub fn dequant_iq4nl_block(block: &[u8], output: &mut [f32; 32]) {
+    if block.len() < 18 {
+        return;
+    }
+    let scale = f16_to_f32(u16::from_le_bytes([block[0], block[1]]));
+    for i in 0..16 {
+        let byte = block[2 + i];
+        let lo = KVALUES_IQ4NL[(byte & 0x0F) as usize];
+        let hi = KVALUES_IQ4NL[((byte >> 4) & 0x0F) as usize];
+        output[i * 2] = lo as f32 * scale;
+        output[i * 2 + 1] = hi as f32 * scale;
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `QuantFormat::IQ4NL` (GGUF type 20) with CPU dequant path using the 16-entry `kvalues_iq4nl` lookup table from llama.cpp
- Adds `WeightFormat::IQ4NL` in `flare-core` (32 weights per block, 18 bytes per block)
- New WGSL shader `dequant_matvec_iq4nl.wgsl`: identical block layout to Q4_0 (2-byte f16 scale + 16 bytes packed nibbles) but uses a non-uniform neural codebook for higher reconstruction quality at 4-bit width
- Wires into `flare-loader` (`quant_to_weight_format` + `dequantize_tensor`) and `flare-gpu` (shader constant + dispatch method + match arm in `batched_dequant_matmul`)

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (all tests green)
- [ ] IQ4_NL GGUF model loads and runs inference via GPU fused path

Closes #190