### PR TITLE
Add flare-edge crate for serverless edge deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flarellm-edge"
+version = "0.1.0"
+dependencies = [
+ "flarellm-core",
+ "flarellm-loader",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "flarellm-gpu"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "flare-simd",
     "flare-web",
     "flare-server",
+    "flare-edge",
 ]
 resolver = "2"
 

--- a/flare-edge/Cargo.toml
+++ b/flare-edge/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "flarellm-edge"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Serverless LLM inference for edge runtimes (Cloudflare Workers, Fermyon Spin, Deno)"
+keywords = ["llm", "edge", "serverless", "wasm", "inference"]
+categories = ["web-programming", "science"]
+readme = "../README.md"
+
+[lib]
+name = "flare_edge"
+
+[dependencies]
+flare-core = { package = "flarellm-core", path = "../flare-core", version = "0.1.0" }
+flare-loader = { package = "flarellm-loader", path = "../flare-loader", version = "0.1.0" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+log = { workspace = true }

--- a/flare-edge/examples/edge_cli.rs
+++ b/flare-edge/examples/edge_cli.rs
@@ -1,0 +1,54 @@
+//! Minimal CLI that simulates an edge runtime request.
+//!
+//! Usage:
+//!   cargo run --example edge_cli -- models/smollm2-135m-instruct-q8_0.gguf "Hello!"
+
+use flare_edge::engine::EdgeEngine;
+use flare_edge::handle_chat_request;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    let model_path = args
+        .get(1)
+        .map(|s| s.as_str())
+        .unwrap_or("models/smollm2-135m-instruct-q8_0.gguf");
+
+    let user_message = args
+        .get(2)
+        .map(|s| s.as_str())
+        .unwrap_or("Hello!");
+
+    eprintln!("Loading model from {model_path}...");
+    let model_data = match std::fs::read(model_path) {
+        Ok(data) => data,
+        Err(e) => {
+            eprintln!("Error reading model file: {e}");
+            eprintln!("Usage: edge_cli <model.gguf> [message]");
+            std::process::exit(1);
+        }
+    };
+
+    let mut engine = match EdgeEngine::from_gguf_bytes(&model_data) {
+        Ok(engine) => engine,
+        Err(e) => {
+            eprintln!("Error loading model: {e}");
+            std::process::exit(1);
+        }
+    };
+    eprintln!("Model loaded successfully.");
+
+    let request = format!(
+        r#"{{"model":"smollm2","messages":[{{"role":"user","content":"{}"}}],"max_tokens":50}}"#,
+        user_message.replace('"', "\\\"")
+    );
+
+    eprintln!("Sending request...");
+    match handle_chat_request(&mut engine, &request) {
+        Ok(response) => println!("{response}"),
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/flare-edge/src/api.rs
+++ b/flare-edge/src/api.rs
@@ -1,0 +1,256 @@
+//! OpenAI-compatible chat completions API types for edge runtimes.
+//!
+//! These types mirror the OpenAI API specification and can be serialized /
+//! deserialized with serde_json for use in any HTTP handler.
+
+use serde::{Deserialize, Serialize};
+
+/// POST /v1/chat/completions request body.
+#[derive(Debug, Deserialize)]
+pub struct ChatCompletionRequest {
+    pub model: Option<String>,
+    pub messages: Vec<Message>,
+    #[serde(default = "default_max_tokens")]
+    pub max_tokens: usize,
+    #[serde(default = "default_temperature")]
+    pub temperature: f32,
+    #[serde(default = "default_top_p")]
+    pub top_p: f32,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default = "default_repeat_penalty")]
+    pub repeat_penalty: f32,
+}
+
+fn default_max_tokens() -> usize {
+    256
+}
+fn default_temperature() -> f32 {
+    0.7
+}
+fn default_top_p() -> f32 {
+    0.9
+}
+fn default_repeat_penalty() -> f32 {
+    1.1
+}
+
+/// A single message in a chat conversation.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Message {
+    pub role: String,
+    pub content: String,
+}
+
+/// Non-streaming response.
+#[derive(Debug, Serialize)]
+pub struct ChatCompletionResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub choices: Vec<Choice>,
+    pub usage: Usage,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Choice {
+    pub index: usize,
+    pub message: Message,
+    pub finish_reason: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Usage {
+    pub prompt_tokens: usize,
+    pub completion_tokens: usize,
+    pub total_tokens: usize,
+}
+
+/// SSE streaming chunk.
+#[derive(Debug, Serialize)]
+pub struct ChatCompletionChunk {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub choices: Vec<ChunkChoice>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChunkChoice {
+    pub index: usize,
+    pub delta: Delta,
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Delta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+
+impl ChatCompletionResponse {
+    /// Build a complete response from generated text.
+    pub fn new(
+        model: &str,
+        content: String,
+        prompt_tokens: usize,
+        completion_tokens: usize,
+    ) -> Self {
+        Self {
+            id: format!("chatcmpl-{}", generate_id()),
+            object: "chat.completion".into(),
+            created: current_timestamp(),
+            model: model.into(),
+            choices: vec![Choice {
+                index: 0,
+                message: Message {
+                    role: "assistant".into(),
+                    content,
+                },
+                finish_reason: "stop".into(),
+            }],
+            usage: Usage {
+                prompt_tokens,
+                completion_tokens,
+                total_tokens: prompt_tokens + completion_tokens,
+            },
+        }
+    }
+}
+
+impl ChatCompletionChunk {
+    /// Create a content delta chunk.
+    pub fn new_delta(
+        model: &str,
+        id: &str,
+        content: Option<String>,
+        finish_reason: Option<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            object: "chat.completion.chunk".into(),
+            created: current_timestamp(),
+            model: model.into(),
+            choices: vec![ChunkChoice {
+                index: 0,
+                delta: Delta {
+                    role: None,
+                    content,
+                },
+                finish_reason,
+            }],
+        }
+    }
+
+    /// Create an initial role chunk (marks the start of the assistant turn).
+    pub fn new_role(model: &str, id: &str) -> Self {
+        Self {
+            id: id.into(),
+            object: "chat.completion.chunk".into(),
+            created: current_timestamp(),
+            model: model.into(),
+            choices: vec![ChunkChoice {
+                index: 0,
+                delta: Delta {
+                    role: Some("assistant".into()),
+                    content: None,
+                },
+                finish_reason: None,
+            }],
+        }
+    }
+}
+
+fn generate_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos();
+    format!("{nanos:x}")
+}
+
+fn current_timestamp() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_request() {
+        let json = r#"{
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 100,
+            "temperature": 0.5,
+            "stream": true
+        }"#;
+        let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.messages.len(), 1);
+        assert_eq!(req.max_tokens, 100);
+        assert!(req.stream);
+        assert!((req.temperature - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_deserialize_defaults() {
+        let json = r#"{"messages": [{"role": "user", "content": "Hi"}]}"#;
+        let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.max_tokens, 256);
+        assert!(!req.stream);
+        assert!((req.temperature - 0.7).abs() < 1e-5);
+        assert!((req.top_p - 0.9).abs() < 1e-5);
+        assert!((req.repeat_penalty - 1.1).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_serialize_response() {
+        let resp = ChatCompletionResponse::new("test-model", "Hello!".into(), 5, 2);
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("chat.completion"));
+        assert!(json.contains("Hello!"));
+        assert!(json.contains("\"total_tokens\":7"));
+    }
+
+    #[test]
+    fn test_serialize_chunk() {
+        let chunk = ChatCompletionChunk::new_delta("test-model", "id-1", Some("Hi".into()), None);
+        let json = serde_json::to_string(&chunk).unwrap();
+        assert!(json.contains("chat.completion.chunk"));
+        assert!(json.contains("Hi"));
+    }
+
+    #[test]
+    fn test_serialize_role_chunk() {
+        let chunk = ChatCompletionChunk::new_role("test-model", "id-1");
+        let json = serde_json::to_string(&chunk).unwrap();
+        assert!(json.contains("\"role\":\"assistant\""));
+        assert!(!json.contains("\"content\""));
+    }
+
+    #[test]
+    fn test_serialize_finish_chunk() {
+        let chunk =
+            ChatCompletionChunk::new_delta("test-model", "id-1", None, Some("stop".into()));
+        let json = serde_json::to_string(&chunk).unwrap();
+        assert!(json.contains("\"finish_reason\":\"stop\""));
+        assert!(!json.contains("\"content\""));
+    }
+
+    #[test]
+    fn test_response_empty_content() {
+        let resp = ChatCompletionResponse::new("model", "".into(), 0, 0);
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"total_tokens\":0"));
+        assert!(json.contains("\"content\":\"\""));
+    }
+}

