### PR TITLE
Expose architecture() and model_name() getters in WASM API

### DIFF
--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -132,6 +132,10 @@ pub struct FlareEngine {
     /// Raw Jinja2 chat template string from `tokenizer.chat_template` in GGUF metadata.
     /// `None` if the GGUF file did not include a chat template.
     raw_chat_template: Option<String>,
+    /// Architecture name from `general.architecture` in GGUF metadata (e.g. `"llama"`).
+    architecture: String,
+    /// Model display name from `general.name` in GGUF metadata, or empty string if absent.
+    model_name: String,
     /// Number of tokens consumed in the current KV-cache session (prompt + generated).
     /// Updated after every generation call; reset to 0 by `engine.reset()`.
     kv_pos: usize,
@@ -193,6 +197,13 @@ impl FlareEngine {
             .get("tokenizer.chat_template")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        let architecture = gguf.architecture().unwrap_or("unknown").to_string();
+        let model_name = gguf
+            .metadata
+            .get("general.name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
         let gguf_vocab = GgufVocab::from_gguf(&gguf).ok();
         let config = gguf
             .to_model_config()
@@ -208,6 +219,8 @@ impl FlareEngine {
             bos_token_id,
             add_bos_token,
             raw_chat_template,
+            architecture,
+            model_name,
             kv_pos: 0,
             stream_params: SamplingParams {
                 temperature: 0.0,
@@ -420,6 +433,24 @@ impl FlareEngine {
     #[wasm_bindgen(getter)]
     pub fn raw_chat_template(&self) -> Option<String> {
         self.raw_chat_template.clone()
+    }
+
+    /// Model architecture name from `general.architecture` in the GGUF metadata.
+    ///
+    /// Returns a lowercase string such as `"llama"`, `"mistral"`, `"gemma2"`,
+    /// `"phi3"`, or `"qwen2"`. Returns `"unknown"` if the field is absent.
+    #[wasm_bindgen(getter)]
+    pub fn architecture(&self) -> String {
+        self.architecture.clone()
+    }
+
+    /// Model display name from `general.name` in the GGUF metadata.
+    ///
+    /// Returns the human-readable name embedded by the model author (e.g.
+    /// `"Llama 3.2 1B Instruct"`). Returns an empty string if the field is absent.
+    #[wasm_bindgen(getter)]
+    pub fn model_name(&self) -> String {
+        self.model_name.clone()
     }
 
     /// Maximum sequence length (context window size) of the loaded model.
@@ -1066,6 +1097,13 @@ impl FlareProgressiveLoader {
             .get("tokenizer.chat_template")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        let architecture = gguf.architecture().unwrap_or("unknown").to_string();
+        let model_name = gguf
+            .metadata
+            .get("general.name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
         let gguf_vocab = GgufVocab::from_gguf(&gguf).ok();
         let config = gguf
             .to_model_config()
@@ -1087,6 +1125,8 @@ impl FlareProgressiveLoader {
             bos_token_id,
             add_bos_token,
             raw_chat_template,
+            architecture,
+            model_name,
             kv_pos: 0,
             stream_params: SamplingParams {
                 temperature: 0.0,


### PR DESCRIPTION
## Summary

- Adds  getter returning the lowercase architecture string from  GGUF metadata (e.g. , , , , ); falls back to 
- Adds  getter returning the display name from  GGUF metadata; falls back to empty string
- Both fields populated in  and the progressive loader constructor
-  and 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 79 tests
test chat::tests::test_from_gguf_template_chatml ... ok
test chat::tests::test_from_gguf_template_alpaca ... ok
test chat::tests::test_from_gguf_template_llama3 ... ok
test chat::tests::test_auto_detect ... ok
test chat::tests::test_alpaca_format ... ok
test chat::tests::test_from_gguf_template_phi3 ... ok
test chat::tests::test_from_gguf_template_gemma ... ok
test chat::tests::test_from_gguf_template_unknown_falls_back ... ok
test chat::tests::test_chatml_format ... ok
test chat::tests::test_gemma_format ... ok
test chat::tests::test_llama3_format ... ok
test chat::tests::test_phi3_format ... ok
test chat::tests::test_raw_format ... ok
test chat::tests::test_serde_role ... ok
test chat::tests::test_with_assistant_message ... ok
test config::tests::test_kv_cache_estimate ... ok
test config::tests::test_memory_estimates ... ok
test error::tests::test_context_length_error ... ok
test error::tests::test_error_display ... ok
test error::tests::test_from_tensor_error ... ok
test error::tests::test_from_tokenizer_error ... ok
test error::tests::test_oom_error ... ok
test generate::tests::test_batched_prefill_single_token ... ok
test kv_cache::tests::test_clear_and_reuse ... ok
test generate::tests::test_eos_stops_generation ... ok
test generate::tests::test_batched_prefill_matches_sequential ... ok
test kv_cache::tests::test_kv_cache_clear ... ok
test kv_cache::tests::test_kv_cache_basic ... ok
test kv_cache::tests::test_kv_cache_ring_buffer ... ok
test kv_cache::tests::test_minimal_cache_size_one ... ok
test kv_cache::tests::test_multi_layer_independence ... ok
test generate::tests::test_generation_loop ... ok
test kv_cache::tests::test_position_tracking_after_many_wraps ... ok
test kv_cache::tests::test_wraparound_data_integrity ... ok
test memory::tests::test_can_run ... ok
test memory::tests::test_format_bytes ... ok
test memory::tests::test_plan_fits_browser ... ok
test memory::tests::test_plan_fits_native ... ok
test memory::tests::test_plan_too_large_for_mobile ... ok
test memory::tests::test_recommended_context ... ok
test model::tests::test_forward_different_tokens_different_logits ... ok
test model::tests::test_forward_logits_are_finite ... ok
test model::tests::test_forward_output_shape ... ok
test model::tests::test_forward_residual_connection ... ok
test model::tests::test_gqa_heads_per_kv_group ... ok
test model::tests::test_matvec ... ok
test model::tests::test_forward_position_affects_output ... ok
test model::tests::test_multi_layer_forward ... ok
test model::tests::test_multi_token_forward_kv_cache_grows ... ok
test model::tests::test_rmsnorm ... ok
test model::tests::test_rope_preserves_magnitude ... ok
test sampling::tests::test_greedy ... ok
test sampling::tests::test_softmax_sums_to_one ... ok
test sampling::tests::test_temperature_zero_is_noop ... ok
test sampling::tests::test_top_k ... ok
test sampling::tests::test_top_p_deterministic_at_zero ... ok
test tensor::tests::test_add_inplace ... ok
test tensor::tests::test_from_vec ... ok
test tensor::tests::test_from_vec_mismatch ... ok
test tensor::tests::test_reshape ... ok
test tensor::tests::test_scale ... ok
test tensor::tests::test_zeros ... ok
test tokenizer::tests::test_decode_multiple_tokens ... ok
test model::tests::test_rmsnorm_simd_matches_naive ... ok
test tokenizer::tests::test_decode_roundtrip ... ok
test tokenizer::tests::test_decode_special_tokens ... ok
test tokenizer::tests::test_encode_empty ... ok
test tokenizer::tests::test_decode_unknown_id ... ok
test tokenizer::tests::test_encode_hello ... ok
test tokenizer::tests::test_encode_special_token ... ok
test tokenizer::tests::test_encode_with_unmergeable ... ok
test tokenizer::tests::test_invalid_json ... ok
test tokenizer::tests::test_gpt2_space_decoding ... ok
test tokenizer::tests::test_load_vocab_from_json ... ok
test tokenizer::tests::test_merges_loaded ... ok
test tokenizer::tests::test_special_tokens ... ok
test tokenizer::tests::test_vocab_size ... ok
test model::tests::test_matvec_simd_matches_scalar ... ok
test model::tests::test_matvec_parallel_matches_sequential ... ok

test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.21s


running 36 tests
test backend::tests::test_batched_rmsnorm_matches_cpu ... ignored
test backend::tests::test_batched_rope_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_bf16_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_bf16_negative_weights ... ignored
test backend::tests::test_dequant_matvec_q2k_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_q2k_with_min ... ignored
test backend::tests::test_dequant_matvec_q3k_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_q3k_multi_row ... ignored
test backend::tests::test_dequant_matvec_q4_0_nonzero ... ignored
test backend::tests::test_dequant_matvec_q4_0_zero_weights ... ignored
test backend::tests::test_dequant_matvec_q4_1_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_q4_1_multi_row ... ignored
test backend::tests::test_dequant_matvec_q4k_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_q4k_multi_row ... ignored
test backend::tests::test_dequant_matvec_q5_0_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_q5_0_multi_row ... ignored
test backend::tests::test_dequant_matvec_q5_1_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_q5_1_nonzero_min ... ignored
test backend::tests::test_dequant_matvec_q5k_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_q5k_multi_row ... ignored
test backend::tests::test_dequant_matvec_q6k_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_q6k_multi_row ... ignored
test backend::tests::test_dequant_matvec_q8_0_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_q8_0_negative_weights ... ignored
test backend::tests::test_dequant_matvec_q8_1_matches_cpu ... ignored
test backend::tests::test_dequant_matvec_q8_1_negative_weights ... ignored
test backend::tests::test_dequant_q3k_matches_cpu ... ignored
test backend::tests::test_dequant_q3k_zeroed ... ignored
test backend::tests::test_dequant_q4_1_matches_cpu ... ignored
test backend::tests::test_dequant_q4k_matches_cpu ... ignored
test backend::tests::test_dequant_q5k_matches_cpu ... ignored
test backend::tests::test_dequant_q6k_matches_cpu ... ignored
test backend::tests::test_dequant_q6k_zeroed ... ignored
test backend::tests::test_prefill_attention_matches_cpu ... ignored
test backend::tests::test_softmax_matches_cpu_reference ... ignored
test backend::tests::test_softmax_sums_to_one ... ignored

test result: ok. 0 passed; 0 failed; 36 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 4 tests
test test_gpu_matvec_basic ... ignored
test test_gpu_matvec_identity ... ignored
test test_gpu_matvec_large ... ignored
test test_gpu_silu_mul_vec ... ignored

test result: ok. 0 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 76 tests
test gguf::tests::test_dequant_k_blocks_partial_last_block ... ok
test gguf::tests::test_invalid_magic ... ok
test gguf::tests::test_parse_empty_gguf ... ok
test gguf::tests::test_parse_tensor_info ... ok
test gguf::tests::test_load_raw_layer_weights_missing_tensor_returns_none ... ok
test gguf::tests::test_read_raw_weight_missing_returns_none ... ok
test gguf::tests::test_parse_multiple_metadata_types ... ok
test gguf::tests::test_parse_metadata ... ok
test gguf::tests::test_load_raw_layer_weights_complete ... ok
test gguf::tests::test_read_raw_weight_bytes_match ... ok
test gguf::tests::test_read_raw_weight_q4_1_metadata ... ok
test gguf::tests::test_to_model_config_defaults ... ok
test gguf::tests::test_to_model_config_llama ... ok
test gguf::tests::test_to_model_config_missing_required ... ok
test gguf::tests::test_to_model_config_unsupported_arch ... ok
test gguf::tests::test_to_model_config_qwen2 ... ok
test gguf::tests::test_unsupported_version ... ok
test progressive::tests::test_extract_layer_index ... ok
test progressive::tests::test_layer_ready_check ... ok
test progressive::tests::test_load_plan_ordering ... ok
test progressive::tests::test_load_progress_basic ... ok
test progressive::tests::test_load_progress_complete ... ok
test progressive::tests::test_progressive_config_defaults ... ok
test quantize::tests::test_dequant_q2k_short_block ... ok
test quantize::tests::test_dequant_q2k_zeroed ... ok
test quantize::tests::test_dequant_q2k_nonzero ... ok
test quantize::tests::test_dequant_q3k_nonzero ... ok
test quantize::tests::test_dequant_q3k_short_block ... ok
test quantize::tests::test_dequant_q3k_zeroed ... ok
test quantize::tests::test_dequant_q4_0 ... ok
test quantize::tests::test_dequant_q4_1_with_min ... ok
test quantize::tests::test_dequant_q4_1_short_block ... ok
test quantize::tests::test_dequant_q4_1_nonzero ... ok
test quantize::tests::test_dequant_q4_1_zeroed ... ok
test quantize::tests::test_dequant_q4k_zeroed ... ok
test quantize::tests::test_dequant_q5k_short_block ... ok
test quantize::tests::test_dequant_q5k_zeroed ... ok
test quantize::tests::test_dequant_q6k_short_block ... ok
test quantize::tests::test_dequant_q6k_zeroed ... ok
test quantize::tests::test_dequant_q8_0 ... ok
test quantize::tests::test_dequant_q8_1_nonzero ... ok
test quantize::tests::test_dequant_q8_1_short_block ... ok
test quantize::tests::test_dequant_q8_1_zeroed ... ok
test quantize::tests::test_quant_format_from_gguf ... ok
test quantize::tests::test_f16_to_f32 ... ok
test safetensors::tests::test_bf16_conversion ... ok
test safetensors::tests::test_f16_conversion_roundtrip ... ok
test safetensors::tests::test_header_too_large ... ok
test safetensors::tests::test_parse_empty ... ok
test safetensors::tests::test_parse_metadata ... ok
test safetensors::tests::test_multiple_tensors ... ok
test safetensors::tests::test_read_f16_tensor ... ok
test safetensors::tests::test_read_bf16_tensor ... ok
test safetensors::tests::test_read_f32_tensor ... ok
test safetensors::tests::test_read_tensor_data_raw ... ok
test safetensors::tests::test_tensor_not_found ... ok
test safetensors::tests::test_tensor_names ... ok
test tokenizer::tests::test_control_tokens ... ok
test tokenizer::tests::test_decode_byte_token ... ok
test tokenizer::tests::test_decode_tokens ... ok
test tokenizer::tests::test_encode_bpe_merges ... ok
test tokenizer::tests::test_encode_empty ... ok
test tokenizer::tests::test_encode_token_lookup ... ok
test tokenizer::tests::test_extract_vocab ... ok
test tokenizer::tests::test_missing_tokens_metadata ... ok
test tokenizer::tests::test_token_types ... ok
test weights::tests::test_find_tensor_fallback ... ok
test weights::tests::test_find_tensor_missing ... ok
test weights::tests::test_infer_config_missing_embedding_fails ... ok
test tokenizer::tests::test_encode_byte_fallback ... ok
test weights::tests::test_load_layer_gguf_names ... ok
test weights::tests::test_load_layer_hf_names ... ok
test weights::tests::test_missing_layer_tensor_errors ... ok
test weights::tests::test_load_multiple_layers ... ok
test weights::tests::test_infer_config_from_safetensors ... ok
test weights::tests::test_infer_config_gqa ... ok

test result: ok. 76 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test test_q4k_real_block ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test test_q5_0_real_block ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 11 tests
test api::tests::test_deserialize_defaults ... ok
test api::tests::test_deserialize_request ... ok
test api::tests::test_serialize_chunk ... ok
test api::tests::test_serialize_response ... ok
test tests::test_sse_chunk_format ... ok
test tests::test_cors_headers_present ... ok
test tests::test_list_models ... ok
test tests::test_chat_completions_streaming_no_model_returns_error ... ok
test tests::test_chat_completions_no_model_returns_error ... ok
test tests::test_health_endpoint ... ok
test tests::test_streaming_returns_sse_content_type_when_no_model ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 8 tests
test backend::tests::test_matmul_non_square ... ok
test backend::tests::test_rmsnorm_unit_weight ... ok
test backend::tests::test_rope_preserves_magnitude ... ok
test backend::tests::test_silu_mul ... ok
test backend::tests::test_softmax_properties ... ok
test matmul::tests::test_matmul_larger ... ok
test matmul::tests::test_matmul_identity ... ok
test matmul::tests::test_matmul_basic ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test flarellm/src/lib.rs - (line 19) - compile ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 1 test
test flare-core/src/lib.rs - (line 9) ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test flare-loader/src/lib.rs - (line 8) ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s pass

Closes #202