### PR TITLE
Add min-p sampling to flare-core and WASM API

### DIFF
--- a/flare-core/src/generate.rs
+++ b/flare-core/src/generate.rs
@@ -51,13 +51,17 @@ impl<'a> Generator<'a> {
         sampling::apply_repeat_penalty(&mut logits, &self.tokens, self.params.repeat_penalty);
         sampling::apply_temperature(&mut logits, self.params.temperature);
 
-        // Sample
+        // Sample — priority: greedy > top_p > min_p > top_k > full nucleus
         let token_id = if self.params.temperature == 0.0 {
             sampling::sample_greedy(&logits)
         } else if self.params.top_p < 1.0 {
             sampling::sample_top_p(&logits, self.params.top_p, rng_val)
-        } else {
+        } else if self.params.min_p > 0.0 {
+            sampling::sample_min_p(&logits, self.params.min_p, rng_val)
+        } else if self.params.top_k > 0 {
             sampling::sample_top_k(&logits, self.params.top_k, rng_val)
+        } else {
+            sampling::sample_top_p(&logits, 1.0, rng_val)
         };
 
         self.tokens.push(token_id);

--- a/flare-core/src/sampling.rs
+++ b/flare-core/src/sampling.rs
@@ -7,6 +7,11 @@ pub struct SamplingParams {
     pub top_p: f32,
     pub top_k: usize,
     pub repeat_penalty: f32,
+    /// Min-p threshold (0.0 = disabled).  When enabled, samples all tokens
+    /// whose probability is ≥ `min_p * p_max` (where `p_max` is the highest
+    /// token probability after softmax).  Takes precedence over `top_k` but
+    /// yields to `top_p` when `top_p < 1.0`.
+    pub min_p: f32,
 }
 
 impl Default for SamplingParams {
@@ -16,6 +21,7 @@ impl Default for SamplingParams {
             top_p: 0.9,
             top_k: 40,
             repeat_penalty: 1.1,
+            min_p: 0.0,
         }
     }
 }
@@ -168,6 +174,55 @@ pub fn sample_top_k(logits: &[f32], top_k: usize, rng_val: f32) -> u32 {
     items[items.len() - 1].1
 }
 
