### PR TITLE
Add IQ2_XS and IQ3_XXS fused dequant+matvec GPU kernels

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -23,6 +23,8 @@ pub enum WeightFormat {
     Q8_1,
     IQ4NL,
     IQ2XXS,
+    IQ2XS,
+    IQ3XXS,
 }
 
 impl WeightFormat {
@@ -34,7 +36,9 @@ impl WeightFormat {
             | WeightFormat::Q4K
             | WeightFormat::Q5K
             | WeightFormat::Q6K
-            | WeightFormat::IQ2XXS => 256,
+            | WeightFormat::IQ2XXS
+            | WeightFormat::IQ2XS
+            | WeightFormat::IQ3XXS => 256,
             WeightFormat::Q4_0
             | WeightFormat::Q4_1
             | WeightFormat::Q5_0

--- a/flare-gpu/shaders/dequant_matvec_iq2xs.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_iq2xs.wgsl
@@ -1,0 +1,443 @@
+// Fused IQ2_XS dequantize + batched matrix-vector multiply on GPU.
+//
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
+//
+// IQ2_XS block layout (74 bytes per block, 256 weights per block — GGUF type 17):
+//   bytes 0-1:   d  — f16 LE super-block scale
+//   bytes 2-65:  qs[32] — 32 × uint16 LE
+//     Each uint16: bits[8:0] = 9-bit grid index (0-511), bits[15:9] = 7-bit sign index
+//   bytes 66-73: scales[8] — 8 × uint8, one per ib32 group
+//     Per ib32: lo nibble = dl1 scale, hi nibble = dl2 scale
+//
+// For each ib32 ∈ [0, 7]:
+//   scale_byte = scales[ib32]
+//   dl1 = d * (0.5 + f32(scale_byte & 0xf)) * 0.25   (used for qs[0], qs[1])
+//   dl2 = d * (0.5 + f32(scale_byte >> 4)) * 0.25    (used for qs[2], qs[3])
+//   For j ∈ [0, 1]:  dl = dl1 if j==0 else dl2
+//     For k ∈ [0, 1]:  entry = qs[4*ib32 + 2*j + k]
+//       grid_idx   = entry & 0x1FF
+//       sign_7bit  = entry >> 9
+//       signs_8bit = KSIGNS_IQ2XS[sign_7bit] → 8 sign bits
+//       For i ∈ [0, 7]: weight = dl * grid_byte(grid_idx, i) * sign(signs_8bit, i)
+//
+// Lookup tables embedded as WGSL const arrays (sourced from llama.cpp ggml-common.h):
+//   IQ2XS_GRID_LO / IQ2XS_GRID_HI  — low/high u32 halves of iq2xs_grid[512] (uint64_t)
+//   KSIGNS_IQ2XS                    — ksigns_iq2xs[128] packed 4-per-u32
+//
+// 74 bytes is not u32-aligned.  The Rust caller pads the raw buffer to the
+// nearest 4-byte multiple before upload.
+//
+// One workgroup per (output row, batch item). 64 threads split the 8 super-block
+// groups; a tree reduction accumulates partial sums.
+//
+// Bindings:
+//   binding 0: raw    — packed IQ2_XS weight data (padded to 4-byte multiple)
+//   binding 1: vec    — f32 input matrix  [batch_size * num_blocks_per_row * 256]
+//   binding 2: output — f32 result        [batch_size * num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+    batch_size:         u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+var<workgroup> partials: array<f32, 64>;
+
+// iq2xs_grid[512] uint64 entries split into low / high u32 halves.
+// Source: llama.cpp ggml-common.h iq2xs_grid table.
+const IQ2XS_GRID_LO: array<u32, 512> = array<u32, 512>(
+    0x08080808u, 0x0808082bu, 0x08081919u, 0x08082b08u,
+    0x08082b2bu, 0x08190819u, 0x08191908u, 0x0819192bu,
+    0x08192b19u, 0x082b0808u, 0x082b082bu, 0x082b1919u,
+    0x082b2b08u, 0x19080819u, 0x19081908u, 0x1908192bu,
+    0x19082b19u, 0x19190808u, 0x1919082bu, 0x19191919u,
+    0x19192b08u, 0x192b0819u, 0x192b1908u, 0x2b080808u,
+    0x2b08082bu, 0x2b081919u, 0x2b082b08u, 0x2b190819u,
+    0x2b191908u, 0x2b192b19u, 0x2b2b0808u, 0x08080819u,
+    0x08081908u, 0x0808192bu, 0x08082b19u, 0x08190808u,
+    0x0819082bu, 0x08191919u, 0x08192b08u, 0x08192b2bu,
+    0x082b0819u, 0x082b1908u, 0x19080808u, 0x1908082bu,
+    0x19081919u, 0x19082b08u, 0x19190819u, 0x19191908u,
+    0x192b0808u, 0x192b2b08u, 0x2b080819u, 0x2b081908u,
+    0x2b190808u, 0x08080808u, 0x0808082bu, 0x08081919u,
+    0x08082b08u, 0x08190819u, 0x08191908u, 0x082b0808u,
+    0x19080819u, 0x19081908u, 0x19190808u, 0x19191919u,
+    0x2b080808u, 0x2b082b2bu, 0x08080819u, 0x08081908u,
+    0x0808192bu, 0x08082b19u, 0x08190808u, 0x0819082bu,
+    0x08191919u, 0x08192b08u, 0x082b0819u, 0x082b1908u,
+    0x19080808u, 0x1908082bu, 0x19081919u, 0x19082b08u,
+    0x19190819u, 0x19191908u, 0x1919192bu, 0x192b0808u,
+    0x2b080819u, 0x2b081908u, 0x2b190808u, 0x08080808u,
+    0x0808082bu, 0x08081919u, 0x08082b08u, 0x08190819u,
+    0x08191908u, 0x082b0808u, 0x19080819u, 0x19081908u,
+    0x19190808u, 0x192b0819u, 0x2b080808u, 0x08080819u,
+    0x08081908u, 0x08190808u, 0x082b192bu, 0x19080808u,
+    0x1908082bu, 0x2b081908u, 0x08080808u, 0x0808082bu,
+    0x08081919u, 0x08082b08u, 0x08082b2bu, 0x08190819u,
+    0x08191908u, 0x082b0808u, 0x082b1919u, 0x19080819u,
+    0x19081908u, 0x19190808u, 0x19192b08u, 0x2b080808u,
+    0x2b2b0808u, 0x2b2b2b2bu, 0x08080819u, 0x08081908u,
+    0x08190808u, 0x19080808u, 0x2b080819u, 0x2b082b19u,
+    0x08080808u, 0x082b0808u, 0x082b2b08u, 0x2b19192bu,
+    0x2b2b0808u, 0x08080819u, 0x08081908u, 0x0808192bu,
+    0x08082b19u, 0x08190808u, 0x0819082bu, 0x08191919u,
+    0x08192b08u, 0x082b0819u, 0x082b1908u, 0x19080808u,
+    0x1908082bu, 0x19081919u, 0x19082b08u, 0x19190819u,
+    0x19191908u, 0x192b0808u, 0x192b2b2bu, 0x2b080819u,
+    0x2b081908u, 0x2b190808u, 0x08080808u, 0x0808082bu,
+    0x08081919u, 0x08082b08u, 0x08190819u, 0x08191908u,
+    0x082b0808u, 0x19080819u, 0x19081908u, 0x19190808u,
+    0x2b080808u, 0x2b191908u, 0x2b19192bu, 0x08080819u,
+    0x08081908u, 0x0808192bu, 0x08190808u, 0x19080808u,
+    0x192b0808u, 0x08080808u, 0x0808082bu, 0x08081919u,
+    0x08082b08u, 0x08190819u, 0x08191908u, 0x082b0808u,
+    0x19080819u, 0x19081908u, 0x19082b19u, 0x19190808u,
+    0x192b1908u, 0x2b080808u, 0x08080819u, 0x08081908u,
+    0x08190808u, 0x19080808u, 0x08080808u, 0x08191908u,
+    0x19082b19u, 0x08080819u, 0x08081908u, 0x08190808u,
+    0x0819082bu, 0x19080808u, 0x19191908u, 0x2b08192bu,
+    0x08080808u, 0x08081919u, 0x192b192bu, 0x19190819u,
+    0x2b2b2b19u, 0x08080808u, 0x0808082bu, 0x08081919u,
+    0x08082b08u, 0x08082b2bu, 0x08190819u, 0x08191908u,
+    0x082b0808u, 0x19080819u, 0x19081908u, 0x19190808u,
+    0x2b080808u, 0x2b2b0808u, 0x08080819u, 0x08081908u,
+    0x08190808u, 0x19080808u, 0x19082b08u, 0x192b1919u,
+    0x08080808u, 0x082b082bu, 0x2b080808u, 0x2b2b2b08u,
+    0x08080819u, 0x08081908u, 0x08190808u, 0x082b2b19u,
+    0x19080808u, 0x08080808u, 0x19080819u, 0x1919082bu,
+    0x2b192b19u, 0x08080819u, 0x08192b2bu, 0x2b2b192bu,
+    0x08080808u, 0x08082b08u, 0x08082b2bu, 0x082b0808u,
+    0x19191919u, 0x2b082b08u, 0x2b2b082bu, 0x192b2b08u,
+    0x2b190808u, 0x08082b08u, 0x082b0808u, 0x2b08082bu,
+    0x2b082b08u, 0x2b082b2bu, 0x08080819u, 0x08081908u,
+    0x0808192bu, 0x08082b19u, 0x08190808u, 0x0819082bu,
+    0x08191919u, 0x08192b08u, 0x082b0819u, 0x082b1908u,
+    0x19080808u, 0x1908082bu, 0x19081919u, 0x19082b08u,
+    0x19082b2bu, 0x19190819u, 0x19191908u, 0x192b0808u,
+    0x192b1919u, 0x2b080819u, 0x2b081908u, 0x2b190808u,
+    0x08080808u, 0x0808082bu, 0x08081919u, 0x08082b08u,
+    0x08190819u, 0x08191908u, 0x082b0808u, 0x19080819u,
+    0x19081908u, 0x19190808u, 0x2b080808u, 0x2b081919u,
+    0x2b2b082bu, 0x08080819u, 0x08081908u, 0x08190808u,
+    0x0819082bu, 0x082b2b19u, 0x19080808u, 0x08080808u,
+    0x0808082bu, 0x08081919u, 0x08082b08u, 0x08190819u,
+    0x08191908u, 0x08192b19u, 0x082b0808u, 0x19080819u,
+    0x19081908u, 0x19190808u, 0x2b080808u, 0x2b191908u,
+    0x08080819u, 0x08081908u, 0x08190808u, 0x082b1908u,
+    0x19080808u, 0x2b192b2bu, 0x08080808u, 0x08082b2bu,
+    0x19081908u, 0x19190808u, 0x08080819u, 0x08081908u,
+    0x08190808u, 0x19080808u, 0x19081919u, 0x19191908u,
+    0x192b082bu, 0x08080808u, 0x08190819u, 0x19081908u,
+    0x19190808u, 0x192b2b19u, 0x08081908u, 0x08080808u,
+    0x0808082bu, 0x08081919u, 0x08082b08u, 0x08190819u,
+    0x08191908u, 0x082b0808u, 0x082b2b08u, 0x19080819u,
+    0x19081908u, 0x19190808u, 0x2b080808u, 0x08080819u,
+    0x08081908u, 0x08190808u, 0x08191919u, 0x19080808u,
+    0x1908082bu, 0x08080808u, 0x19081908u, 0x2b2b2b2bu,
+    0x08080819u, 0x08081908u, 0x08190808u, 0x082b0819u,
+    0x19080808u, 0x192b0808u, 0x2b080819u, 0x2b2b0819u,
+    0x08080808u, 0x08082b08u, 0x2b080808u, 0x2b082b08u,
+    0x082b0819u, 0x192b2b08u, 0x2b2b0819u, 0x08080808u,
+    0x08191908u, 0x19080819u, 0x19190808u, 0x2b192b19u,
+    0x08192b2bu, 0x19080808u, 0x1908082bu, 0x2b081919u,
+    0x08080819u, 0x08081908u, 0x08190808u, 0x19080808u,
+    0x19191908u, 0x192b082bu, 0x2b08192bu, 0x2b2b2b19u,
+    0x08080808u, 0x082b1908u, 0x19082b2bu, 0x2b19082bu,
+    0x08080808u, 0x0819192bu, 0x08190808u, 0x19080808u,
+    0x19081919u, 0x2b2b1908u, 0x08080819u, 0x192b2b2bu,
+    0x082b1919u, 0x0808192bu, 0x19191908u, 0x192b082bu,
+    0x08080808u, 0x0808082bu, 0x08081919u, 0x08082b08u,
+    0x08190819u, 0x08191908u, 0x082b0808u, 0x082b2b2bu,
+    0x19080819u, 0x19081908u, 0x19190808u, 0x2b080808u,
+    0x2b08082bu, 0x2b2b2b08u, 0x2b2b2b2bu, 0x08080819u,
+    0x08081908u, 0x0808192bu, 0x08190808u, 0x19080808u,
+    0x19190819u, 0x19192b19u, 0x08080808u, 0x082b0808u,
+    0x2b080808u, 0x2b08082bu, 0x2b2b0808u, 0x2b2b2b08u,
+    0x08080819u, 0x08081908u, 0x08190808u, 0x0819082bu,
+    0x08191919u, 0x19080808u, 0x192b0808u, 0x2b082b19u,
+    0x08080808u, 0x19081908u, 0x2b2b1919u, 0x08192b08u,
+    0x192b2b2bu, 0x08080808u, 0x08082b08u, 0x082b1919u,
+    0x19192b2bu, 0x2b080808u, 0x2b08082bu, 0x2b2b2b08u,
+    0x0808192bu, 0x082b082bu, 0x2b080808u, 0x2b082b08u,
+    0x2b19192bu, 0x2b2b2b08u, 0x08080819u, 0x08081908u,
+    0x08190808u, 0x19080808u, 0x1919192bu, 0x2b081908u,
+    0x08080808u, 0x082b082bu, 0x192b1908u, 0x1919192bu,
+    0x2b082b19u, 0x08080808u, 0x08081919u, 0x19081908u,
+    0x19190808u, 0x19192b08u, 0x082b2b19u, 0x2b190808u,
+    0x2b19082bu, 0x19080819u, 0x19190819u, 0x2b2b192bu,
+    0x19082b19u, 0x08191919u, 0x192b0808u, 0x08080808u,
+    0x0808082bu, 0x08082b08u, 0x08082b2bu, 0x082b0808u,
+    0x082b2b2bu, 0x2b2b0808u, 0x19190819u, 0x19192b19u,
+    0x2b2b192bu, 0x08080808u, 0x0808082bu, 0x08082b08u,
+    0x082b2b2bu, 0x2b080808u, 0x2b2b0808u, 0x19080808u,
+    0x2b191919u, 0x192b1919u, 0x2b192b08u, 0x08082b2bu,
+    0x082b0808u, 0x082b082bu, 0x082b2b08u, 0x2b2b0808u,
+    0x2b2b2b08u, 0x08081908u, 0x2b081908u, 0x2b08192bu,
+    0x082b2b08u, 0x082b2b2bu, 0x2b190819u, 0x2b2b2b2bu
+);
+
+const IQ2XS_GRID_HI: array<u32, 512> = array<u32, 512>(
+    0x08080808u, 0x08080808u, 0x08080808u, 0x08080808u,
+    0x08080808u, 0x08080808u, 0x08080808u, 0x08080808u,
+    0x08080808u, 0x08080808u, 0x08080808u, 0x08080808u,
+    0x08080808u, 0x08080808u, 0x08080808u, 0x08080808u,
+    0x08080808u, 0x08080808u, 0x08080808u, 0x08080808u,
+    0x08080808u, 0x08080808u, 0x08080808u, 0x08080808u,
+    0x08080808u, 0x08080808u, 0x08080808u, 0x08080808u,
+    0x08080808u, 0x08080808u, 0x08080808u, 0x08080819u,
+    0x08080819u, 0x08080819u, 0x08080819u, 0x08080819u,
+    0x08080819u, 0x08080819u, 0x08080819u, 0x08080819u,
+    0x08080819u, 0x08080819u, 0x08080819u, 0x08080819u,
+    0x08080819u, 0x08080819u, 0x08080819u, 0x08080819u,
+    0x08080819u, 0x08080819u, 0x08080819u, 0x08080819u,
+    0x08080819u, 0x0808082bu, 0x0808082bu, 0x0808082bu,
+    0x0808082bu, 0x0808082bu, 0x0808082bu, 0x0808082bu,
+    0x0808082bu, 0x0808082bu, 0x0808082bu, 0x0808082bu,
+    0x0808082bu, 0x0808082bu, 0x08081908u, 0x08081908u,
+    0x08081908u, 0x08081908u, 0x08081908u, 0x08081908u,
+    0x08081908u, 0x08081908u, 0x08081908u, 0x08081908u,
+    0x08081908u, 0x08081908u, 0x08081908u, 0x08081908u,
+    0x08081908u, 0x08081908u, 0x08081908u, 0x08081908u,
+    0x08081908u, 0x08081908u, 0x08081908u, 0x08081919u,
+    0x08081919u, 0x08081919u, 0x08081919u, 0x08081919u,
+    0x08081919u, 0x08081919u, 0x08081919u, 0x08081919u,
+    0x08081919u, 0x08081919u, 0x08081919u, 0x0808192bu,
+    0x0808192bu, 0x0808192bu, 0x0808192bu, 0x0808192bu,
+    0x0808192bu, 0x0808192bu, 0x08082b08u, 0x08082b08u,
+    0x08082b08u, 0x08082b08u, 0x08082b08u, 0x08082b08u,
+    0x08082b08u, 0x08082b08u, 0x08082b08u, 0x08082b08u,
+    0x08082b08u, 0x08082b08u, 0x08082b08u, 0x08082b08u,
+    0x08082b08u, 0x08082b08u, 0x08082b19u, 0x08082b19u,
+    0x08082b19u, 0x08082b19u, 0x08082b19u, 0x08082b19u,
+    0x08082b2bu, 0x08082b2bu, 0x08082b2bu, 0x08082b2bu,
+    0x08082b2bu, 0x08190808u, 0x08190808u, 0x08190808u,
+    0x08190808u, 0x08190808u, 0x08190808u, 0x08190808u,
+    0x08190808u, 0x08190808u, 0x08190808u, 0x08190808u,
+    0x08190808u, 0x08190808u, 0x08190808u, 0x08190808u,
+    0x08190808u, 0x08190808u, 0x08190808u, 0x08190808u,
+    0x08190808u, 0x08190808u, 0x08190819u, 0x08190819u,
+    0x08190819u, 0x08190819u, 0x08190819u, 0x08190819u,
+    0x08190819u, 0x08190819u, 0x08190819u, 0x08190819u,
+    0x08190819u, 0x08190819u, 0x08190819u, 0x0819082bu,
+    0x0819082bu, 0x0819082bu, 0x0819082bu, 0x0819082bu,
+    0x0819082bu, 0x08191908u, 0x08191908u, 0x08191908u,
+    0x08191908u, 0x08191908u, 0x08191908u, 0x08191908u,
+    0x08191908u, 0x08191908u, 0x08191908u, 0x08191908u,
+    0x08191908u, 0x08191908u, 0x08191919u, 0x08191919u,
+    0x08191919u, 0x08191919u, 0x0819192bu, 0x0819192bu,
+    0x0819192bu, 0x08192b08u, 0x08192b08u, 0x08192b08u,
+    0x08192b08u, 0x08192b08u, 0x08192b08u, 0x08192b08u,
+    0x08192b19u, 0x08192b19u, 0x08192b19u, 0x08192b2bu,
+    0x08192b2bu, 0x082b0808u, 0x082b0808u, 0x082b0808u,
+    0x082b0808u, 0x082b0808u, 0x082b0808u, 0x082b0808u,
+    0x082b0808u, 0x082b0808u, 0x082b0808u, 0x082b0808u,
+    0x082b0808u, 0x082b0808u, 0x082b0819u, 0x082b0819u,
+    0x082b0819u, 0x082b0819u, 0x082b0819u, 0x082b0819u,
+    0x082b082bu, 0x082b082bu, 0x082b082bu, 0x082b082bu,
+    0x082b1908u, 0x082b1908u, 0x082b1908u, 0x082b1908u,
+    0x082b1908u, 0x082b1919u, 0x082b1919u, 0x082b1919u,
+    0x082b1919u, 0x082b192bu, 0x082b192bu, 0x082b192bu,
+    0x082b2b08u, 0x082b2b08u, 0x082b2b08u, 0x082b2b08u,
+    0x082b2b08u, 0x082b2b08u, 0x082b2b08u, 0x082b2b19u,
+    0x082b2b19u, 0x082b2b2bu, 0x082b2b2bu, 0x082b2b2bu,
+    0x082b2b2bu, 0x082b2b2bu, 0x19080808u, 0x19080808u,
+    0x19080808u, 0x19080808u, 0x19080808u, 0x19080808u,
+    0x19080808u, 0x19080808u, 0x19080808u, 0x19080808u,
+    0x19080808u, 0x19080808u, 0x19080808u, 0x19080808u,
+    0x19080808u, 0x19080808u, 0x19080808u, 0x19080808u,
+    0x19080808u, 0x19080808u, 0x19080808u, 0x19080808u,
+    0x19080819u, 0x19080819u, 0x19080819u, 0x19080819u,
+    0x19080819u, 0x19080819u, 0x19080819u, 0x19080819u,
+    0x19080819u, 0x19080819u, 0x19080819u, 0x19080819u,
+    0x19080819u, 0x1908082bu, 0x1908082bu, 0x1908082bu,
+    0x1908082bu, 0x1908082bu, 0x1908082bu, 0x19081908u,
+    0x19081908u, 0x19081908u, 0x19081908u, 0x19081908u,
+    0x19081908u, 0x19081908u, 0x19081908u, 0x19081908u,
+    0x19081908u, 0x19081908u, 0x19081908u, 0x19081908u,
+    0x19081919u, 0x19081919u, 0x19081919u, 0x19081919u,
+    0x19081919u, 0x19081919u, 0x1908192bu, 0x1908192bu,
+    0x1908192bu, 0x1908192bu, 0x19082b08u, 0x19082b08u,
+    0x19082b08u, 0x19082b08u, 0x19082b08u, 0x19082b08u,
+    0x19082b08u, 0x19082b19u, 0x19082b19u, 0x19082b19u,
+    0x19082b19u, 0x19082b19u, 0x19082b2bu, 0x19190808u,
+    0x19190808u, 0x19190808u, 0x19190808u, 0x19190808u,
+    0x19190808u, 0x19190808u, 0x19190808u, 0x19190808u,
+    0x19190808u, 0x19190808u, 0x19190808u, 0x19190819u,
+    0x19190819u, 0x19190819u, 0x19190819u, 0x19190819u,
+    0x19190819u, 0x1919082bu, 0x1919082bu, 0x1919082bu,
+    0x19191908u, 0x19191908u, 0x19191908u, 0x19191908u,
+    0x19191908u, 0x19191908u, 0x19191908u, 0x19191908u,
+    0x19191919u, 0x19191919u, 0x19191919u, 0x19191919u,
+    0x1919192bu, 0x1919192bu, 0x1919192bu, 0x19192b08u,
+    0x19192b08u, 0x19192b08u, 0x19192b08u, 0x19192b08u,
+    0x19192b19u, 0x19192b19u, 0x19192b19u, 0x19192b2bu,
+    0x192b0808u, 0x192b0808u, 0x192b0808u, 0x192b0808u,
+    0x192b0808u, 0x192b0808u, 0x192b0808u, 0x192b0808u,
+    0x192b0819u, 0x192b082bu, 0x192b082bu, 0x192b082bu,
+    0x192b1908u, 0x192b1908u, 0x192b1919u, 0x192b1919u,
+    0x192b1919u, 0x192b1919u, 0x192b2b08u, 0x192b2b08u,
+    0x192b2b19u, 0x192b2b2bu, 0x192b2b2bu, 0x192b2b2bu,
+    0x2b080808u, 0x2b080808u, 0x2b080808u, 0x2b080808u,
+    0x2b080808u, 0x2b080808u, 0x2b080808u, 0x2b080808u,
+    0x2b080808u, 0x2b080808u, 0x2b080808u, 0x2b080808u,
+    0x2b080808u, 0x2b080808u, 0x2b080808u, 0x2b080819u,
+    0x2b080819u, 0x2b080819u, 0x2b080819u, 0x2b080819u,
+    0x2b080819u, 0x2b080819u, 0x2b08082bu, 0x2b08082bu,
+    0x2b08082bu, 0x2b08082bu, 0x2b08082bu, 0x2b08082bu,
+    0x2b081908u, 0x2b081908u, 0x2b081908u, 0x2b081908u,
+    0x2b081908u, 0x2b081908u, 0x2b081908u, 0x2b081908u,
+    0x2b081919u, 0x2b081919u, 0x2b081919u, 0x2b08192bu,
+    0x2b08192bu, 0x2b082b08u, 0x2b082b08u, 0x2b082b08u,
+    0x2b082b08u, 0x2b082b08u, 0x2b082b08u, 0x2b082b08u,
+    0x2b082b19u, 0x2b082b2bu, 0x2b082b2bu, 0x2b082b2bu,
+    0x2b082b2bu, 0x2b082b2bu, 0x2b190808u, 0x2b190808u,
+    0x2b190808u, 0x2b190808u, 0x2b190808u, 0x2b190808u,
+    0x2b190819u, 0x2b190819u, 0x2b190819u, 0x2b19082bu,
+    0x2b19082bu, 0x2b191908u, 0x2b191908u, 0x2b191908u,
+    0x2b191908u, 0x2b191908u, 0x2b191919u, 0x2b191919u,
+    0x2b191919u, 0x2b19192bu, 0x2b192b08u, 0x2b192b08u,
+    0x2b192b19u, 0x2b192b2bu, 0x2b192b2bu, 0x2b2b0808u,
+    0x2b2b0808u, 0x2b2b0808u, 0x2b2b0808u, 0x2b2b0808u,
+    0x2b2b0808u, 0x2b2b0808u, 0x2b2b0819u, 0x2b2b0819u,
+    0x2b2b0819u, 0x2b2b082bu, 0x2b2b082bu, 0x2b2b082bu,
+    0x2b2b082bu, 0x2b2b082bu, 0x2b2b082bu, 0x2b2b1908u,
+    0x2b2b1908u, 0x2b2b192bu, 0x2b2b192bu, 0x2b2b2b08u,
+    0x2b2b2b08u, 0x2b2b2b08u, 0x2b2b2b08u, 0x2b2b2b08u,
+    0x2b2b2b08u, 0x2b2b2b19u, 0x2b2b2b19u, 0x2b2b2b19u,
+    0x2b2b2b2bu, 0x2b2b2b2bu, 0x2b2b2b2bu, 0x2b2b2b2bu
+);
+
+// ksigns_iq2xs[128]: converts 7-bit sign index → 8-bit sign mask.
+// Source: llama.cpp ggml-common.h. Packed 4 bytes per u32 (LE).
+const KSIGNS_IQ2XS: array<u32, 32> = array<u32, 32>(
+    0x03828100u, 0x87060584u, 0x8b0a0988u, 0x0f8e8d0cu,
+    0x93121190u, 0x17969514u, 0x1b9a9918u, 0x9f1e1d9cu,
+    0xa32221a0u, 0x27a6a524u, 0x2baaa928u, 0xaf2e2dacu,
+    0x33b2b130u, 0xb73635b4u, 0xbb3a39b8u, 0x3fbebd3cu,
+    0xc34241c0u, 0x47c6c544u, 0x4bcac948u, 0xcf4e4dccu,
+    0x53d2d150u, 0xd75655d4u, 0xdb5a59d8u, 0x5fdedd5cu,
+    0x63e2e160u, 0xe76665e4u, 0xeb6a69e8u, 0x6feeed6cu,
+    0xf37271f0u, 0x77f6f574u, 0x7bfaf978u, 0xff7e7dfcu
+);
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+/// Read a u16 (LE) from two consecutive bytes at byte_offset.
+fn read_u16(byte_offset: u32) -> u32 {
+    return read_byte(byte_offset) | (read_byte(byte_offset + 1u) << 8u);
+}
+
+/// Look up ksigns_iq2xs[i] (i in [0, 127]).
+fn ksign(i: u32) -> u32 {
+    let word = KSIGNS_IQ2XS[i / 4u];
+    return (word >> ((i % 4u) * 8u)) & 0xFFu;
+}
+
+/// Read byte j of iq2xs_grid[idx] (j in [0, 7]).
+fn grid_byte(idx: u32, j: u32) -> u32 {
+    if j < 4u {
+        return (IQ2XS_GRID_LO[idx] >> (j * 8u)) & 0xFFu;
+    } else {
+        return (IQ2XS_GRID_HI[idx] >> ((j - 4u) * 8u)) & 0xFFu;
+    }
+}
+
+@compute @workgroup_size(64)
+fn dequant_matvec_iq2xs(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
+        return;
+    }
+
+    let tid     = lid.x;
+    let in_cols = params.num_blocks_per_row * 256u; // 256 weights per block
+    var acc: f32 = 0.0;
+
+    // Each block is 74 bytes; threads stride across blocks.
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Byte offset of this block in the raw buffer (74 bytes per block).
+        let bb = (row * params.num_blocks_per_row + b) * 74u;
+
+        // d: f16 LE at bytes 0-1 of the block.
+        let d_bits = read_byte(bb) | (read_byte(bb + 1u) << 8u);
+        let d = unpack2x16float(d_bits).x;
+
+        // vec base for this block and batch.
+        let vec_base = batch * in_cols + b * 256u;
+
+        // Process 8 groups of 32 weights (ib32 = 0..7).
+        for (var ib32 = 0u; ib32 < 8u; ib32 = ib32 + 1u) {
+            // scale byte at bytes 66+ib32 of the block.
+            let scale_byte = read_byte(bb + 66u + ib32);
+            let dl1 = d * (0.5 + f32(scale_byte & 0xFu)) * 0.25;
+            let dl2 = d * (0.5 + f32(scale_byte >> 4u)) * 0.25;
+
+            // qs base: 4 uint16 entries per ib32, each 2 bytes, starting at block byte 2.
+            // Byte offset of qs[4*ib32]: bb + 2 + 8*ib32
+            let qs_base = bb + 2u + 8u * ib32;
+
+            let vec_ib32_base = vec_base + ib32 * 32u;
+
+            // j=0 → dl1, entries qs[0] and qs[1]
+            // j=1 → dl2, entries qs[2] and qs[3]
+            for (var j = 0u; j < 2u; j = j + 1u) {
+                let dl = select(dl2, dl1, j == 0u);
+                for (var k = 0u; k < 2u; k = k + 1u) {
+                    let qs16 = read_u16(qs_base + (j * 2u + k) * 2u);
+                    let grid_idx  = qs16 & 0x1FFu;
+                    let sign_7bit = qs16 >> 9u;
+                    let signs_8bit = ksign(sign_7bit);
+
+                    let vec_sub = vec_ib32_base + j * 16u + k * 8u;
+                    for (var i = 0u; i < 8u; i = i + 1u) {
+                        let gb   = grid_byte(grid_idx, i);
+                        let sign = select(1.0, -1.0, (signs_8bit & (1u << i)) != 0u);
+                        acc = acc + dl * f32(gb) * sign * vec[vec_sub + i];
+                    }
+                }
+            }
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u { partials[tid] = partials[tid] + partials[tid + 32u]; }
+    workgroupBarrier();
+    if tid < 16u { partials[tid] = partials[tid] + partials[tid + 16u]; }
+    workgroupBarrier();
+    if tid < 8u  { partials[tid] = partials[tid] + partials[tid + 8u]; }
+    workgroupBarrier();
+    if tid < 4u  { partials[tid] = partials[tid] + partials[tid + 4u]; }
+    workgroupBarrier();
+    if tid < 2u  { partials[tid] = partials[tid] + partials[tid + 2u]; }
+    workgroupBarrier();
+    if tid < 1u  { partials[tid] = partials[tid] + partials[tid + 1u]; }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[batch * params.num_rows + row] = partials[0u];
+    }
+}

--- a/flare-gpu/shaders/dequant_matvec_iq3xxs.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_iq3xxs.wgsl
@@ -1,0 +1,250 @@
+// Fused IQ3_XXS dequantize + batched matrix-vector multiply on GPU.
+//
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
+//
+// IQ3_XXS block layout (98 bytes per block, 256 weights per block — GGUF type 18):
+//   bytes 0-1:   d  — f16 LE super-block scale
+//   bytes 2-65:  qs[64] — 64 × uint8, indices into iq3xxs_grid
+//     Two consecutive indices per 8-weight sub-group (grid1, grid2)
+//   bytes 66-97: scales_and_signs[32] — 8 × uint32 LE, one per ib32 group
+//     aux32: bits[31:28] = 4-bit sub-scale, bits[27:0] = 4×7-bit sign indices
+//
+// For each ib32 ∈ [0, 7]:
+//   aux32     = u32 LE at bytes 66+4*ib32
+//   dl        = d * (0.5 + f32(aux32 >> 28)) * 0.5
+//   For l ∈ [0, 3]:
+//     qs1     = qs[8*ib32 + 2*l + 0] = grid index for first 4 weights
+//     qs2     = qs[8*ib32 + 2*l + 1] = grid index for next 4 weights
+//     sign_7bit = (aux32 >> (7*l)) & 127
+//     signs_8bit = KSIGNS_IQ2XS[sign_7bit] → 8 sign bits
+//     For j ∈ [0, 3]:
+//       weight[j]   = dl * f32(iq3xxs_grid[qs1] byte j)   * sign(signs_8bit, j)
+//       weight[j+4] = dl * f32(iq3xxs_grid[qs2] byte j)   * sign(signs_8bit, j+4)
+//
+// Lookup tables embedded as WGSL const arrays (sourced from llama.cpp ggml-common.h):
+//   IQ3XXS_GRID  — iq3xxs_grid[256] (uint32_t entries, 4 weight bytes each)
+//   KSIGNS_IQ2XS — ksigns_iq2xs[128] packed 4-per-u32
+//
+// 98 bytes is not u32-aligned.  The Rust caller pads the raw buffer to the
+// nearest 4-byte multiple before upload.
+//
+// One workgroup per (output row, batch item). 64 threads split the 8 super-block
+// groups; a tree reduction accumulates partial sums.
+//
+// Bindings:
+//   binding 0: raw    — packed IQ3_XXS weight data (padded to 4-byte multiple)
+//   binding 1: vec    — f32 input matrix  [batch_size * num_blocks_per_row * 256]
+//   binding 2: output — f32 result        [batch_size * num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+    batch_size:         u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+var<workgroup> partials: array<f32, 64>;
+
+// iq3xxs_grid[256] uint32 entries (4 weight bytes each).
+// Source: llama.cpp ggml-common.h iq3xxs_grid table.
+const IQ3XXS_GRID: array<u32, 256> = array<u32, 256>(
+    0x04040404u, 0x04040414u, 0x04040424u, 0x04040c0cu,
+    0x04040c1cu, 0x04040c3eu, 0x04041404u, 0x04041414u,
+    0x04041c0cu, 0x04042414u, 0x04043e1cu, 0x04043e2cu,
+    0x040c040cu, 0x040c041cu, 0x040c0c04u, 0x040c0c14u,
+    0x040c140cu, 0x040c142cu, 0x040c1c04u, 0x040c1c14u,
+    0x040c240cu, 0x040c2c24u, 0x040c3e04u, 0x04140404u,
+    0x04140414u, 0x04140424u, 0x04140c0cu, 0x04141404u,
+    0x04141414u, 0x04141c0cu, 0x04141c1cu, 0x04141c3eu,
+    0x04142c0cu, 0x04142c3eu, 0x04143e2cu, 0x041c040cu,
+    0x041c043eu, 0x041c0c04u, 0x041c0c14u, 0x041c142cu,
+    0x041c3e04u, 0x04240c1cu, 0x04241c3eu, 0x04242424u,
+    0x04242c3eu, 0x04243e1cu, 0x04243e2cu, 0x042c040cu,
+    0x042c043eu, 0x042c1c14u, 0x042c2c14u, 0x04341c2cu,
+    0x04343424u, 0x043e0c04u, 0x043e0c24u, 0x043e0c34u,
+    0x043e241cu, 0x043e340cu, 0x0c04040cu, 0x0c04041cu,
+    0x0c040c04u, 0x0c040c14u, 0x0c04140cu, 0x0c04141cu,
+    0x0c041c04u, 0x0c041c14u, 0x0c041c24u, 0x0c04243eu,
+    0x0c042c04u, 0x0c0c0404u, 0x0c0c0414u, 0x0c0c0c0cu,
+    0x0c0c1404u, 0x0c0c1414u, 0x0c14040cu, 0x0c14041cu,
+    0x0c140c04u, 0x0c140c14u, 0x0c14140cu, 0x0c141c04u,
+    0x0c143e14u, 0x0c1c0404u, 0x0c1c0414u, 0x0c1c1404u,
+    0x0c1c1c0cu, 0x0c1c2434u, 0x0c1c3434u, 0x0c24040cu,
+    0x0c24042cu, 0x0c242c04u, 0x0c2c1404u, 0x0c2c1424u,
+    0x0c2c2434u, 0x0c2c3e0cu, 0x0c34042cu, 0x0c3e1414u,
+    0x0c3e2404u, 0x14040404u, 0x14040414u, 0x14040c0cu,
+    0x14040c1cu, 0x14041404u, 0x14041414u, 0x14041434u,
+    0x14041c0cu, 0x14042414u, 0x140c040cu, 0x140c041cu,
+    0x140c042cu, 0x140c0c04u, 0x140c0c14u, 0x140c140cu,
+    0x140c1c04u, 0x140c341cu, 0x140c343eu, 0x140c3e04u,
+    0x14140404u, 0x14140414u, 0x14140c0cu, 0x14140c3eu,
+    0x14141404u, 0x14141414u, 0x14141c3eu, 0x14142404u,
+    0x14142c2cu, 0x141c040cu, 0x141c0c04u, 0x141c0c24u,
+    0x141c3e04u, 0x141c3e24u, 0x14241c2cu, 0x14242c1cu,
+    0x142c041cu, 0x142c143eu, 0x142c240cu, 0x142c3e24u,
+    0x143e040cu, 0x143e041cu, 0x143e0c34u, 0x143e242cu,
+    0x1c04040cu, 0x1c040c04u, 0x1c040c14u, 0x1c04140cu,
+    0x1c04141cu, 0x1c042c04u, 0x1c04342cu, 0x1c043e14u,
+    0x1c0c0404u, 0x1c0c0414u, 0x1c0c1404u, 0x1c0c1c0cu,
+    0x1c0c2424u, 0x1c0c2434u, 0x1c14040cu, 0x1c14041cu,
+    0x1c140c04u, 0x1c14142cu, 0x1c142c14u, 0x1c143e14u,
+    0x1c1c0c0cu, 0x1c1c1c1cu, 0x1c241c04u, 0x1c24243eu,
+    0x1c243e14u, 0x1c2c0404u, 0x1c2c0434u, 0x1c2c1414u,
+    0x1c2c2c2cu, 0x1c340c24u, 0x1c341c34u, 0x1c34341cu,
+    0x1c3e1c1cu, 0x1c3e3404u, 0x24040424u, 0x24040c3eu,
+    0x24041c2cu, 0x24041c3eu, 0x24042c1cu, 0x24042c3eu,
+    0x240c3e24u, 0x24141404u, 0x24141c3eu, 0x24142404u,
+    0x24143404u, 0x24143434u, 0x241c043eu, 0x241c242cu,
+    0x24240424u, 0x24242c0cu, 0x24243424u, 0x242c142cu,
+    0x242c241cu, 0x242c3e04u, 0x243e042cu, 0x243e0c04u,
+    0x243e0c14u, 0x243e1c04u, 0x2c040c14u, 0x2c04240cu,
+    0x2c043e04u, 0x2c0c0404u, 0x2c0c0434u, 0x2c0c1434u,
+    0x2c0c2c2cu, 0x2c140c24u, 0x2c141c14u, 0x2c143e14u,
+    0x2c1c0414u, 0x2c1c2c1cu, 0x2c240c04u, 0x2c24141cu,
+    0x2c24143eu, 0x2c243e14u, 0x2c2c0414u, 0x2c2c1c0cu,
+    0x2c342c04u, 0x2c3e1424u, 0x2c3e2414u, 0x34041424u,
+    0x34042424u, 0x34042434u, 0x34043424u, 0x340c140cu,
+    0x340c340cu, 0x34140c3eu, 0x34143424u, 0x341c1c04u,
+    0x341c1c34u, 0x34242424u, 0x342c042cu, 0x342c2c14u,
+    0x34341c1cu, 0x343e041cu, 0x343e140cu, 0x3e04041cu,
+    0x3e04042cu, 0x3e04043eu, 0x3e040c04u, 0x3e041c14u,
+    0x3e042c14u, 0x3e0c1434u, 0x3e0c2404u, 0x3e140c14u,
+    0x3e14242cu, 0x3e142c14u, 0x3e1c0404u, 0x3e1c0c2cu,
+    0x3e1c1c1cu, 0x3e1c3404u, 0x3e24140cu, 0x3e24240cu,
+    0x3e2c0404u, 0x3e2c0414u, 0x3e2c1424u, 0x3e341c04u
+);
+
+// ksigns_iq2xs[128]: converts 7-bit sign index → 8-bit sign mask.
+// Source: llama.cpp ggml-common.h. Packed 4 bytes per u32 (LE).
+const KSIGNS_IQ2XS: array<u32, 32> = array<u32, 32>(
+    0x03828100u, 0x87060584u, 0x8b0a0988u, 0x0f8e8d0cu,
+    0x93121190u, 0x17969514u, 0x1b9a9918u, 0x9f1e1d9cu,
+    0xa32221a0u, 0x27a6a524u, 0x2baaa928u, 0xaf2e2dacu,
+    0x33b2b130u, 0xb73635b4u, 0xbb3a39b8u, 0x3fbebd3cu,
+    0xc34241c0u, 0x47c6c544u, 0x4bcac948u, 0xcf4e4dccu,
+    0x53d2d150u, 0xd75655d4u, 0xdb5a59d8u, 0x5fdedd5cu,
+    0x63e2e160u, 0xe76665e4u, 0xeb6a69e8u, 0x6feeed6cu,
+    0xf37271f0u, 0x77f6f574u, 0x7bfaf978u, 0xff7e7dfcu
+);
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+/// Read a u32 (LE) from four consecutive bytes at byte_offset.
+fn read_u32(byte_offset: u32) -> u32 {
+    return read_byte(byte_offset)
+         | (read_byte(byte_offset + 1u) << 8u)
+         | (read_byte(byte_offset + 2u) << 16u)
+         | (read_byte(byte_offset + 3u) << 24u);
+}
+
+/// Look up ksigns_iq2xs[i] (i in [0, 127]).
+fn ksign(i: u32) -> u32 {
+    let word = KSIGNS_IQ2XS[i / 4u];
+    return (word >> ((i % 4u) * 8u)) & 0xFFu;
+}
+
+/// Read byte j of iq3xxs_grid[idx] (j in [0, 3]).
+fn grid3_byte(idx: u32, j: u32) -> u32 {
+    return (IQ3XXS_GRID[idx] >> (j * 8u)) & 0xFFu;
+}
+
+@compute @workgroup_size(64)
+fn dequant_matvec_iq3xxs(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
+        return;
+    }
+
+    let tid     = lid.x;
+    let in_cols = params.num_blocks_per_row * 256u; // 256 weights per block
+    var acc: f32 = 0.0;
+
+    // Each block is 98 bytes; threads stride across blocks.
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Byte offset of this block in the raw buffer (98 bytes per block).
+        let bb = (row * params.num_blocks_per_row + b) * 98u;
+
+        // d: f16 LE at bytes 0-1 of the block.
+        let d_bits = read_byte(bb) | (read_byte(bb + 1u) << 8u);
+        let d = unpack2x16float(d_bits).x;
+
+        // vec base for this block and batch.
+        let vec_base = batch * in_cols + b * 256u;
+
+        // Process 8 groups of 32 weights (ib32 = 0..7).
+        for (var ib32 = 0u; ib32 < 8u; ib32 = ib32 + 1u) {
+            // aux32 at bytes 66+4*ib32 of the block.
+            let aux32 = read_u32(bb + 66u + 4u * ib32);
+            let dl = d * (0.5 + f32(aux32 >> 28u)) * 0.5;
+
+            let vec_ib32_base = vec_base + ib32 * 32u;
+
+            // 4 sub-groups (l=0..3), each producing 8 output weights.
+            for (var l = 0u; l < 4u; l = l + 1u) {
+                // Grid indices from qs: byte offset = 2 + 8*ib32 + 2*l
+                let qs_off = bb + 2u + 8u * ib32 + 2u * l;
+                let qs1 = read_byte(qs_off);
+                let qs2 = read_byte(qs_off + 1u);
+
+                let sign_7bit  = (aux32 >> (7u * l)) & 127u;
+                let signs_8bit = ksign(sign_7bit);
+
+                let vec_sub = vec_ib32_base + l * 8u;
+
+                // First 4 weights from grid1.
+                for (var j = 0u; j < 4u; j = j + 1u) {
+                    let gb   = grid3_byte(qs1, j);
+                    let sign = select(1.0, -1.0, (signs_8bit & (1u << j)) != 0u);
+                    acc = acc + dl * f32(gb) * sign * vec[vec_sub + j];
+                }
+                // Next 4 weights from grid2.
+                for (var j = 0u; j < 4u; j = j + 1u) {
+                    let gb   = grid3_byte(qs2, j);
+                    let sign = select(1.0, -1.0, (signs_8bit & (1u << (j + 4u))) != 0u);
+                    acc = acc + dl * f32(gb) * sign * vec[vec_sub + 4u + j];
+                }
+            }
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u { partials[tid] = partials[tid] + partials[tid + 32u]; }
+    workgroupBarrier();
+    if tid < 16u { partials[tid] = partials[tid] + partials[tid + 16u]; }
+    workgroupBarrier();
+    if tid < 8u  { partials[tid] = partials[tid] + partials[tid + 8u]; }
+    workgroupBarrier();
+    if tid < 4u  { partials[tid] = partials[tid] + partials[tid + 4u]; }
+    workgroupBarrier();
+    if tid < 2u  { partials[tid] = partials[tid] + partials[tid + 2u]; }
+    workgroupBarrier();
+    if tid < 1u  { partials[tid] = partials[tid] + partials[tid + 1u]; }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[batch * params.num_rows + row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -41,6 +41,8 @@ const DEQUANT_MATVEC_Q5K_SHADER: &str = include_str!("../shaders/dequant_matvec_
 const DEQUANT_MATVEC_Q6K_SHADER: &str = include_str!("../shaders/dequant_matvec_q6k.wgsl");
 const DEQUANT_MATVEC_IQ4NL_SHADER: &str = include_str!("../shaders/dequant_matvec_iq4nl.wgsl");
 const DEQUANT_MATVEC_IQ2XXS_SHADER: &str = include_str!("../shaders/dequant_matvec_iq2xxs.wgsl");
+const DEQUANT_MATVEC_IQ2XS_SHADER: &str = include_str!("../shaders/dequant_matvec_iq2xs.wgsl");
+const DEQUANT_MATVEC_IQ3XXS_SHADER: &str = include_str!("../shaders/dequant_matvec_iq3xxs.wgsl");
 const DEQUANT_Q5K_SHADER: &str = include_str!("../shaders/dequant_q5k.wgsl");
 const DEQUANT_Q6K_SHADER: &str = include_str!("../shaders/dequant_q6k.wgsl");
 const PREFILL_ATTENTION_SHADER: &str = include_str!("../shaders/prefill_attention.wgsl");
@@ -864,6 +866,138 @@ impl WebGpuBackend {
             "dequant_matvec_iq2xxs",
             DEQUANT_MATVEC_IQ2XXS_SHADER,
             "dequant_matvec_iq2xxs",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, batch as u32, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused IQ2_XS dequantize + batched matrix-vector multiply.
+    ///
+    /// IQ2_XS (GGUF type 17) is a 2.31-bit quantization format using a 512-entry
+    /// grid lookup table.  Each super-block is 74 bytes (2 bytes f16 scale + 64 bytes qs
+    /// + 8 bytes scales) covering 256 weights.
+    ///
+    /// - `raw_bytes`: packed GGUF tensor data — `num_rows × num_blocks_per_row × 74` bytes
+    /// - `input`: f32 input matrix of length `batch × num_blocks_per_row × 256`
+    /// - Returns `batch × num_rows` f32 dot products
+    pub fn dequant_matvec_iq2xs(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * batch as u64 * 4;
+
+        // 74 bytes is not u32-aligned — pad to next multiple of 4.
+        #[allow(clippy::manual_is_multiple_of)]
+        let raw_buf = if raw_bytes.len() % 4 == 0 {
+            self.pool.get_storage(&self.device, &self.queue, raw_bytes)
+        } else {
+            let mut padded = raw_bytes.to_vec();
+            padded.resize((padded.len() + 3) & !3, 0);
+            self.pool.get_storage(&self.device, &self.queue, &padded)
+        };
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_iq2xs",
+            DEQUANT_MATVEC_IQ2XS_SHADER,
+            "dequant_matvec_iq2xs",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, batch as u32, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused IQ3_XXS dequantize + batched matrix-vector multiply.
+    ///
+    /// IQ3_XXS (GGUF type 18) is a 3.06-bit quantization format using a 256-entry
+    /// grid lookup table.  Each super-block is 98 bytes (2 bytes f16 scale + 64 bytes qs
+    /// + 32 bytes scales_and_signs) covering 256 weights.
+    ///
+    /// - `raw_bytes`: packed GGUF tensor data — `num_rows × num_blocks_per_row × 98` bytes
+    /// - `input`: f32 input matrix of length `batch × num_blocks_per_row × 256`
+    /// - Returns `batch × num_rows` f32 dot products
+    pub fn dequant_matvec_iq3xxs(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * batch as u64 * 4;
+
+        // 98 bytes is not u32-aligned — pad to next multiple of 4.
+        #[allow(clippy::manual_is_multiple_of)]
+        let raw_buf = if raw_bytes.len() % 4 == 0 {
+            self.pool.get_storage(&self.device, &self.queue, raw_bytes)
+        } else {
+            let mut padded = raw_bytes.to_vec();
+            padded.resize((padded.len() + 3) & !3, 0);
+            self.pool.get_storage(&self.device, &self.queue, &padded)
+        };
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_iq3xxs",
+            DEQUANT_MATVEC_IQ3XXS_SHADER,
+            "dequant_matvec_iq3xxs",
             &layout_entries,
             |cached| {
                 let bind_group =
@@ -2538,6 +2672,20 @@ impl ComputeBackend for WebGpuBackend {
                 batch,
             ),
             WeightFormat::IQ2XXS => self.dequant_matvec_iq2xxs(
+                &weight.data,
+                input,
+                num_rows,
+                weight.blocks_per_row,
+                batch,
+            ),
+            WeightFormat::IQ2XS => self.dequant_matvec_iq2xs(
+                &weight.data,
+                input,
+                num_rows,
+                weight.blocks_per_row,
+                batch,
+            ),
+            WeightFormat::IQ3XXS => self.dequant_matvec_iq3xxs(
                 &weight.data,
                 input,
                 num_rows,

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -435,6 +435,8 @@ fn quant_to_weight_format(q: QuantFormat) -> Option<WeightFormat> {
         QuantFormat::Q6K => Some(WeightFormat::Q6K),
         QuantFormat::IQ4NL => Some(WeightFormat::IQ4NL),
         QuantFormat::IQ2XXS => Some(WeightFormat::IQ2XXS),
+        QuantFormat::IQ2XS => Some(WeightFormat::IQ2XS),
+        QuantFormat::IQ3XXS => Some(WeightFormat::IQ3XXS),
         _ => None,
     }
 }

--- a/flare-loader/src/quantize.rs
+++ b/flare-loader/src/quantize.rs
@@ -17,6 +17,8 @@ pub enum QuantFormat {
     Q6K,
     IQ4NL,
     IQ2XXS,
+    IQ2XS,
+    IQ3XXS,
     Unknown(u32),
 }
 
@@ -38,6 +40,8 @@ impl QuantFormat {
             13 => QuantFormat::Q5K,
             14 => QuantFormat::Q6K,
             16 => QuantFormat::IQ2XXS,
+            17 => QuantFormat::IQ2XS,
+            18 => QuantFormat::IQ3XXS,
             20 => QuantFormat::IQ4NL,
             other => QuantFormat::Unknown(other),
         }
@@ -56,6 +60,8 @@ impl QuantFormat {
             QuantFormat::Q6K => 6.6,
             QuantFormat::IQ4NL => 4.5, // 4 bits + 2-byte scale per 32 weights
             QuantFormat::IQ2XXS => 2.0625, // 66 bytes per 256 weights
+            QuantFormat::IQ2XS => 2.3125, // 74 bytes per 256 weights
+            QuantFormat::IQ3XXS => 3.0625, // 98 bytes per 256 weights
             QuantFormat::Unknown(_) => 32.0, // assume worst case
         }
     }
@@ -72,7 +78,9 @@ impl QuantFormat {
             | QuantFormat::Q4K
             | QuantFormat::Q5K
             | QuantFormat::Q6K
-            | QuantFormat::IQ2XXS => 256,
+            | QuantFormat::IQ2XXS
+            | QuantFormat::IQ2XS
+            | QuantFormat::IQ3XXS => 256,
             QuantFormat::Unknown(_) => 1,
         }
     }
@@ -94,6 +102,8 @@ impl QuantFormat {
             QuantFormat::Q5K => 176, // 2 (d) + 2 (dmin) + 12 (scales) + 32 (qh) + 128 (ql)
             QuantFormat::Q6K => 210, // 128 (ql) + 64 (qh) + 16 (scales) + 2 (d)
             QuantFormat::IQ2XXS => 66, // 2 (d) + 64 (qs[32] × u16) for 256 weights
+            QuantFormat::IQ2XS => 74, // 2 (d) + 64 (qs[32] × u16) + 8 (scales[8]) for 256 weights
+            QuantFormat::IQ3XXS => 98, // 2 (d) + 64 (qs[64] × u8) + 32 (scales_and_signs[8] × u32)
             QuantFormat::Unknown(_) => 4,
         }
     }


### PR DESCRIPTION
## Summary

- Adds WGSL compute shader `dequant_matvec_iq2xs.wgsl` for GGUF type 17 (IQ2_XS, 2.31 bpw, 512-entry grid, 74 bytes/block)
- Adds WGSL compute shader `dequant_matvec_iq3xxs.wgsl` for GGUF type 18 (IQ3_XXS, 3.06 bpw, 256-entry grid, 98 bytes/block)
- Wires both formats through `flare-core/model.rs`, `flare-loader/quantize.rs`, `flare-loader/gguf.rs`, and `flare-gpu/backend.rs`

Both shaders use the same fused dequant+matvec pattern as IQ2_XXS: one workgroup per output row, 64 threads, tree reduction.

Closes #185

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo clippy --workspace` passes
- [ ] `cargo doc --workspace --no-deps --all-features` passes (RUSTDOCFLAGS=-D warnings)
- [ ] CI passes