### PR TITLE
Add num_heads WASM getter; complete tokenizer/metadata API (#226, #227)

### DIFF
--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -520,6 +520,12 @@ impl FlareEngine {
         self.model.config().hidden_dim as u32
     }
 
+    /// Get the number of attention heads.
+    #[wasm_bindgen(getter)]
+    pub fn num_heads(&self) -> u32 {
+        self.model.config().num_heads as u32
+    }
+
     /// Name of the auto-detected chat template (e.g. `"ChatML"`, `"Llama3"`,
     /// `"Alpaca"`, `"Raw"`).  Use this to display the template in the UI and
     /// decide whether to call `apply_chat_template` before encoding.


### PR DESCRIPTION
## Summary

- Adds `num_heads` getter to `FlareEngine` so JS code can read the number of attention heads from the loaded model
- Closes #226 and #227: all other requested methods (`encode_text`, `decode_ids`, `vocab_size`, `count_tokens`, `max_seq_len`, `num_layers`, `hidden_dim`, `model_name`) were already present in the WASM API

## Changes

- `flare-web/src/lib.rs`: +6 lines — `num_heads()` getter backed by `self.model.config().num_heads`

## Test plan
- [ ] `cargo check -p flarellm-web` passes
- [ ] CI (Check, Clippy, Format, Test, WASM build, Docker build) all green