+/// Min-p sampling: keep all tokens whose probability is ≥ `min_p * p_max`.
+///
+/// `p_max` is the maximum token probability after softmax.  Tokens below the
+/// threshold are discarded and the remaining candidates are sampled
+/// proportionally.  Falls back to the top-1 (greedy) token when no candidate
+/// survives the threshold.
+///
+/// This method avoids the "repetition trap" that nucleus sampling can exhibit
+/// while still restricting the tail of the distribution.
+pub fn sample_min_p(logits: &[f32], min_p: f32, rng_val: f32) -> u32 {
+    let probs = softmax(logits);
+
+    let p_max = probs.iter().cloned().fold(0.0f32, f32::max);
+    let threshold = min_p * p_max;
+
+    // Collect candidates above the threshold.
+    let mut candidates: Vec<(f32, u32)> = probs
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &p)| {
+            if p >= threshold {
+                Some((p, i as u32))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if candidates.is_empty() {
+        // Safety fallback: return greedy token.
+        return sample_greedy(logits);
+    }
+
+    // Sort descending by probability for consistent behaviour with top_p / top_k.
+    candidates.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let total: f32 = candidates.iter().map(|&(p, _)| p).sum();
+    let target = rng_val * total;
+
+    let mut acc = 0.0f32;
+    for &(p, idx) in &candidates {
+        acc += p;
+        if acc >= target {
+            return idx;
+        }
+    }
+    candidates[candidates.len() - 1].1
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -208,5 +263,23 @@ mod tests {
         let token = sample_top_k(&logits, 2, 0.01);
         // Should be one of the top 2
         assert!(token == 1 || token == 0);
+    }
+
+    #[test]
+    fn test_min_p_keeps_high_prob_tokens() {
+        // Token 1 has a much higher logit; with min_p=0.1, token 2 (logit=0.1)
+        // should be excluded and only the dominant token returned.
+        let logits = vec![0.01, 10.0, 0.01, 0.01];
+        let token = sample_min_p(&logits, 0.1, 0.01);
+        assert_eq!(token, 1, "dominant token should win with tight min_p");
+    }
+
+    #[test]
+    fn test_min_p_fallback_on_zero() {
+        // min_p=0 should behave like sampling from all tokens (threshold=0)
+        let logits = vec![1.0, 2.0, 3.0];
+        let token = sample_min_p(&logits, 0.0, 0.01);
+        // With rng~0, highest-prob token should dominate
+        assert_eq!(token, 2);
     }
 }

--- a/flare-server/src/cli.rs
+++ b/flare-server/src/cli.rs
@@ -118,6 +118,7 @@ fn main() {
         top_p: 0.9,
         top_k: 40,
         repeat_penalty: 1.1,
+        min_p: 0.0,
     };
 
     // Detect chat template from GGUF metadata or architecture

--- a/flare-server/src/main.rs
+++ b/flare-server/src/main.rs
@@ -388,6 +388,7 @@ async fn non_stream_response(
         top_p: req.top_p,
         top_k: 40,
         repeat_penalty: req.repeat_penalty,
+        min_p: 0.0,
     };
 
     model.reset();
@@ -453,6 +454,7 @@ async fn stream_response(
         top_p: req.top_p,
         top_k: 40,
         repeat_penalty: req.repeat_penalty,
+        min_p: 0.0,
     };
 
     let max_tokens = req.max_tokens;

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -857,8 +857,9 @@ impl FlareEngine {
     ///
     /// - `temperature`: 0 = greedy, higher = more diverse
     /// - `top_p`: nucleus sampling (1.0 = disabled)
-    /// - `top_k`: top-k sampling, applied when `top_p` is 1.0 (0 = disabled)
+    /// - `top_k`: top-k sampling, applied when `top_p` is 1.0 and `min_p` is 0.0 (0 = disabled)
     /// - `repeat_penalty`: repetition penalty (1.0 = disabled, 1.1–1.3 = typical)
+    /// - `min_p`: min-p threshold (0.0 = disabled)
     ///
     /// Encodes `prompt` with the embedded GGUF vocabulary, generates up to
     /// `max_tokens` tokens, and calls `on_token(token_str)` with the decoded
@@ -873,7 +874,7 @@ impl FlareEngine {
     /// engine.reset();
     /// let out = '';
     /// const count = engine.generate_stream_with_params(
-    ///   prompt, 200, 0.8, 0.95, 40, 1.1,
+    ///   prompt, 200, 0.8, 0.95, 40, 1.1, 0.0,
     ///   (token) => { out += token; }
     /// );
     /// ```
@@ -887,6 +888,7 @@ impl FlareEngine {
         top_p: f32,
         top_k: u32,
         repeat_penalty: f32,
+        min_p: f32,
         on_token: &js_sys::Function,
     ) -> u32 {
         let raw_tokens = match &self.gguf_vocab {
@@ -900,6 +902,7 @@ impl FlareEngine {
             top_p,
             top_k,
             repeat_penalty,
+            min_p,
         );
         let mut count = 0u32;
         while let Some(token_id) = self.next_token() {
@@ -975,8 +978,9 @@ impl FlareEngine {
     ///   reduce repetition (1.0 = disabled, 1.1–1.3 = typical range)
     ///
     /// ```javascript
-    /// engine.begin_stream_with_params(promptIds, 200, 0.8, 0.95, 40, 1.1);
+    /// engine.begin_stream_with_params(promptIds, 200, 0.8, 0.95, 40, 1.1, 0.0);
     /// ```
+    #[allow(clippy::too_many_arguments)]
     #[wasm_bindgen]
     pub fn begin_stream_with_params(
         &mut self,
@@ -986,12 +990,14 @@ impl FlareEngine {
         top_p: f32,
         top_k: u32,
         repeat_penalty: f32,
+        min_p: f32,
     ) {
         self.stream_params = SamplingParams {
             temperature,
             top_p,
             top_k: top_k as usize,
             repeat_penalty,
+            min_p,
         };
         self.stream_rng_state = self.rng_seed;
         self.begin_stream_impl(prompt_tokens, max_tokens);
@@ -1064,10 +1070,11 @@ impl FlareEngine {
                 .wrapping_mul(1664525)
                 .wrapping_add(1013904223);
             let rng_val = (self.stream_rng_state as f32) / (u32::MAX as f32);
-            // Mirror Generator::step() logic: top_p takes precedence; fall back
-            // to top_k when top_p is 1.0 (disabled); otherwise sample all tokens.
+            // Mirror Generator::step() priority: top_p > min_p > top_k > full nucleus
             if self.stream_params.top_p < 1.0 {
                 sampling::sample_top_p(&logits, self.stream_params.top_p, rng_val)
+            } else if self.stream_params.min_p > 0.0 {
+                sampling::sample_min_p(&logits, self.stream_params.min_p, rng_val)
             } else if self.stream_params.top_k > 0 {
                 sampling::sample_top_k(&logits, self.stream_params.top_k, rng_val)
             } else {
@@ -1226,10 +1233,12 @@ impl FlareEngine {
     ///
     /// - `temperature`: 0 = greedy, higher = more diverse
     /// - `top_p`: nucleus sampling (1.0 = disabled)
-    /// - `top_k`: top-k sampling, applied when `top_p` is 1.0 (0 = disabled)
+    /// - `top_k`: top-k sampling, applied when `top_p` is 1.0 and `min_p` is 0.0 (0 = disabled)
     /// - `repeat_penalty`: repetition penalty applied to recently-seen tokens (1.0 = disabled)
+    /// - `min_p`: min-p threshold (0.0 = disabled); applied after `top_p`, before `top_k`
     ///
     /// Stops early at EOS. Uses a fixed LCG RNG seed for reproducibility.
+    #[allow(clippy::too_many_arguments)]
     #[wasm_bindgen]
     pub fn generate_with_params(
         &mut self,
@@ -1239,6 +1248,7 @@ impl FlareEngine {
         top_p: f32,
         top_k: u32,
         repeat_penalty: f32,
+        min_p: f32,
     ) -> Vec<u32> {
         let effective = self.with_bos(prompt_tokens);
         let params = SamplingParams {
@@ -1246,6 +1256,7 @@ impl FlareEngine {
             top_p,
             top_k: top_k as usize,
             repeat_penalty,
+            min_p,
         };
         let stop_seqs = &self.stop_sequences;
         let vocab = &self.gguf_vocab;


### PR DESCRIPTION
## Summary
- New `min_p: f32` field in `SamplingParams` (default `0.0` = disabled)
- `sample_min_p(logits, min_p, rng)` — keeps all tokens with probability ≥ `min_p * p_max`, sorts candidates descending for consistency with `top_p` / `top_k`, samples proportionally
- `Generator::step()` sampling priority: `greedy > top_p > min_p > top_k > full nucleus`
- `begin_stream_with_params`, `generate_with_params`, and `generate_stream_with_params` each accept `min_p` as a new parameter
- Streaming `next_token()` path updated to match `Generator` priority
- `flare-server` and CLI initializers updated with `min_p: 0.0`

## Usage
```javascript
// Use min-p=0.05 instead of top-k
engine.begin_stream_with_params(promptIds, 200, 0.8, 1.0, 0, 1.1, 0.05);
```

## Test plan
- [ ] CI passes (fmt, clippy, doc, test, WASM build, Docker build)
- [ ] `test_min_p_keeps_high_prob_tokens` — dominant token wins with tight threshold
- [ ] `test_min_p_fallback_on_zero` — zero threshold includes all tokens

Closes #219