### PR TITLE
Add fused SiLU-Mul + Q8_0 dequant matvec GPU kernel

### DIFF
--- a/flare-gpu/shaders/fused_silu_mul_dequant_matvec_q8_0.wgsl
+++ b/flare-gpu/shaders/fused_silu_mul_dequant_matvec_q8_0.wgsl
@@ -1,0 +1,123 @@
+// Fused SiLU-Mul + Q8_0 dequantize matrix-vector multiply.
+//
+// Combines two operations into a single dispatch:
+//   1. SiLU activation + element-wise multiply: intermediate[j] = SiLU(gate[j]) * up[j]
+//   2. Q8_0 dequant matvec: output[row] = Σ_j dequant(raw[row, j]) * intermediate[j]
+//
+// This avoids materialising the intermediate buffer and saves one dispatch per layer
+// in the FFN block (silu_mul + dequant_matvec_q8_0 → single fused kernel).
+//
+// Q8_0 block layout (34 bytes per block, 32 weights per block):
+//   bytes  0-1:  scale (f16 LE)
+//   bytes  2-33: qs[32] — signed int8 quantized values
+//
+// Weight reconstruction: w[i] = scale * i32(qs[i])
+//
+// One workgroup per output row.  64 threads stride over blocks;
+// a tree reduction over workgroup-shared memory accumulates partial sums.
+//
+// Bindings:
+//   binding 0: gate   — f32 gate projection output  [in_cols]
+//   binding 1: up     — f32 up projection output    [in_cols]
+//   binding 2: raw    — packed Q8_0 weight data      [num_rows * num_blocks_per_row * 34 bytes, padded]
+//   binding 3: output — f32 result                   [num_rows]
+//   binding 4: params — uniform
+
+@group(0) @binding(0) var<storage, read> gate: array<f32>;
+@group(0) @binding(1) var<storage, read> up: array<f32>;
+@group(0) @binding(2) var<storage, read> raw: array<u32>;
+@group(0) @binding(3) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    num_rows:           u32,
+    num_blocks_per_row: u32,
+}
+@group(0) @binding(4) var<uniform> params: Params;
+
+/// Workgroup-shared partial sums for the tree reduction.
+var<workgroup> partials: array<f32, 64>;
+
+/// Extract one byte at the given absolute byte offset from the u32 storage array.
+fn read_byte(byte_offset: u32) -> u32 {
+    return (raw[byte_offset / 4u] >> ((byte_offset % 4u) * 8u)) & 0xFFu;
+}
+
+@compute @workgroup_size(64)
+fn fused_silu_mul_dequant_matvec_q8_0(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+) {
+    let row = wid.x;
+    if row >= params.num_rows {
+        return;
+    }
+
+    let tid = lid.x;
+    var acc: f32 = 0.0;
+
+    // Each thread strides across blocks in this row.
+    var b: u32 = tid;
+    loop {
+        if b >= params.num_blocks_per_row {
+            break;
+        }
+
+        // Absolute byte offset of this block in the raw buffer (34 bytes per block).
+        let bb = (row * params.num_blocks_per_row + b) * 34u;
+        // Corresponding start position in the input vectors for this block.
+        let vec_base = b * 32u;
+
+        // Scale: f16 LE at bytes 0-1 of the block.
+        let scale_bits = read_byte(bb) | (read_byte(bb + 1u) << 8u);
+        let scale = unpack2x16float(scale_bits).x;
+
+        // qs[32]: signed int8 values at bytes 2-33 of the block.
+        for (var k = 0u; k < 32u; k = k + 1u) {
+            let byte_val = read_byte(bb + 2u + k);
+            let q = i32(byte_val << 24u) >> 24;
+
+            // Fused SiLU(gate) * up — computed inline instead of from a temp buffer.
+            let idx = vec_base + k;
+            let g = gate[idx];
+            let silu_val = g / (1.0 + exp(-g));
+            let input_val = silu_val * up[idx];
+
+            acc = acc + scale * f32(q) * input_val;
+        }
+
+        b = b + 64u;
+    }
+
+    partials[tid] = acc;
+    workgroupBarrier();
+
+    // Parallel tree reduction: 64 → 1.
+    if tid < 32u {
+        partials[tid] = partials[tid] + partials[tid + 32u];
+    }
+    workgroupBarrier();
+    if tid < 16u {
+        partials[tid] = partials[tid] + partials[tid + 16u];
+    }
+    workgroupBarrier();
+    if tid < 8u {
+        partials[tid] = partials[tid] + partials[tid + 8u];
+    }
+    workgroupBarrier();
+    if tid < 4u {
+        partials[tid] = partials[tid] + partials[tid + 4u];
+    }
+    workgroupBarrier();
+    if tid < 2u {
+        partials[tid] = partials[tid] + partials[tid + 2u];
+    }
+    workgroupBarrier();
+    if tid < 1u {
+        partials[tid] = partials[tid] + partials[tid + 1u];
+    }
+    workgroupBarrier();
+
+    if tid == 0u {
+        output[row] = partials[0u];
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -58,6 +58,8 @@ const BATCHED_MATVEC_SHADER: &str = include_str!("../shaders/batched_matvec.wgsl
 const BATCHED_RMSNORM_SHADER: &str = include_str!("../shaders/batched_rmsnorm.wgsl");
 const BATCHED_ROPE_SHADER: &str = include_str!("../shaders/batched_rope.wgsl");
 const ADD_RESIDUAL_SHADER: &str = include_str!("../shaders/add_residual.wgsl");
+const FUSED_SILU_MUL_DEQUANT_MATVEC_Q8_0_SHADER: &str =
+    include_str!("../shaders/fused_silu_mul_dequant_matvec_q8_0.wgsl");
 
 /// GPU-resident weight buffer for a single quantized weight matrix.
 ///
@@ -379,6 +381,18 @@ impl WebGpuBackend {
     /// 5-binding layout for the attention shader:
     /// q (read), k_cache (read), v_cache (read), output (read-write), params (uniform).
     fn attention_layout() -> [wgpu::BindGroupLayoutEntry; 5] {
+        [
+            storage_ro_entry(0),
+            storage_ro_entry(1),
+            storage_ro_entry(2),
+            storage_rw_entry(3),
+            uniform_entry(4),
+        ]
+    }
+
+    /// 5-binding layout for fused kernels with 3 read-only inputs, 1 read-write output, 1 uniform.
+    /// Used by fused_silu_mul_dequant_matvec_q8_0.
+    fn fused_3in_layout() -> [wgpu::BindGroupLayoutEntry; 5] {
         [
             storage_ro_entry(0),
             storage_ro_entry(1),
@@ -3334,6 +3348,72 @@ impl WebGpuBackend {
         self.pool.return_uniform(params_buf);
     }
 
+    /// Dispatch fused SiLU-Mul + Q8_0 dequant matvec on an existing compute pass.
+    ///
+    /// Combines `silu_mul` and `dequant_matvec_q8_0` into a single dispatch:
+    /// output[row] = Σ_j  dequant(w_down[row, j]) * SiLU(gate[j]) * up[j]
+    ///
+    /// Saves one dispatch per layer in the FFN block.
+    fn dispatch_fused_silu_mul_dequant_matvec_q8_0(
+        &self,
+        pass: &mut wgpu::ComputePass<'_>,
+        gate_buf: &wgpu::Buffer,
+        up_buf: &wgpu::Buffer,
+        weight: &GpuWeightBuffer,
+        output_buf: &wgpu::Buffer,
+    ) {
+        let num_rows = weight.num_rows;
+        let blocks_per_row = weight.blocks_per_row;
+
+        let params: [u32; 2] = [num_rows as u32, blocks_per_row as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::fused_3in_layout();
+        self.cache.with_pipeline(
+            &self.device,
+            "fused_silu_mul_dequant_matvec_q8_0",
+            FUSED_SILU_MUL_DEQUANT_MATVEC_Q8_0_SHADER,
+            "fused_silu_mul_dequant_matvec_q8_0",
+            &layout_entries,
+            |cached| {
+                let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: None,
+                    layout: &cached.layout,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: gate_buf.as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: up_buf.as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 2,
+                            resource: weight.buf.as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 3,
+                            resource: output_buf.as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 4,
+                            resource: params_buf.as_entire_binding(),
+                        },
+                    ],
+                });
+
+                pass.set_pipeline(&cached.pipeline);
+                pass.set_bind_group(0, &bind_group, &[]);
+                pass.dispatch_workgroups(num_rows as u32, 1, 1);
+            },
+        );
+
+        self.pool.return_uniform(params_buf);
+    }
+
     /// Dispatch add_residual on an existing compute pass.
     fn dispatch_add_residual(
         &self,
@@ -3603,11 +3683,31 @@ impl WebGpuBackend {
                 self.dispatch_dequant_matvec(&mut pass, &layer.w_gate, ffn_normed_buf, gate_buf);
                 self.dispatch_dequant_matvec(&mut pass, &layer.w_up, ffn_normed_buf, up_buf);
 
-                // 11. SiLU(gate) * up
-                self.dispatch_silu_mul(&mut pass, gate_buf, up_buf, silu_buf, intermediate_dim);
-
-                // 12. Down projection
-                self.dispatch_dequant_matvec(&mut pass, &layer.w_down, silu_buf, ffn_out_buf);
+                // 11-12. SiLU(gate) * up → down projection.
+                // Use fused kernel for Q8_0 weights (saves 1 dispatch per layer).
+                if layer.w_down.format == WeightFormat::Q8_0 {
+                    self.dispatch_fused_silu_mul_dequant_matvec_q8_0(
+                        &mut pass,
+                        gate_buf,
+                        up_buf,
+                        &layer.w_down,
+                        ffn_out_buf,
+                    );
+                } else {
+                    self.dispatch_silu_mul(
+                        &mut pass,
+                        gate_buf,
+                        up_buf,
+                        silu_buf,
+                        intermediate_dim,
+                    );
+                    self.dispatch_dequant_matvec(
+                        &mut pass,
+                        &layer.w_down,
+                        silu_buf,
+                        ffn_out_buf,
+                    );
+                }
 
                 // 13-14. Optional post-FFN RMSNorm + residual
                 if let Some(ref post_norm_buf) = layer.post_ffn_norm {


### PR DESCRIPTION
## Summary

- Adds a new fused WGSL shader (`fused_silu_mul_dequant_matvec_q8_0.wgsl`) that combines the SiLU activation + element-wise multiply with the Q8_0 dequantized matrix-vector product into a single GPU dispatch
- Eliminates the intermediate `silu_buf` materialization in the FFN down projection, reducing dispatch count by 1 per transformer layer
- Non-Q8_0 weight formats fall back to the existing two-dispatch path (silu_mul + dequant_matvec)

Per [arxiv.org/abs/2604.02344], kernel fusion of this type reduces total GPU dispatches by ~40% and can improve throughput by up to 53%.

## Changes

- **New file**: `flare-gpu/shaders/fused_silu_mul_dequant_matvec_q8_0.wgsl` -- fused compute shader with 5 bindings (gate, up, raw Q8_0 weights, output, params)
- **Modified**: `flare-gpu/src/backend.rs` -- added `dispatch_fused_silu_mul_dequant_matvec_q8_0()`, `fused_3in_layout()`, shader constant, and conditional fusion in `forward_single_token_gpu()`

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test --workspace` passes
- [ ] Run `e2e_bench --log` with a Q8_0 model to measure dispatch count reduction and throughput improvement

Closes #379