### PR TITLE
Add edge-case tests for SafeTensors Dtype and SafeTensorInfo methods

### DIFF
--- a/flare-loader/src/safetensors.rs
+++ b/flare-loader/src/safetensors.rs
@@ -546,4 +546,57 @@ mod tests {
         assert_eq!(data.len(), 8);
         assert_eq!(data, raw);
     }
+
+    #[test]
+    fn test_dtype_element_size() {
+        assert_eq!(Dtype::F32.element_size(), 4);
+        assert_eq!(Dtype::F16.element_size(), 2);
+        assert_eq!(Dtype::BF16.element_size(), 2);
+    }
+
+    #[test]
+    fn test_dtype_to_quant_format() {
+        use crate::QuantFormat;
+        assert_eq!(Dtype::F32.to_quant_format(), QuantFormat::F32);
+        assert_eq!(Dtype::F16.to_quant_format(), QuantFormat::F16);
+        assert_eq!(Dtype::BF16.to_quant_format(), QuantFormat::F16);
+    }
+
+    #[test]
+    fn test_dtype_display() {
+        assert_eq!(format!("{}", Dtype::F32), "F32");
+        assert_eq!(format!("{}", Dtype::F16), "F16");
+        assert_eq!(format!("{}", Dtype::BF16), "BF16");
+    }
+
+    #[test]
+    fn test_safe_tensor_info_numel() {
+        let make_info = |shape: Vec<usize>| SafeTensorInfo {
+            name: "x".into(),
+            dtype: Dtype::F32,
+            shape,
+            start: 0,
+            end: 0,
+        };
+        // Scalar (empty shape) → numel=1 (max(product,1))
+        assert_eq!(make_info(vec![]).numel(), 1);
+        // 1D
+        assert_eq!(make_info(vec![5]).numel(), 5);
+        // 2D
+        assert_eq!(make_info(vec![2, 3]).numel(), 6);
+        // 3D
+        assert_eq!(make_info(vec![2, 3, 4]).numel(), 24);
+    }
+
+    #[test]
+    fn test_safe_tensor_info_byte_len() {
+        let info = SafeTensorInfo {
+            name: "w".into(),
+            dtype: Dtype::F32,
+            shape: vec![2, 3],
+            start: 10,
+            end: 34, // 24 bytes = 2*3*4
+        };
+        assert_eq!(info.byte_len(), 24);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds 5 new unit tests to `flare-loader/src/safetensors.rs`
- `Dtype::element_size()` verified for F32=4, F16=2, BF16=2
- `Dtype::to_quant_format()` mapping: F32→F32, F16→F16, BF16→F16
- `Dtype` Display format verified for all three variants
- `SafeTensorInfo::numel()` tested for scalar (=1), 1D, 2D, 3D shapes
- `SafeTensorInfo::byte_len()` verified from start/end offset difference

Closes #315