--- a/flare-edge/src/engine.rs
+++ b/flare-edge/src/engine.rs
@@ -1,0 +1,264 @@
+//! Edge inference engine: loads a model from bytes and runs chat completions.
+//!
+//! Designed for serverless edge runtimes where model data arrives as a byte
+//! slice (e.g. from a KV store, embedded binary, or fetch). No filesystem
+//! access required.
+
+use std::io::Cursor;
+
+use flare_core::chat::{ChatMessage, ChatTemplate, Role};
+use flare_core::generate::Generator;
+use flare_core::model::Model;
+use flare_core::sampling::SamplingParams;
+use flare_loader::gguf::{GgufFile, MetadataValue};
+use flare_loader::tokenizer::GgufVocab;
+use flare_loader::weights::load_model_weights;
+use thiserror::Error;
+
+use crate::api::{
+    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Message,
+};
+
+/// Errors that can occur in the edge engine.
+#[derive(Debug, Error)]
+pub enum EdgeError {
+    #[error("failed to parse GGUF header: {0}")]
+    GgufParse(String),
+    #[error("failed to extract model config: {0}")]
+    ConfigError(String),
+    #[error("failed to load model weights: {0}")]
+    WeightError(String),
+    #[error("failed to load tokenizer vocabulary: {0}")]
+    TokenizerError(String),
+}
+
+/// A self-contained inference engine for edge runtimes.
+///
+/// Holds the loaded model, tokenizer vocabulary, and chat template.
+/// All state is initialized from GGUF bytes — no filesystem needed.
+pub struct EdgeEngine {
+    model: Model,
+    vocab: GgufVocab,
+    chat_template: ChatTemplate,
+    model_name: String,
+}
+
+impl EdgeEngine {
+    /// Load a model from GGUF bytes (e.g. from a KV store or embedded binary).
+    ///
+    /// Parses the GGUF header, extracts configuration and vocabulary,
+    /// loads weights, and detects the chat template.
+    pub fn from_gguf_bytes(data: &[u8]) -> Result<Self, EdgeError> {
+        Self::from_gguf_bytes_with_name(data, "flare-edge")
+    }
+
+    /// Load from GGUF bytes with a custom model name.
+    pub fn from_gguf_bytes_with_name(data: &[u8], name: &str) -> Result<Self, EdgeError> {
+        let mut cursor = Cursor::new(data);
+
+        let gguf = GgufFile::parse_header(&mut cursor)
+            .map_err(|e| EdgeError::GgufParse(e.to_string()))?;
+
+        let config = gguf
+            .to_model_config()
+            .map_err(|e| EdgeError::ConfigError(e.to_string()))?;
+
+        let weights = load_model_weights(&gguf, &mut cursor)
+            .map_err(|e| EdgeError::WeightError(e.to_string()))?;
+
+        let vocab = GgufVocab::from_gguf(&gguf)
+            .map_err(|e| EdgeError::TokenizerError(e.to_string()))?;
+
+        // Detect chat template from GGUF metadata
+        let arch = gguf.architecture().unwrap_or("llama");
+        let chat_template = match gguf.metadata.get("tokenizer.chat_template") {
+            Some(MetadataValue::String(tmpl)) => ChatTemplate::from_gguf_template(tmpl, arch),
+            _ => ChatTemplate::from_architecture(arch),
+        };
+
+        let model = Model::new(config, weights);
+
+        Ok(Self {
+            model,
+            vocab,
+            chat_template,
+            model_name: name.to_string(),
+        })
+    }
+
+    /// Process a chat completion request, returning a non-streaming response.
+    pub fn chat_completion(&mut self, req: &ChatCompletionRequest) -> ChatCompletionResponse {
+        let model_name = req
+            .model
+            .as_deref()
+            .unwrap_or(&self.model_name)
+            .to_string();
+
+        let prompt = self.format_prompt(&req.messages);
+        let mut prompt_tokens = self.vocab.encode(&prompt);
+
+        // Truncate from the left if prompt exceeds context window
+        let max_seq = self.model.config().max_seq_len;
+        if prompt_tokens.len() > max_seq {
+            let excess = prompt_tokens.len() - max_seq;
+            prompt_tokens.drain(..excess);
+        }
+        let prompt_token_count = prompt_tokens.len();
+        let eos_token = self.vocab.eos_id;
+
+        let params = SamplingParams {
+            temperature: req.temperature,
+            top_p: req.top_p,
+            top_k: 40,
+            repeat_penalty: req.repeat_penalty,
+            min_p: 0.0,
+            ..Default::default()
+        };
+
+        self.model.reset();
+        let mut rng = make_rng();
+        let mut gen = Generator::new(&mut self.model, params);
+
+        let mut collected = String::new();
+        let generated = gen.generate(
+            &prompt_tokens,
+            req.max_tokens,
+            eos_token,
+            &mut rng,
+            |token_id, _step| {
+                if let Some(text) = self.vocab.decode_token(token_id) {
+                    collected.push_str(text);
+                }
+                true
+            },
+        );
+
+        let completion_tokens = generated.len();
+
+        ChatCompletionResponse::new(&model_name, collected, prompt_token_count, completion_tokens)
+    }
+
+    /// Process a chat completion request and return SSE-formatted stream chunks.
+    ///
+    /// Returns a `Vec<String>` where each entry is a complete SSE event line
+    /// (e.g. `"data: {...}\n\n"`). The last two entries are the finish chunk
+    /// and the `"data: [DONE]\n\n"` sentinel.
+    ///
+    /// Edge runtimes can iterate over these and write them to their
+    /// streaming response body.
+    pub fn chat_completion_stream(&mut self, req: &ChatCompletionRequest) -> Vec<String> {
+        let model_name = req
+            .model
+            .as_deref()
+            .unwrap_or(&self.model_name)
+            .to_string();
+        let id = format!("chatcmpl-stream-{}", generate_stream_id());
+
+        let prompt = self.format_prompt(&req.messages);
+        let mut prompt_tokens = self.vocab.encode(&prompt);
+
+        let max_seq = self.model.config().max_seq_len;
+        if prompt_tokens.len() > max_seq {
+            let excess = prompt_tokens.len() - max_seq;
+            prompt_tokens.drain(..excess);
+        }
+        let eos_token = self.vocab.eos_id;
+
+        let params = SamplingParams {
+            temperature: req.temperature,
+            top_p: req.top_p,
+            top_k: 40,
+            repeat_penalty: req.repeat_penalty,
+            min_p: 0.0,
+            ..Default::default()
+        };
+
+        let mut events: Vec<String> = Vec::new();
+
+        // Role chunk: marks the start of the assistant turn
+        let role_chunk = ChatCompletionChunk::new_role(&model_name, &id);
+        if let Ok(json) = serde_json::to_string(&role_chunk) {
+            events.push(format!("data: {json}\n\n"));
+        }
+
+        self.model.reset();
+        let mut rng = make_rng();
+        let mut gen = Generator::new(&mut self.model, params);
+
+        gen.generate(
+            &prompt_tokens,
+            req.max_tokens,
+            eos_token,
+            &mut rng,
+            |token_id, _step| {
+                if let Some(text) = self.vocab.decode_token(token_id) {
+                    let chunk = ChatCompletionChunk::new_delta(
+                        &model_name,
+                        &id,
+                        Some(text.to_string()),
+                        None,
+                    );
+                    if let Ok(json) = serde_json::to_string(&chunk) {
+                        events.push(format!("data: {json}\n\n"));
+                    }
+                }
+                true
+            },
+        );
+
+        // Finish chunk
+        let done_chunk =
+            ChatCompletionChunk::new_delta(&model_name, &id, None, Some("stop".to_string()));
+        if let Ok(json) = serde_json::to_string(&done_chunk) {
+            events.push(format!("data: {json}\n\n"));
+        }
+        events.push("data: [DONE]\n\n".to_string());
+
+        events
+    }
+
+    /// Format chat messages into a prompt string using the detected template.
+    fn format_prompt(&self, messages: &[Message]) -> String {
+        let chat_messages: Vec<ChatMessage> = messages
+            .iter()
+            .map(|m| ChatMessage {
+                role: match m.role.as_str() {
+                    "system" => Role::System,
+                    "assistant" => Role::Assistant,
+                    _ => Role::User,
+                },
+                content: m.content.clone(),
+            })
+            .collect();
+        self.chat_template.apply(&chat_messages)
+    }
+
+    /// Returns the model name.
+    pub fn model_name(&self) -> &str {
+        &self.model_name
+    }
+}
+
+/// Simple xorshift32 RNG seeded from the system clock.
+fn make_rng() -> impl FnMut() -> f32 {
+    let mut state: u32 = 0xDEADBEEF
+        ^ (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos());
+    move || {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        (state as f32) / (u32::MAX as f32)
+    }
+}
+
+fn generate_stream_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos();
+    format!("{nanos:x}")
+}

