### PR TITLE
Add unit tests for flare-core memory management

### DIFF
--- a/flare-core/src/memory.rs
+++ b/flare-core/src/memory.rs
@@ -312,4 +312,49 @@ mod tests {
             plan.recommended_quant_bits
         );
     }
+
+    #[test]
+    fn test_memory_budget_mobile_fields() {
+        let b = MemoryBudget::mobile();
+        assert_eq!(b.total_bytes, 1024 * 1024 * 1024);
+        assert_eq!(b.gpu_bytes, 512 * 1024 * 1024);
+        assert_eq!(b.label, "Mobile Browser");
+    }
+
+    #[test]
+    fn test_memory_budget_clone() {
+        let b = MemoryBudget::browser();
+        let c = b.clone();
+        assert_eq!(b.total_bytes, c.total_bytes);
+        assert_eq!(b.gpu_bytes, c.gpu_bytes);
+        assert_eq!(b.label, c.label);
+    }
+
+    #[test]
+    fn test_plan_zero_context_kv_is_zero() {
+        // With context_len=0, kv_cache_bytes must be 0
+        let config = small_model();
+        let plan = plan_memory(&config, 4.0, 0, &MemoryBudget::native());
+        assert_eq!(plan.kv_cache_bytes, 0, "zero context → zero KV cache");
+    }
+
+    #[test]
+    fn test_can_run_false_on_one_byte_budget() {
+        // A 1-byte budget must reject any non-trivial model
+        let config = small_model();
+        let tiny_budget = MemoryBudget {
+            total_bytes: 1,
+            gpu_bytes: 1,
+            label: "1B".into(),
+        };
+        assert!(!can_run(&config, 4.0, &tiny_budget));
+    }
+
+    #[test]
+    fn test_format_bytes_exact_mb() {
+        // Exactly 1 MiB → "1MB"
+        assert_eq!(format_bytes(1024 * 1024), "1MB");
+        // Exactly 1 GiB → "1.0GB"
+        assert_eq!(format_bytes(1024 * 1024 * 1024), "1.0GB");
+    }
 }


### PR DESCRIPTION
## Summary
- `test_memory_budget_mobile_fields`: verifies mobile budget has total=1GB, gpu=512MB, label="Mobile Browser"
- `test_memory_budget_clone`: `MemoryBudget::clone()` produces a value with identical fields
- `test_plan_zero_context_kv_is_zero`: `plan_memory` with `context_len=0` yields `kv_cache_bytes=0`
- `test_can_run_false_on_one_byte_budget`: a 1-byte budget rejects any non-trivial model
- `test_format_bytes_exact_mb`: exactly 1 MiB formats as `"1MB"` and 1 GiB as `"1.0GB"`

Closes #348

## Test plan
- [x] `cargo test -p flarellm-core -- memory` — 20 tests pass (11 pre-existing + 5 new + 4 others)
- [x] `cargo fmt -p flarellm-core` — no changes
- [x] `cargo clippy -p flarellm-core -- -D warnings` — no warnings