### PR TITLE
Add wgpu driver pipeline cache for faster cold-start

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -352,6 +352,17 @@ pub trait ComputeBackend: Send + Sync {
              call Model::set_backend with a GPU backend before using quantized weights"
         )
     }
+
+    /// Serialise the driver-managed GPU pipeline cache to bytes.
+    ///
+    /// On backends that support `wgpu::Features::PIPELINE_CACHE` (Vulkan native),
+    /// this returns an opaque blob that can be passed to the backend constructor
+    /// on the next startup to skip shader recompilation.
+    ///
+    /// Returns an empty `Vec` on unsupported backends (WebGPU, Metal, DX12, CPU).
+    fn pipeline_cache_data(&self) -> Vec<u8> {
+        Vec::new()
+    }
 }
 
 /// Default CPU compute backend. Uses optimized scalar loops.
@@ -505,6 +516,11 @@ impl Model {
     /// Returns `true` if raw quantized weights have been set.
     pub fn has_raw_weights(&self) -> bool {
         self.raw_weights.is_some()
+    }
+
+    /// Return a reference to the current compute backend.
+    pub fn backend(&self) -> &dyn ComputeBackend {
+        self.backend.as_ref()
     }
 
     /// Replace the compute backend (e.g. with a GPU backend).

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::buffers::{self, BufferPool};
 use crate::kv_cache::GpuKvCache;
-use crate::pipeline::{CachedPipeline, PipelineCache};
+use crate::pipeline::{try_create_wgpu_cache, CachedPipeline, PipelineCache};
 
 #[derive(Debug, Error)]
 pub enum GpuError {
@@ -76,6 +76,27 @@ impl WebGpuBackend {
     /// Create a new GPU backend. This is async because adapter/device
     /// request is async on both native and web.
     pub async fn new() -> Result<Self, GpuError> {
+        Self::new_impl(None).await
+    }
+
+    /// Create a new GPU backend pre-loaded with serialised pipeline cache data.
+    ///
+    /// On backends that support `Features::PIPELINE_CACHE` (Vulkan), the driver
+    /// can reuse compiled GPU machine code from a previous run, avoiding cold-start
+    /// shader recompilation.  Pass bytes previously obtained from
+    /// [`Self::pipeline_cache_data`].  On unsupported backends the data is silently
+    /// ignored and the backend behaves identically to [`Self::new`].
+    ///
+    /// # Safety of cache data
+    ///
+    /// The data must originate from the same (or ABI-compatible) device and driver.
+    /// `fallback: true` is set so the driver discards mismatched blobs without
+    /// causing undefined behaviour.
+    pub async fn new_with_cache(data: &[u8]) -> Result<Self, GpuError> {
+        Self::new_impl(Some(data)).await
+    }
+
+    async fn new_impl(cache_data: Option<&[u8]>) -> Result<Self, GpuError> {
         let instance = wgpu::Instance::default();
 
         let adapter = instance
@@ -87,11 +108,21 @@ impl WebGpuBackend {
             .await
             .ok_or(GpuError::NoAdapter)?;
 
+        // Enable PIPELINE_CACHE if the backend supports it (Vulkan).
+        // On WebGPU / Metal / DX12 the feature flag is absent; requesting an
+        // absent feature is an error, so we check first.
+        let adapter_features = adapter.features();
+        let extra_features = if adapter_features.contains(wgpu::Features::PIPELINE_CACHE) {
+            wgpu::Features::PIPELINE_CACHE
+        } else {
+            wgpu::Features::empty()
+        };
+
         let (device, queue) = adapter
             .request_device(
                 &wgpu::DeviceDescriptor {
                     label: Some("flare-gpu"),
-                    required_features: wgpu::Features::empty(),
+                    required_features: extra_features,
                     required_limits: wgpu::Limits::default(),
                     ..Default::default()
                 },
@@ -100,13 +131,32 @@ impl WebGpuBackend {
             .await
             .map_err(|e| GpuError::DeviceRequest(e.to_string()))?;
 
+        let pipeline_cache = match try_create_wgpu_cache(&device, adapter_features, cache_data) {
+            Some(wgpu_cache) => {
+                log::debug!("flare-gpu: driver pipeline cache enabled");
+                PipelineCache::new_with_wgpu_cache(wgpu_cache)
+            }
+            None => PipelineCache::new(),
+        };
+
         Ok(Self {
             device,
             queue,
-            cache: PipelineCache::new(),
+            cache: pipeline_cache,
             pool: BufferPool::new(),
             gpu_kv_cache: Mutex::new(None),
         })
+    }
+
+    /// Serialise the driver-managed pipeline cache to bytes.
+    ///
+    /// Store these bytes and pass them to [`Self::new_with_cache`] on the next
+    /// startup to skip shader recompilation on supported backends (Vulkan).
+    ///
+    /// Returns an empty `Vec` on backends that do not support pipeline caching
+    /// or when the driver has not produced any serialisable data yet.
+    pub fn get_pipeline_cache_bytes(&self) -> Vec<u8> {
+        self.cache.get_data()
     }
 
     pub fn device(&self) -> &wgpu::Device {
@@ -2421,6 +2471,10 @@ impl ComputeBackend for WebGpuBackend {
                 batch,
             ),
         }
+    }
+
+    fn pipeline_cache_data(&self) -> Vec<u8> {
+        self.get_pipeline_cache_bytes()
     }
 }
 

--- a/flare-gpu/src/pipeline.rs
+++ b/flare-gpu/src/pipeline.rs
@@ -1,8 +1,16 @@
 //! Cached compute pipelines to amortize shader compilation cost.
 //!
 //! Compiling a WGSL shader and creating a compute pipeline costs ~100µs to
-//! several ms on first call. This cache holds the compiled artifacts so
-//! repeated calls (e.g., per-layer matvec in inference) only pay the cost once.
+//! several ms on first call. This in-memory cache holds the compiled artifacts
+//! so repeated calls (e.g., per-layer matvec in inference) only pay the cost once.
+//!
+//! Additionally, if `Features::PIPELINE_CACHE` is supported by the GPU backend
+//! (currently Vulkan only), a `wgpu::PipelineCache` can be supplied.  The driver
+//! then serialises compiled GPU machine code to an opaque blob; restoring the blob
+//! on the next run lets the driver skip recompilation entirely.
+//!
+//! On backends that do not support `PIPELINE_CACHE` (WebGPU, Metal, DX12, GL) the
+//! `wgpu_cache` field is `None` and `get_data()` returns an empty `Vec`.
 
 use std::collections::HashMap;
 use std::sync::RwLock;
@@ -13,11 +21,14 @@ pub struct CachedPipeline {
     pub layout: wgpu::BindGroupLayout,
 }
 
-/// Lazy cache for compute pipelines, keyed by name.
+/// Lazy in-memory cache for compute pipelines, optionally backed by a
+/// `wgpu::PipelineCache` for cross-session persistence.
 ///
-/// Uses RwLock for interior mutability so it can be held behind &self.
+/// Uses `RwLock` for interior mutability so it can be held behind `&self`.
 pub struct PipelineCache {
     cache: RwLock<HashMap<&'static str, CachedPipeline>>,
+    /// Driver-managed binary cache; `None` on backends that don't support it.
+    wgpu_cache: Option<wgpu::PipelineCache>,
 }
 
 impl Default for PipelineCache {
@@ -27,10 +38,37 @@ impl Default for PipelineCache {
 }
 
 impl PipelineCache {
+    /// Create a cache with no driver-level pipeline cache backing.
     pub fn new() -> Self {
         Self {
             cache: RwLock::new(HashMap::new()),
+            wgpu_cache: None,
         }
+    }
+
+    /// Create a cache backed by a driver-level `wgpu::PipelineCache`.
+    ///
+    /// The driver cache accelerates repeated starts on backends that support
+    /// `Features::PIPELINE_CACHE` (Vulkan).  On other backends, pass the
+    /// result of [`try_create_wgpu_cache`] which returns `None` safely.
+    pub fn new_with_wgpu_cache(wgpu_cache: wgpu::PipelineCache) -> Self {
+        Self {
+            cache: RwLock::new(HashMap::new()),
+            wgpu_cache: Some(wgpu_cache),
+        }
+    }
+
+    /// Serialise the driver-managed binary cache to bytes.
+    ///
+    /// Returns an empty `Vec` if no driver cache is active or if the backend
+    /// does not produce any data (e.g. the driver manages its own cache).
+    /// The bytes can be stored and later fed back via
+    /// [`WebGpuBackend::new_with_cache`] to skip recompilation on next start.
+    pub fn get_data(&self) -> Vec<u8> {
+        self.wgpu_cache
+            .as_ref()
+            .and_then(|c| c.get_data())
+            .unwrap_or_default()
     }
 
     /// Run `f` with the cached pipeline for `name`, building it on first call.
@@ -83,7 +121,9 @@ impl PipelineCache {
                 module: &shader_module,
                 entry_point: Some(entry_point),
                 compilation_options: Default::default(),
-                cache: None,
+                // Pass the driver cache when available so compiled GPU machine
+                // code can be reused across sessions on supported backends.
+                cache: self.wgpu_cache.as_ref(),
             });
 
             write.insert(name, CachedPipeline { pipeline, layout });
@@ -91,4 +131,41 @@ impl PipelineCache {
 
         f(write.get(name).expect("just inserted"))
     }
+}
+
+/// Attempt to create a `wgpu::PipelineCache` on `device` using `data` as the
+/// initial blob (pass `None` for a fresh cache).
+///
+/// Returns `None` if the `PIPELINE_CACHE` feature is not available on the
+/// current backend.
+///
+/// # Safety
+///
+/// The caller must ensure `data`, when `Some`, was obtained from a previous call
+/// to [`PipelineCache::get_data`] on a *compatible* device (same GPU, same driver
+/// version). Passing mismatched data is safe only because `fallback: true` makes
+/// the driver silently discard invalid blobs rather than invoking UB.
+///
+/// The `unsafe` block is required by the wgpu API (`Device::create_pipeline_cache`
+/// is marked `unsafe` because the caller is responsible for data validity).
+pub fn try_create_wgpu_cache(
+    device: &wgpu::Device,
+    features: wgpu::Features,
+    data: Option<&[u8]>,
+) -> Option<wgpu::PipelineCache> {
+    if !features.contains(wgpu::Features::PIPELINE_CACHE) {
+        return None;
+    }
+    // SAFETY: `fallback: true` means the driver discards invalid data rather than
+    // causing undefined behaviour.  When `data` is `Some`, it must come from
+    // `PipelineCache::get_data()` on a compatible device; the caller is responsible
+    // for that contract, but the fallback flag provides a safety net.
+    let cache = unsafe {
+        device.create_pipeline_cache(&wgpu::PipelineCacheDescriptor {
+            label: Some("flare-pipeline-cache"),
+            data,
+            fallback: true,
+        })
+    };
+    Some(cache)
 }

--- a/flare-gpu/src/pipeline.rs
+++ b/flare-gpu/src/pipeline.rs
@@ -63,7 +63,7 @@ impl PipelineCache {
     /// Returns an empty `Vec` if no driver cache is active or if the backend
     /// does not produce any data (e.g. the driver manages its own cache).
     /// The bytes can be stored and later fed back via
-    /// [`WebGpuBackend::new_with_cache`] to skip recompilation on next start.
+    /// `WebGpuBackend::new_with_cache` to skip recompilation on next start.
     pub fn get_data(&self) -> Vec<u8> {
         self.wgpu_cache
             .as_ref()

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -265,6 +265,58 @@ impl FlareEngine {
         }
     }
 
+    /// Initialise the WebGPU backend using previously serialised pipeline cache
+    /// bytes (from `engine.pipeline_cache_data()`).
+    ///
+    /// On backends that support driver-managed pipeline caches (Vulkan native),
+    /// this allows the driver to reuse compiled GPU machine code from a previous
+    /// run, eliminating cold-start shader recompilation (typically 100ms–2s).
+    ///
+    /// On unsupported backends (WebGPU, Metal, DX12) this behaves identically to
+    /// `init_gpu()` — the cache bytes are silently ignored.
+    ///
+    /// ```javascript
+    /// const cached = localStorage.getItem('flare-pipeline-cache');
+    /// const cacheBytes = cached ? new Uint8Array(JSON.parse(cached)) : new Uint8Array();
+    /// await engine.init_gpu_with_cache(cacheBytes);
+    /// // After inference, persist the cache:
+    /// const data = engine.pipeline_cache_data();
+    /// if (data.length > 0) {
+    ///   localStorage.setItem('flare-pipeline-cache', JSON.stringify(Array.from(data)));
+    /// }
+    /// ```
+    #[wasm_bindgen]
+    pub async fn init_gpu_with_cache(&mut self, cache_data: &[u8]) -> bool {
+        if !webgpu_available() {
+            return false;
+        }
+        let result = if cache_data.is_empty() {
+            WebGpuBackend::new().await
+        } else {
+            WebGpuBackend::new_with_cache(cache_data).await
+        };
+        match result {
+            Ok(gpu) => {
+                self.model.set_backend(Box::new(gpu));
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Serialise the driver-managed GPU pipeline cache to bytes.
+    ///
+    /// Returns an opaque blob that can be passed to `init_gpu_with_cache()` on
+    /// the next startup to skip shader recompilation.  Store it in
+    /// `localStorage` or `IndexedDB` between page loads.
+    ///
+    /// Returns an empty `Uint8Array` if no GPU is active, or if the current
+    /// backend does not support pipeline caching (WebGPU, Metal, DX12).
+    #[wasm_bindgen(getter)]
+    pub fn pipeline_cache_data(&self) -> Vec<u8> {
+        self.model.backend().pipeline_cache_data()
+    }
+
     /// Load raw quantized weights from GGUF bytes so the GPU fused
     /// dequant+matvec kernels can be used during inference.
     ///


### PR DESCRIPTION
## Summary

- Extends `PipelineCache` in `flare-gpu` to optionally hold a `wgpu::PipelineCache`, which lets the GPU driver serialise compiled machine code across sessions
- Adds `try_create_wgpu_cache()` helper: checks for `Features::PIPELINE_CACHE` (Vulkan only); returns `None` on unsupported backends (WebGPU, Metal, DX12) with no behaviour change
- Adds `WebGpuBackend::new_with_cache(data)` constructor and `get_pipeline_cache_bytes()` for native persistence
- Adds `ComputeBackend::pipeline_cache_data()` trait method (default: empty Vec) and `Model::backend()` accessor
- Exposes `engine.init_gpu_with_cache(cacheBytes)` and `engine.pipeline_cache_data` getter in WASM API so browsers can persist the cache in `localStorage`/`IndexedDB`

Closes #193