### PR TITLE
Add doc-tests for flare-core public API (closes #362)

### DIFF
--- a/flare-core/src/chat.rs
+++ b/flare-core/src/chat.rs
@@ -41,6 +41,19 @@ pub enum ChatTemplate {
 impl ChatTemplate {
     /// Auto-detect template from model architecture name.
     /// Prefer `from_gguf_template()` when the Jinja template string is available.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flare_core::chat::ChatTemplate;
+    ///
+    /// assert_eq!(ChatTemplate::from_architecture("llama"), ChatTemplate::Llama3);
+    /// assert_eq!(ChatTemplate::from_architecture("qwen2"), ChatTemplate::ChatML);
+    /// assert_eq!(ChatTemplate::from_architecture("phi3"),  ChatTemplate::Phi3);
+    /// assert_eq!(ChatTemplate::from_architecture("gemma2"), ChatTemplate::Gemma);
+    /// // Unknown architecture falls back to ChatML
+    /// assert_eq!(ChatTemplate::from_architecture("unknown"), ChatTemplate::ChatML);
+    /// ```
     pub fn from_architecture(arch: &str) -> Self {
         match arch.to_lowercase().as_str() {
             "llama" => ChatTemplate::Llama3,

--- a/flare-core/src/config.rs
+++ b/flare-core/src/config.rs
@@ -1,6 +1,18 @@
 use serde::{Deserialize, Serialize};
 
 /// Model architecture configuration parsed from GGUF metadata or config.json.
+///
+/// # Examples
+///
+/// ```
+/// use flare_core::config::{ModelConfig, Architecture};
+///
+/// let cfg = ModelConfig::default();
+/// assert_eq!(cfg.architecture, Architecture::Llama);
+/// assert_eq!(cfg.num_heads, 32);
+/// assert!(cfg.vocab_size > 0);
+/// assert!(cfg.rope_theta > 0.0);
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelConfig {
     pub architecture: Architecture,

--- a/flare-core/src/error.rs
+++ b/flare-core/src/error.rs
@@ -19,6 +19,18 @@ pub enum FlareError {
 }
 
 /// Errors related to model loading and inference.
+///
+/// # Examples
+///
+/// ```
+/// use flare_core::error::ModelError;
+///
+/// let err = ModelError::UnsupportedArchitecture("gpt4".into());
+/// assert!(err.to_string().contains("gpt4"));
+///
+/// let oom = ModelError::OutOfMemory { needed: 8_000_000_000, available: 4_000_000_000 };
+/// assert!(oom.to_string().contains("8000000000"));
+/// ```
 #[derive(Debug, Error)]
 pub enum ModelError {
     #[error("unsupported model architecture: {0}")]

--- a/flare-core/src/sampling.rs
+++ b/flare-core/src/sampling.rs
@@ -1,6 +1,20 @@
 //! Sampling strategies for token generation.
 
 /// Parameters controlling text generation.
+///
+/// # Examples
+///
+/// ```
+/// use flare_core::sampling::SamplingParams;
+///
+/// // Greedy (deterministic) decoding
+/// let greedy = SamplingParams { temperature: 0.0, top_p: 1.0, top_k: 0, repeat_penalty: 1.0, min_p: 0.0 };
+/// assert_eq!(greedy.temperature, 0.0);
+///
+/// // Default creative sampling
+/// let creative = SamplingParams::default();
+/// assert!(creative.temperature > 0.0);
+/// ```
 #[derive(Debug, Clone)]
 pub struct SamplingParams {
     pub temperature: f32,


### PR DESCRIPTION
Adds rustdoc examples to SamplingParams, ChatTemplate::from_architecture, ModelConfig, and ModelError. All 4 examples are compiled and run by cargo test --doc.