### PR TITLE
Add IQ4_XS fused dequant+matvec GPU kernel

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -22,6 +22,7 @@ pub enum WeightFormat {
     Q8_0,
     Q8_1,
     IQ4NL,
+    IQ4XS,
     IQ2XXS,
     IQ2XS,
     IQ3XXS,
@@ -38,7 +39,8 @@ impl WeightFormat {
             | WeightFormat::Q6K
             | WeightFormat::IQ2XXS
             | WeightFormat::IQ2XS
-            | WeightFormat::IQ3XXS => 256,
+            | WeightFormat::IQ3XXS
+            | WeightFormat::IQ4XS => 256,
             WeightFormat::Q4_0
             | WeightFormat::Q4_1
             | WeightFormat::Q5_0

--- a/flare-gpu/shaders/dequant_matvec_iq4xs.wgsl
+++ b/flare-gpu/shaders/dequant_matvec_iq4xs.wgsl
@@ -1,0 +1,142 @@
+// Fused IQ4_XS dequantize + batched matrix-vector multiply on GPU.
+//
+// Computes: output[b * num_rows + row] = Σ_j  dequant(raw[row, j]) * vec[b * in_cols + j]
+// for each batch item b ∈ [0, batch_size) and output row ∈ [0, num_rows).
+//
+// IQ4_XS block layout (136 bytes per block, 256 weights per block — GGUF type 22):
+//   bytes 0-1:   d       — f16 LE super-block scale
+//   bytes 2-3:   scales_h — u16 LE, 2 high bits of each group scale (8 × 2-bit)
+//   bytes 4-7:   scales_l[4] — 4 × u8, packed 4-bit low nibbles (2 groups per byte)
+//   bytes 8-135: qs[128] — 128 × u8, packed 4-bit indices into KVALUES_IQ4NL
+//
+// For each ib32 ∈ [0, 7] (groups of 32 weights):
+//   ls_lo = (scales_l[ib32/2] >> (4 * (ib32 % 2))) & 0xF   — 4 low bits
+//   ls_hi = (scales_h >> (2 * ib32)) & 3                    — 2 high bits
+//   ls    = ls_lo | (ls_hi << 4)                             — 6-bit scale [0, 63]
+//   dl    = d * f32(i32(ls) - 32)
+//   For j ∈ [0, 15]:  (qs byte at 8 + 16*ib32 + j)
+//     y[j+0]  = dl * KVALUES_IQ4NL[qs[j] & 0xF]
+//     y[j+16] = dl * KVALUES_IQ4NL[qs[j] >> 4]
+//
+// Block size (136 bytes) is u32-aligned — no padding required.
+//
+// One workgroup per (output row, batch item). 64 threads split the 8 groups;
+// a tree reduction accumulates partial sums.
+//
+// Bindings:
+//   binding 0: raw    — packed IQ4_XS weight data
+//   binding 1: vec    — f32 input matrix  [batch_size * num_blocks_per_row * 256]
+//   binding 2: output — f32 result        [batch_size * num_rows]
+//   binding 3: params — uniform
+
+@group(0) @binding(0) var<storage, read> raw: array<u32>;
+@group(0) @binding(1) var<storage, read> vec: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+    batch_size:         u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+var<workgroup> partials: array<f32, 64>;
+
+// kvalues_iq4nl[16]: dequantization lookup table for IQ4_NL / IQ4_XS.
+// Source: llama.cpp ggml-common.h
+const KVALUES_IQ4NL: array<f32, 16> = array<f32, 16>(
+    -127.0, -104.0, -83.0, -65.0, -49.0, -35.0, -22.0, -10.0,
+       1.0,   13.0,  25.0,  38.0,  53.0,  69.0,  89.0, 113.0
+);
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+/// Read a u16 (LE) from two consecutive bytes at byte_offset.
+fn read_u16(byte_offset: u32) -> u32 {
+    return read_byte(byte_offset) | (read_byte(byte_offset + 1u) << 8u);
+}
+
+@compute @workgroup_size(64)
+fn dequant_matvec_iq4xs(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row   = wid.x;
+    let batch = wid.y;
+    if row >= params.num_rows || batch >= params.batch_size {
+        return;
+    }
+
+    let tid     = lid.x;
+    let in_cols = params.num_blocks_per_row * 256u; // 256 weights per block
+    var acc: f32 = 0.0;
+
+    // Each block is 136 bytes; threads stride across blocks.
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Byte offset of this block (136 bytes per block).
+        let bb = (row * params.num_blocks_per_row + b) * 136u;
+
+        // d: f16 LE at bytes 0-1.
+        let d_bits = read_byte(bb) | (read_byte(bb + 1u) << 8u);
+        let d = unpack2x16float(d_bits).x;
+
+        // scales_h: u16 LE at bytes 2-3.
+        let scales_h = read_u16(bb + 2u);
+
+        // vec base for this block and batch.
+        let vec_base = batch * in_cols + b * 256u;
+
+        // Process 8 groups of 32 weights (ib32 = 0..7).
+        for (var ib32 = 0u; ib32 < 8u; ib32 = ib32 + 1u) {
+            // scales_l nibble: byte 4 + ib32/2, select lo or hi nibble.
+            let sl_byte = read_byte(bb + 4u + ib32 / 2u);
+            let ls_lo = (sl_byte >> ((ib32 % 2u) * 4u)) & 0xFu;
+            let ls_hi = (scales_h >> (ib32 * 2u)) & 3u;
+            let ls = ls_lo | (ls_hi << 4u);
+            let dl = d * f32(i32(ls) - 32);
+
+            // qs base: byte 8 + 16*ib32.
+            let qs_base = bb + 8u + 16u * ib32;
+            let vec_group = vec_base + ib32 * 32u;
+
+            for (var j = 0u; j < 16u; j = j + 1u) {
+                let byte_val = read_byte(qs_base + j);
+                let lo_idx = byte_val & 0xFu;
+                let hi_idx = byte_val >> 4u;
+                acc = acc + dl * KVALUES_IQ4NL[lo_idx] * vec[vec_group + j];
+                acc = acc + dl * KVALUES_IQ4NL[hi_idx] * vec[vec_group + j + 16u];
+            }
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u { partials[tid] = partials[tid] + partials[tid + 32u]; }
+    workgroupBarrier();
+    if tid < 16u { partials[tid] = partials[tid] + partials[tid + 16u]; }
+    workgroupBarrier();
+    if tid < 8u  { partials[tid] = partials[tid] + partials[tid + 8u]; }
+    workgroupBarrier();
+    if tid < 4u  { partials[tid] = partials[tid] + partials[tid + 4u]; }
+    workgroupBarrier();
+    if tid < 2u  { partials[tid] = partials[tid] + partials[tid + 2u]; }
+    workgroupBarrier();
+    if tid < 1u  { partials[tid] = partials[tid] + partials[tid + 1u]; }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[batch * params.num_rows + row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -40,6 +40,7 @@ const DEQUANT_MATVEC_Q4K_SHADER: &str = include_str!("../shaders/dequant_matvec_
 const DEQUANT_MATVEC_Q5K_SHADER: &str = include_str!("../shaders/dequant_matvec_q5k.wgsl");
 const DEQUANT_MATVEC_Q6K_SHADER: &str = include_str!("../shaders/dequant_matvec_q6k.wgsl");
 const DEQUANT_MATVEC_IQ4NL_SHADER: &str = include_str!("../shaders/dequant_matvec_iq4nl.wgsl");
+const DEQUANT_MATVEC_IQ4XS_SHADER: &str = include_str!("../shaders/dequant_matvec_iq4xs.wgsl");
 const DEQUANT_MATVEC_IQ2XXS_SHADER: &str = include_str!("../shaders/dequant_matvec_iq2xxs.wgsl");
 const DEQUANT_MATVEC_IQ2XS_SHADER: &str = include_str!("../shaders/dequant_matvec_iq2xs.wgsl");
 const DEQUANT_MATVEC_IQ3XXS_SHADER: &str = include_str!("../shaders/dequant_matvec_iq3xxs.wgsl");
@@ -800,6 +801,66 @@ impl WebGpuBackend {
             "dequant_matvec_iq4nl",
             DEQUANT_MATVEC_IQ4NL_SHADER,
             "dequant_matvec_iq4nl",
+            &layout_entries,
+            |cached| {
+                let bind_group =
+                    self.make_bind_group(cached, &raw_buf, &vec_buf, &out_buf, &params_buf);
+                self.dispatch_and_readback(
+                    &cached.pipeline,
+                    &bind_group,
+                    [num_rows as u32, batch as u32, 1],
+                    &out_buf,
+                    output_size,
+                )
+            },
+        );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Fused IQ4_XS dequantize + batched matrix-vector multiply.
+    ///
+    /// IQ4_XS (GGUF type 22) is a 4.25-bit quantization format using the 16-entry
+    /// KVALUES_IQ4NL lookup table with sub-group scales.  Each super-block is 136 bytes
+    /// (2 bytes f16 scale + 2 bytes scales_h + 4 bytes scales_l + 128 bytes qs)
+    /// covering 256 weights.
+    ///
+    /// - `raw_bytes`: packed GGUF tensor data — `num_rows × num_blocks_per_row × 136` bytes
+    /// - `input`: f32 input matrix of length `batch × num_blocks_per_row × 256`
+    /// - Returns `batch × num_rows` f32 dot products
+    pub fn dequant_matvec_iq4xs(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * batch as u64 * 4;
+
+        // 136 bytes is u32-aligned — no padding needed.
+        let raw_buf = self.pool.get_storage(&self.device, &self.queue, raw_bytes);
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let result = self.cache.with_pipeline(
+            &self.device,
+            "dequant_matvec_iq4xs",
+            DEQUANT_MATVEC_IQ4XS_SHADER,
+            "dequant_matvec_iq4xs",
             &layout_entries,
             |cached| {
                 let bind_group =
@@ -2686,6 +2747,13 @@ impl ComputeBackend for WebGpuBackend {
                 batch,
             ),
             WeightFormat::IQ3XXS => self.dequant_matvec_iq3xxs(
+                &weight.data,
+                input,
+                num_rows,
+                weight.blocks_per_row,
+                batch,
+            ),
+            WeightFormat::IQ4XS => self.dequant_matvec_iq4xs(
                 &weight.data,
                 input,
                 num_rows,

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -434,6 +434,7 @@ fn quant_to_weight_format(q: QuantFormat) -> Option<WeightFormat> {
         QuantFormat::Q5K => Some(WeightFormat::Q5K),
         QuantFormat::Q6K => Some(WeightFormat::Q6K),
         QuantFormat::IQ4NL => Some(WeightFormat::IQ4NL),
+        QuantFormat::IQ4XS => Some(WeightFormat::IQ4XS),
         QuantFormat::IQ2XXS => Some(WeightFormat::IQ2XXS),
         QuantFormat::IQ2XS => Some(WeightFormat::IQ2XS),
         QuantFormat::IQ3XXS => Some(WeightFormat::IQ3XXS),

--- a/flare-loader/src/quantize.rs
+++ b/flare-loader/src/quantize.rs
@@ -16,6 +16,7 @@ pub enum QuantFormat {
     Q5K,
     Q6K,
     IQ4NL,
+    IQ4XS,
     IQ2XXS,
     IQ2XS,
     IQ3XXS,
@@ -43,6 +44,7 @@ impl QuantFormat {
             17 => QuantFormat::IQ2XS,
             18 => QuantFormat::IQ3XXS,
             20 => QuantFormat::IQ4NL,
+            22 => QuantFormat::IQ4XS,
             other => QuantFormat::Unknown(other),
         }
     }
@@ -59,6 +61,7 @@ impl QuantFormat {
             QuantFormat::Q3K => 3.4,
             QuantFormat::Q6K => 6.6,
             QuantFormat::IQ4NL => 4.5, // 4 bits + 2-byte scale per 32 weights
+            QuantFormat::IQ4XS => 4.25, // 136 bytes per 256 weights
             QuantFormat::IQ2XXS => 2.0625, // 66 bytes per 256 weights
             QuantFormat::IQ2XS => 2.3125, // 74 bytes per 256 weights
             QuantFormat::IQ3XXS => 3.0625, // 98 bytes per 256 weights
@@ -71,6 +74,7 @@ impl QuantFormat {
         match self {
             QuantFormat::F32 | QuantFormat::F16 | QuantFormat::BF16 => 1,
             QuantFormat::Q4_0 | QuantFormat::Q4_1 | QuantFormat::IQ4NL => 32,
+            QuantFormat::IQ4XS => 256,
             QuantFormat::Q5_0 | QuantFormat::Q5_1 => 32,
             QuantFormat::Q8_0 | QuantFormat::Q8_1 => 32,
             QuantFormat::Q2K
@@ -104,6 +108,7 @@ impl QuantFormat {
             QuantFormat::IQ2XXS => 66, // 2 (d) + 64 (qs[32] × u16) for 256 weights
             QuantFormat::IQ2XS => 74, // 2 (d) + 64 (qs[32] × u16) + 8 (scales[8]) for 256 weights
             QuantFormat::IQ3XXS => 98, // 2 (d) + 64 (qs[64] × u8) + 32 (scales_and_signs[8] × u32)
+            QuantFormat::IQ4XS => 136, // 2 (d) + 2 (scales_h) + 4 (scales_l[4]) + 128 (qs[128])
             QuantFormat::Unknown(_) => 4,
         }
     }


### PR DESCRIPTION
Adds WGSL compute shader and Rust wiring for IQ4_XS (GGUF type 22, 4.25 bpw, 136 bytes/block). Uses the same 16-entry KVALUES_IQ4NL codebook as IQ4_NL but with per-group 6-bit scales (4-bit low from `scales_l`, 2-bit high from `scales_h`). Fully wired through QuantFormat, WeightFormat, GGUF loader, and GPU dispatch. Closes #252