### PR TITLE
feat: multi-threaded WASM inference via SharedArrayBuffer

### DIFF
--- a/examples/browser-chat/index.html
+++ b/examples/browser-chat/index.html
@@ -3,6 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- COOP/COEP headers required for SharedArrayBuffer (multi-threaded WASM).
+     These can also be set via HTTP response headers on the server. -->
+<meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin">
+<meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp">
 <title>Flare LLM — Browser Demo</title>
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/flare-core/Cargo.toml
+++ b/flare-core/Cargo.toml
@@ -19,6 +19,15 @@ log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
-# Native multi-threading via rayon. Disabled on wasm32 (no threads).
+[features]
+default = []
+# Enable multi-threaded WASM inference via SharedArrayBuffer + wasm-bindgen-rayon.
+# Requires COOP/COEP headers on the serving page. Not all deployments support this.
+wasm_threads = ["rayon"]
+
+# Native multi-threading via rayon. Disabled on wasm32 (no threads) unless wasm_threads is enabled.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rayon = "1.10"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+rayon = { version = "1.10", optional = true }

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -1623,33 +1623,65 @@ fn matvec_simd(mat: &[f32], vec: &[f32], rows: usize, cols: usize) -> Vec<f32> {
     output
 }
 
+/// Compute a single row dot product with 4-wide unrolling for auto-vectorization.
+fn matvec_scalar_row(row: &[f32], vec: &[f32], cols: usize) -> f32 {
+    let cols4 = cols & !3;
+    let mut sum0 = 0.0f32;
+    let mut sum1 = 0.0f32;
+    let mut sum2 = 0.0f32;
+    let mut sum3 = 0.0f32;
+
+    let mut j = 0;
+    while j < cols4 {
+        sum0 += row[j] * vec[j];
+        sum1 += row[j + 1] * vec[j + 1];
+        sum2 += row[j + 2] * vec[j + 2];
+        sum3 += row[j + 3] * vec[j + 3];
+        j += 4;
+    }
+    while j < cols {
+        sum0 += row[j] * vec[j];
+        j += 1;
+    }
+    sum0 + sum1 + sum2 + sum3
+}
+
 /// Scalar matvec with 4-wide unrolling for auto-vectorization.
 ///
 /// Always available as a reference implementation for tests, regardless of target.
+/// When the `wasm_threads` feature is enabled on wasm32, rows are processed in
+/// parallel via rayon (backed by SharedArrayBuffer + Web Workers).
 pub fn matvec_scalar(mat: &[f32], vec: &[f32], rows: usize, cols: usize) -> Vec<f32> {
-    let mut output = vec![0.0f32; rows];
-    let cols4 = cols & !3;
+    // Parallel path for wasm32 with wasm_threads feature enabled.
+    #[cfg(all(target_arch = "wasm32", feature = "wasm_threads"))]
+    {
+        const PARALLEL_THRESHOLD: usize = 5_000_000;
+        const CHUNK_ROWS: usize = 64;
+        let total_work = rows * cols;
 
+        if total_work >= PARALLEL_THRESHOLD && rows >= CHUNK_ROWS * 2 {
+            use rayon::prelude::*;
+            let mut output = vec![0.0f32; rows];
+            output
+                .par_chunks_mut(CHUNK_ROWS)
+                .enumerate()
+                .for_each(|(chunk_idx, out_chunk)| {
+                    let row_start = chunk_idx * CHUNK_ROWS;
+                    for (local_i, out) in out_chunk.iter_mut().enumerate() {
+                        let i = row_start + local_i;
+                        let row = &mat[i * cols..i * cols + cols];
+                        *out = matvec_scalar_row(row, vec, cols);
+                    }
+                });
+            return output;
+        }
+    }
+
+    // Sequential path (default for wasm32, or when below parallel threshold).
+    let mut output = vec![0.0f32; rows];
     for (i, out) in output.iter_mut().enumerate() {
         let row = &mat[i * cols..(i + 1) * cols];
-        let mut sum0 = 0.0f32;
-        let mut sum1 = 0.0f32;
-        let mut sum2 = 0.0f32;
-        let mut sum3 = 0.0f32;
-
-        let mut j = 0;
-        while j < cols4 {
-            sum0 += row[j] * vec[j];
-            sum1 += row[j + 1] * vec[j + 1];
-            sum2 += row[j + 2] * vec[j + 2];
-            sum3 += row[j + 3] * vec[j + 3];
-            j += 4;
-        }
-        while j < cols {
-            sum0 += row[j] * vec[j];
-            j += 1;
-        }
-        *out = sum0 + sum1 + sum2 + sum3;
+        *out = matvec_scalar_row(row, vec, cols);
     }
     output
 }