--- a/flare-edge/src/lib.rs
+++ b/flare-edge/src/lib.rs
@@ -1,0 +1,113 @@
+//! Serverless LLM inference for edge runtimes.
+//!
+//! `flare-edge` provides a thin API layer over `flare-core` and `flare-loader`
+//! for deploying LLM inference on serverless edge platforms such as Cloudflare
+//! Workers, Fermyon Spin, and Deno Deploy.
+//!
+//! # Design Principles
+//!
+//! - **No filesystem required** — models are loaded from byte slices (KV store,
+//!   embedded binary, or HTTP fetch).
+//! - **No async runtime dependency** — edge runtimes provide their own; this
+//!   crate is purely synchronous.
+//! - **OpenAI-compatible API** — request/response types follow the OpenAI chat
+//!   completions specification.
+//!
+//! # Quick Start
+//!
+//! ```rust,ignore
+//! use flare_edge::engine::EdgeEngine;
+//! use flare_edge::handle_chat_request;
+//!
+//! // Load model from bytes (e.g. from KV store)
+//! let model_data: &[u8] = fetch_model_bytes();
+//! let mut engine = EdgeEngine::from_gguf_bytes(model_data).unwrap();
+//!
+//! // Handle an incoming JSON request
+//! let request_json = r#"{"messages":[{"role":"user","content":"Hello!"}]}"#;
+//! let response_json = handle_chat_request(&mut engine, request_json).unwrap();
+//! ```
+
+pub mod api;
+pub mod engine;
+
+/// Process an HTTP request body (JSON) and return response JSON.
+///
+/// This is the generic handler that edge runtimes can call from their
+/// HTTP handler function. It parses the incoming JSON as a chat completion
+/// request, runs inference, and returns the serialized response.
+///
+/// For streaming requests (`"stream": true`), use
+/// [`handle_chat_request_stream`] instead.
+pub fn handle_chat_request(
+    engine: &mut engine::EdgeEngine,
+    request_body: &str,
+) -> Result<String, String> {
+    let req: api::ChatCompletionRequest =
+        serde_json::from_str(request_body).map_err(|e| format!("Invalid request: {e}"))?;
+
+    if req.stream {
+        return Err(
+            "Streaming requested but handle_chat_request returns a single response. \
+             Use handle_chat_request_stream instead."
+                .to_string(),
+        );
+    }
+
+    let response = engine.chat_completion(&req);
+    serde_json::to_string(&response).map_err(|e| format!("Serialization error: {e}"))
+}
+
+/// Process a streaming chat request and return SSE event chunks.
+///
+/// Returns a `Vec<String>` of SSE-formatted events. Each entry is a
+/// complete `"data: ...\n\n"` line ready to be written to the response
+/// stream. The final entry is `"data: [DONE]\n\n"`.
+pub fn handle_chat_request_stream(
+    engine: &mut engine::EdgeEngine,
+    request_body: &str,
+) -> Result<Vec<String>, String> {
+    let req: api::ChatCompletionRequest =
+        serde_json::from_str(request_body).map_err(|e| format!("Invalid request: {e}"))?;
+
+    Ok(engine.chat_completion_stream(&req))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_request_body() {
+        let json = r#"{"messages":[{"role":"user","content":"Hi"}],"max_tokens":50}"#;
+        let req: api::ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.messages.len(), 1);
+        assert_eq!(req.messages[0].role, "user");
+        assert_eq!(req.messages[0].content, "Hi");
+        assert_eq!(req.max_tokens, 50);
+    }
+
+    #[test]
+    fn test_parse_request_with_stream() {
+        let json = r#"{"messages":[],"stream":true}"#;
+        let req: api::ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        assert!(req.stream);
+    }
+
+    #[test]
+    fn test_parse_request_minimal() {
+        let json = r#"{"messages":[]}"#;
+        let req: api::ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        assert!(req.messages.is_empty());
+        assert_eq!(req.max_tokens, 256);
+        assert!(!req.stream);
+    }
+
+    #[test]
+    fn test_invalid_json_is_rejected() {
+        // Verify that serde_json rejects malformed input
+        let result: Result<api::ChatCompletionRequest, _> =
+            serde_json::from_str("not valid json");
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds new `flarellm-edge` crate for deploying LLM inference on serverless edge runtimes (Cloudflare Workers, Fermyon Spin, Deno Deploy)
- Provides OpenAI-compatible chat completions API types (request, response, SSE streaming chunks)
- Includes `EdgeEngine` that loads models from GGUF bytes (no filesystem needed) and runs inference
- Generic `handle_chat_request` / `handle_chat_request_stream` handler functions that edge runtimes can call from their HTTP handlers
- Example CLI (`edge_cli.rs`) demonstrating usage

## Design

- **No filesystem dependency** — models load from `&[u8]` byte slices (KV store, embedded binary, HTTP fetch)
- **No async runtime dependency** — purely synchronous; edge runtimes provide their own event loop
- **Thin API layer** — delegates to `flare-core` for inference and `flare-loader` for GGUF parsing
- Compiles for both native and wasm32 targets

## Test plan

- [x] `cargo test -p flarellm-edge` — 11 unit tests pass (API serialization, request parsing)
- [x] `cargo test --workspace` — all existing tests continue to pass
- [x] `cargo build --release` — clean build

Closes #392