--- a/flare-web/Cargo.toml
+++ b/flare-web/Cargo.toml
@@ -43,3 +43,10 @@ serde_json = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
 console_error_panic_hook = "0.1"
+wasm-bindgen-rayon = { version = "1.2", optional = true }
+
+[features]
+default = []
+# Enable multi-threaded WASM inference via SharedArrayBuffer.
+# Requires COOP/COEP headers. Build: wasm-pack build flare-web --target web --features wasm_threads
+wasm_threads = ["wasm-bindgen-rayon", "flare-core/wasm_threads"]

--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- COOP/COEP headers required for SharedArrayBuffer (multi-threaded WASM).
+       These can also be set via HTTP response headers on the server. -->
+  <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin">
+  <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp">
   <title>Flare LLM Browser Demo</title>
   <style>
     :root {
@@ -172,7 +176,7 @@
   <script type="module">
     import init, {
       FlareEngine, FlareProgressiveLoader, FlareTokenizer,
-      webgpu_available
+      webgpu_available, init_thread_pool
     } from '../pkg/flare_web.js';
 
     const $ = id => document.getElementById(id);
@@ -394,8 +398,22 @@
     async function startWasm() {
       try {
         await init();
+
+        // Initialize rayon thread pool for multi-threaded inference when
+        // built with --features wasm_threads and SharedArrayBuffer is available.
+        let threadsInfo = '';
+        if (typeof init_thread_pool === 'function' && typeof SharedArrayBuffer !== 'undefined') {
+          const numThreads = navigator.hardwareConcurrency || 4;
+          try {
+            await init_thread_pool(numThreads);
+            threadsInfo = ` | Threads: ${numThreads}`;
+          } catch (e) {
+            console.warn('Thread pool init failed (COOP/COEP headers may be missing):', e);
+          }
+        }
+
         $status.textContent = 'WASM module loaded. Ready.';
-        $env.textContent = `WebGPU: ${webgpu_available() ? 'yes' : 'no'}`;
+        $env.textContent = `WebGPU: ${webgpu_available() ? 'yes' : 'no'}${threadsInfo}`;
         [$fileInput, $urlInput, $urlLoad, $tokFileIn, $tokUrlIn, $tokUrlLoad]
           .forEach(el => { el.disabled = false; });
       } catch (err) {

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -44,6 +44,20 @@ pub fn start() {
     console_error_panic_hook::set_once();
 }
 
+/// Initialize the rayon thread pool for multi-threaded WASM inference.
+///
+/// Call this once after WASM init with the desired number of threads
+/// (typically `navigator.hardwareConcurrency`). Requires the page to be served
+/// with COOP/COEP headers for SharedArrayBuffer access.
+///
+/// Only available when built with `--features wasm_threads`.
+#[cfg(feature = "wasm_threads")]
+#[wasm_bindgen]
+pub fn init_thread_pool(num_threads: usize) -> Result<(), JsValue> {
+    wasm_bindgen_rayon::init_thread_pool(num_threads);
+    Ok(())
+}
+
 /// Check if WebGPU is available in the current browser.
 #[wasm_bindgen]
 pub fn webgpu_available() -> bool {


### PR DESCRIPTION
## Summary

Adds a `wasm_threads` feature flag that enables parallel matvec row processing in WASM using rayon + wasm-bindgen-rayon, targeting 3-4x CPU throughput in the browser by splitting matmul across Web Workers.

- **flare-core**: `wasm_threads` feature gates rayon on wasm32; `matvec_scalar` uses `par_chunks_mut` for parallel row processing when enabled (same threshold/chunking strategy as native NEON/AVX2 paths)
- **flare-web**: `wasm-bindgen-rayon` dependency and `init_thread_pool(num_threads)` export via wasm_bindgen
- **Browser demos**: COOP/COEP meta tags for SharedArrayBuffer; auto-detect and initialize thread pool on startup
- Native build is completely unaffected; feature is opt-in for deployments that can serve COOP/COEP headers

### Usage

```bash
# Build with threads enabled
wasm-pack build flare-web --target web --features wasm_threads
```

```javascript
import init, { init_thread_pool, FlareEngine } from './pkg/flare_web.js';
await init();
await init_thread_pool(navigator.hardwareConcurrency);
// inference now uses multiple workers for matvec
```

## Test plan

- [x] `cargo build --release` passes (native unaffected)
- [x] `cargo test --workspace` passes (all existing tests green)
- [ ] `wasm-pack build flare-web --target web` (single-threaded, no regression)
- [ ] `wasm-pack build flare-web --target web --features wasm_threads` (multi-threaded build)
- [ ] Browser test: load model, verify thread count shown in status, confirm inference works
- [ ] Browser test without COOP/COEP headers: graceful fallback to single-threaded

Closes #384