### PR TITLE
Add self-speculative decoding via layer skipping

### DIFF
--- a/flare-core/src/generate.rs
+++ b/flare-core/src/generate.rs
@@ -123,9 +123,14 @@ impl<'a> Generator<'a> {
         }
     }
 
-    /// Returns whether speculative decoding is active for the current params.
+    /// Returns whether n-gram speculative decoding is active for the current params.
     fn is_speculative(&self) -> bool {
         self.params.speculative && self.params.temperature == 0.0
+    }
+
+    /// Returns whether self-speculative (layer-skipping) decoding is active.
+    fn is_self_speculative(&self) -> bool {
+        self.params.self_speculative && self.params.temperature == 0.0
     }
 
     /// Prefill: process the prompt as a batch, returning logits for the last token.
@@ -300,6 +305,107 @@ impl<'a> Generator<'a> {
         accepted
     }
 
+    /// Attempt self-speculative decoding: generate draft tokens using a
+    /// layer-skipping forward pass, then verify each with the full model.
+    ///
+    /// Returns all accepted tokens (at least one — the verified token at
+    /// the first position).  Returns an empty vec if the model has fewer
+    /// than 2 layers (layer skipping would be pointless).
+    fn self_speculative_step(&mut self) -> Vec<GenerationStep> {
+        let num_layers = self.model.config().num_layers;
+        if num_layers < 2 {
+            return Vec::new();
+        }
+
+        let draft_skip = self.params.draft_skip.max(2);
+        let max_drafts = self.params.draft_tokens.max(1);
+
+        // Build the set of layer indices to use for drafting (skip layers).
+        let draft_layers: Vec<usize> = (0..num_layers).step_by(draft_skip).collect();
+
+        // Save KV cache state so we can roll back after drafting.
+        let saved_kv_len = self.model.kv_cache().len();
+        let saved_position = self.position;
+
+        // --- Draft phase: generate tokens with the reduced model ---
+        let mut draft_tokens = Vec::with_capacity(max_drafts);
+        let mut draft_last_token = *self.tokens.last().unwrap_or(&0);
+
+        for _ in 0..max_drafts {
+            let logits_tensor = self.model.forward_skip_layers(
+                draft_last_token,
+                self.position,
+                &draft_layers,
+            );
+            let draft_token = sampling::sample_greedy(logits_tensor.data());
+            draft_tokens.push(draft_token);
+            draft_last_token = draft_token;
+            self.position += 1;
+        }
+
+        // --- Roll back KV cache and position to pre-draft state ---
+        self.model.truncate_kv_cache(saved_kv_len);
+        self.position = saved_position;
+
+        // --- Verify phase: run full forward pass for each draft position ---
+        self.speculative_stats.attempts += 1;
+        self.speculative_stats.drafted += draft_tokens.len();
+
+        let mut accepted = Vec::new();
+
+        for &draft_token in &draft_tokens {
+            let last_token = *self.tokens.last().unwrap_or(&0);
+
+            let (verified_token, logits) = if self.params.repeat_penalty == 1.0 {
+                let (tid, _val) = self.model.forward_greedy(last_token, self.position);
+                (tid, Vec::new())
+            } else {
+                let logits_tensor = self.model.forward(last_token, self.position);
+                let mut logits = logits_tensor.data().to_vec();
+                sampling::apply_repeat_penalty(
+                    &mut logits,
+                    &self.tokens,
+                    self.params.repeat_penalty,
+                );
+                let tid = sampling::sample_greedy(&logits);
+                (tid, logits)
+            };
+
+            if verified_token == draft_token {
+                // Draft matches — accept it.
+                self.tokens.push(verified_token);
+                self.position += 1;
+                self.speculative_stats.accepted += 1;
+
+                if self.is_speculative() {
+                    self.ngram_cache.record(&self.tokens);
+                }
+
+                accepted.push(GenerationStep {
+                    token_id: verified_token,
+                    logits,
+                });
+            } else {
+                // Mismatch — accept the verified token (correct output for
+                // this position) and stop.
+                self.tokens.push(verified_token);
+                self.position += 1;
+
+                if self.is_speculative() {
+                    self.ngram_cache.record(&self.tokens);
+                }
+
+                accepted.push(GenerationStep {
+                    token_id: verified_token,
+                    logits,
+                });
+                break;
+            }
+        }
+
+        accepted
+    }
+
     /// Generate up to `max_tokens` tokens, calling the callback for each.
     /// Returns the full list of generated token IDs.
     /// The callback receives (token_id, step_number) and returns true to continue.
@@ -320,8 +426,43 @@ impl<'a> Generator<'a> {
         let mut generated = Vec::new();
         let mut step = 0;
         let use_speculation = self.is_speculative();
+        let use_self_speculation = self.is_self_speculative();
 
         while step < max_tokens {
+            // Self-speculative decoding (layer-skipping draft + full verify)
+            if use_self_speculation && step > 0 {
+                let spec_results = self.self_speculative_step();
+                if !spec_results.is_empty() {
+                    let mut should_break = false;
+                    for result in spec_results {
+                        generated.push(result.token_id);
+
+                        if let Some(eos) = eos_token {
+                            if result.token_id == eos {
+                                should_break = true;
+                                break;
+                            }
+                        }
+
+                        if !on_token(result.token_id, step) {
+                            should_break = true;
+                            break;
+                        }
+
+                        step += 1;
+                        if step >= max_tokens {
+                            should_break = true;
+                            break;
+                        }
+                    }
+                    if should_break {
+                        break;
+                    }
+                    continue;
+                }
+            }
+
+            // N-gram speculative decoding
             if use_speculation && step > 0 {
                 // Try speculative decoding first.
                 let spec_results = self.speculative_step();
@@ -939,6 +1080,206 @@ mod tests {
             drafts,
             vec![42],
             "should prefer longer n-gram match, got {drafts:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Self-speculative decoding tests
+    // -----------------------------------------------------------------------
+
+    /// Build a tiny model with multiple layers for self-speculative tests.
+    fn tiny_model_multi_layer() -> Model {
+        let config = ModelConfig {
+            vocab_size: 8,
+            hidden_dim: 4,
+            intermediate_dim: 8,
+            num_layers: 4,
+            num_heads: 2,
+            num_kv_heads: 2,
+            head_dim: 2,
+            max_seq_len: 32,
+            rope_theta: 10000.0,
+            rms_norm_eps: 1e-5,
+            ..Default::default()
+        };
+
+        let dim = config.hidden_dim;
+        let vocab = config.vocab_size;
+        let inter = config.intermediate_dim;
+        let nh = config.num_heads;
+        let nkvh = config.num_kv_heads;
+        let hd = config.head_dim;
+
+        let make_tensor = |size: usize| -> Tensor {
+            let data: Vec<f32> = (0..size).map(|i| (i as f32 * 0.1).sin() * 0.1).collect();
+            Tensor::from_vec(data, &[size]).unwrap()
+        };
+
+        let make_layer = || LayerWeights {
+            attn_norm: Tensor::from_vec(vec![1.0; dim], &[dim]).unwrap(),
+            wq: make_tensor(nh * hd * dim),
+            wk: make_tensor(nkvh * hd * dim),
+            wv: make_tensor(nkvh * hd * dim),
+            wo: make_tensor(dim * nh * hd),
+            ffn_norm: Tensor::from_vec(vec![1.0; dim], &[dim]).unwrap(),
+            w_gate: make_tensor(inter * dim),
+            w_up: make_tensor(inter * dim),
+            w_down: make_tensor(dim * inter),
+            attn_q_bias: None,
+            attn_k_bias: None,
+            attn_v_bias: None,
+            post_attn_norm: None,
+            post_ffn_norm: None,
+        };
+
+        let weights = ModelWeights {
+            token_embedding: make_tensor(vocab * dim),
+            layers: (0..config.num_layers).map(|_| make_layer()).collect(),
+            output_norm: Tensor::from_vec(vec![1.0; dim], &[dim]).unwrap(),
+            output_weight: make_tensor(vocab * dim),
+        };
+
+        Model::new(config, weights)
+    }
+
+    #[test]
+    fn test_self_speculative_output_matches_greedy() {
+        // Self-speculative decoding must produce the exact same output
+        // as non-speculative greedy decoding.
+        let prompt = vec![1u32, 2, 3];
+        let max = 8;
+
+        // Run without self-speculation.
+        let baseline = {
+            let mut model = tiny_model_multi_layer();
+            let params = SamplingParams {
+                temperature: 0.0,
+                speculative: false,
+                self_speculative: false,
+                ..Default::default()
+            };
+            let mut gen = Generator::new(&mut model, params);
+            gen.generate(&prompt, max, None, || 0.5, |_, _| true)
+        };
+
+        // Run with self-speculation.
+        let self_spec = {
+            let mut model = tiny_model_multi_layer();
+            let params = SamplingParams {
+                temperature: 0.0,
+                speculative: false,
+                self_speculative: true,
+                draft_skip: 2,
+                draft_tokens: 4,
+                ..Default::default()
+            };
+            let mut gen = Generator::new(&mut model, params);
+            gen.generate(&prompt, max, None, || 0.5, |_, _| true)
+        };
+
+        assert_eq!(
+            baseline, self_spec,
+            "self-speculative output must match greedy baseline: baseline={baseline:?} vs self_spec={self_spec:?}"
+        );
+    }
+
+    #[test]
+    fn test_self_speculative_disabled_with_temperature() {
+        let mut model = tiny_model_multi_layer();
+        let params = SamplingParams {
+            temperature: 0.7,
+            self_speculative: true,
+            ..Default::default()
+        };
+        let gen = Generator::new(&mut model, params);
+        assert!(
+            !gen.is_self_speculative(),
+            "self-speculation should be disabled with temperature > 0"
+        );
+    }
+
+    #[test]
+    fn test_self_speculative_disabled_by_flag() {
+        let mut model = tiny_model_multi_layer();
+        let params = SamplingParams {
+            temperature: 0.0,
+            self_speculative: false,
+            ..Default::default()
+        };
+        let gen = Generator::new(&mut model, params);
+        assert!(
+            !gen.is_self_speculative(),
+            "self-speculation should be disabled when flag is false"
+        );
+    }
+
+    #[test]
+    fn test_self_speculative_stats_populated() {
+        let mut model = tiny_model_multi_layer();
+        let params = SamplingParams {
+            temperature: 0.0,
+            speculative: false,
+            self_speculative: true,
+            draft_skip: 2,
+            draft_tokens: 3,
+            ..Default::default()
+        };
+        let mut gen = Generator::new(&mut model, params);
+        let prompt = vec![1u32, 2];
+        let _generated = gen.generate(&prompt, 10, None, || 0.5, |_, _| true);
+
+        let stats = gen.speculative_stats();
+        // With 10 max_tokens and step>0 trigger, we should have attempts
+        assert!(
+            stats.attempts > 0,
+            "self-speculation should have at least one attempt"
+        );
+        assert!(
+            stats.drafted > 0,
+            "self-speculation should have drafted tokens"
+        );
+        assert!(
+            stats.accepted <= stats.drafted,
+            "accepted ({}) must not exceed drafted ({})",
+            stats.accepted,
+            stats.drafted
+        );
+    }
+
+    #[test]
+    fn test_self_speculative_single_layer_model_noop() {
+        // With only 1 layer, self-speculative step should return empty
+        // and fall through to normal generation.
+        let prompt = vec![1u32, 2];
+        let max = 4;
+
+        let baseline = {
+            let mut model = tiny_model(); // 1 layer
+            let params = SamplingParams {
+                temperature: 0.0,
+                speculative: false,
+                self_speculative: false,
+                ..Default::default()
+            };
+            let mut gen = Generator::new(&mut model, params);
+            gen.generate(&prompt, max, None, || 0.5, |_, _| true)
+        };
+
+        let self_spec = {
+            let mut model = tiny_model(); // 1 layer
+            let params = SamplingParams {
+                temperature: 0.0,
+                speculative: false,
+                self_speculative: true,
+                ..Default::default()
+            };
+            let mut gen = Generator::new(&mut model, params);
+            gen.generate(&prompt, max, None, || 0.5, |_, _| true)
+        };
+
+        assert_eq!(
+            baseline, self_spec,
+            "single-layer model should produce same output with self-spec enabled"
         );
     }
 }

--- a/flare-core/src/kv_cache.rs
+++ b/flare-core/src/kv_cache.rs
@@ -249,6 +249,24 @@ impl QuantizedKvCache {
         out
     }
 
+    /// Roll back the cache to `target_len` valid entries.
+    ///
+    /// Used by self-speculative decoding to undo draft token KV entries
+    /// before re-verifying with the full model.  Only valid when
+    /// `target_len <= self.length` and the cache has not wrapped around
+    /// (i.e. `self.length < self.max_seq_len`).
+    pub fn truncate_to(&mut self, target_len: usize) {
+        debug_assert!(target_len <= self.length);
+        if target_len >= self.length {
+            return;
+        }
+        // Only simple (non-wrapped) rollback is supported.
+        if self.length < self.max_seq_len {
+            self.position = target_len;
+            self.length = target_len;
+        }
+    }
+
     /// Reset the cache.
     pub fn clear(&mut self) {
         self.position = 0;
@@ -492,6 +510,24 @@ impl KvCache {
     /// Current write position in the ring buffer.
     pub fn position(&self) -> usize {
         self.position
+    }
+
+    /// Roll back the cache to `target_len` valid entries.
+    ///
+    /// Used by self-speculative decoding to undo draft token KV entries
+    /// before re-verifying with the full model.  Only valid when
+    /// `target_len <= self.length` and the cache has not wrapped around
+    /// (i.e. `self.length < self.max_seq_len`).
+    pub fn truncate_to(&mut self, target_len: usize) {
+        debug_assert!(target_len <= self.length);
+        if target_len >= self.length {
+            return;
+        }
+        // Only simple (non-wrapped) rollback is supported.
+        if self.length < self.max_seq_len {
+            self.position = target_len;
+            self.length = target_len;
+        }
     }
 
     /// Reset the cache (e.g., for a new conversation).

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -2743,6 +2743,585 @@ impl Model {
 
         Tensor::from_vec(self.forward_buffers.logits.clone(), &[config.vocab_size]).unwrap()
     }
+
+    /// Run a forward pass processing only the layers at the given indices.
+    ///
+    /// Used by self-speculative decoding to generate draft tokens quickly by
+    /// skipping layers (e.g., running only even-numbered layers).  The KV cache
+    /// is written at every layer index — skipped layers still get KV entries so
+    /// that position tracking stays consistent.
+    ///
+    /// **Important:** The caller must save and restore the KV cache position
+    /// (via `truncate_kv_cache`) after the draft phase, since the verify pass
+    /// needs to overwrite these entries with correct values from the full model.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any index in `layer_indices` is out of range.
+    #[allow(clippy::needless_range_loop)]
+    pub fn forward_skip_layers(
+        &mut self,
+        token_id: u32,
+        pos: usize,
+        layer_indices: &[usize],
+    ) -> Tensor {
+        assert!(
+            !layer_indices.is_empty(),
+            "forward_skip_layers requires at least 1 layer"
+        );
+        let num_layers_total = self.available_layers();
+        for &idx in layer_indices {
+            assert!(
+                idx < num_layers_total,
+                "forward_skip_layers: layer index {idx} out of range (have {num_layers_total})"
+            );
+        }
+
+        let config = &self.config;
+        let dim = config.hidden_dim;
+        let head_dim = config.head_dim;
+        let num_heads = config.num_heads;
+        let num_kv_heads = config.num_kv_heads;
+        let kv_dim = num_kv_heads * head_dim;
+
+        // Token embedding lookup
+        let embed_data = self.weights.token_embedding.data();
+        let offset = token_id as usize * dim;
+        let mut x = Tensor::from_vec(embed_data[offset..offset + dim].to_vec(), &[dim]).unwrap();
+
+        let use_raw = self.backend.supports_dequant_matmul() && self.raw_weights.is_some();
+        let use_cpu_q8 = !use_raw
+            && dim >= 1024
+            && self.raw_weights.is_some()
+            && self
+                .raw_weights
+                .as_ref()
+                .is_some_and(|rw| !rw.is_empty() && rw[0].wq.format == WeightFormat::Q8_0);
+        let use_cpu_q4k = !use_raw
+            && !use_cpu_q8
+            && dim >= 1024
+            && self.raw_weights.is_some()
+            && self
+                .raw_weights
+                .as_ref()
+                .is_some_and(|rw| !rw.is_empty() && rw[0].wq.format == WeightFormat::Q4K);
+
+        // Process only the specified transformer layers
+        for &layer_idx in layer_indices {
+            let layer = &self.weights.layers[layer_idx];
+
+            // --- Attention block ---
+            rmsnorm_into(
+                x.data(),
+                layer.attn_norm.data(),
+                config.rms_norm_eps,
+                &mut self.forward_buffers.normed,
+            );
+
+            // QKV projections
+            let q_dim = num_heads * head_dim;
+            if use_raw {
+                let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                let q_tmp =
+                    self.backend
+                        .batched_dequant_matmul(&rw.wq, &self.forward_buffers.normed, 1);
+                self.forward_buffers.q_data.copy_from_slice(&q_tmp);
+                let k_tmp =
+                    self.backend
+                        .batched_dequant_matmul(&rw.wk, &self.forward_buffers.normed, 1);
+                self.forward_buffers.k_data.copy_from_slice(&k_tmp);
+                let v_tmp =
+                    self.backend
+                        .batched_dequant_matmul(&rw.wv, &self.forward_buffers.normed, 1);
+                self.forward_buffers.v_data.copy_from_slice(&v_tmp);
+            } else if use_cpu_q4k {
+                let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                matvec_q4k_into(
+                    &rw.wq.data,
+                    &self.forward_buffers.normed,
+                    rw.wq.num_rows,
+                    dim,
+                    &mut self.forward_buffers.q_data,
+                );
+                matvec_q4k_into(
+                    &rw.wk.data,
+                    &self.forward_buffers.normed,
+                    rw.wk.num_rows,
+                    dim,
+                    &mut self.forward_buffers.k_data,
+                );
+                matvec_q4k_into(
+                    &rw.wv.data,
+                    &self.forward_buffers.normed,
+                    rw.wv.num_rows,
+                    dim,
+                    &mut self.forward_buffers.v_data,
+                );
+            } else if use_cpu_q8 {
+                quantize_input_q8_0_into(
+                    &self.forward_buffers.normed,
+                    &mut self.forward_buffers.normed_q8,
+                );
+                let fused = &self.fused_weights.as_ref().unwrap()[layer_idx];
+                matvec_q8_0_preq_into(
+                    &fused.qkv_data,
+                    &self.forward_buffers.normed_q8,
+                    fused.qkv_rows,
+                    &mut self.forward_buffers.qkv,
+                );
+                self.forward_buffers
+                    .q_data
+                    .copy_from_slice(&self.forward_buffers.qkv[..q_dim]);
+                self.forward_buffers
+                    .k_data
+                    .copy_from_slice(&self.forward_buffers.qkv[q_dim..q_dim + kv_dim]);
+                self.forward_buffers
+                    .v_data
+                    .copy_from_slice(&self.forward_buffers.qkv[q_dim + kv_dim..]);
+            } else if let Some(ref fused_qkv) = self.fused_f32_qkv {
+                matvec_into(
+                    &fused_qkv[layer_idx],
+                    &self.forward_buffers.normed,
+                    q_dim + kv_dim + kv_dim,
+                    dim,
+                    &mut self.forward_buffers.qkv,
+                );
+                self.forward_buffers
+                    .q_data
+                    .copy_from_slice(&self.forward_buffers.qkv[..q_dim]);
+                self.forward_buffers
+                    .k_data
+                    .copy_from_slice(&self.forward_buffers.qkv[q_dim..q_dim + kv_dim]);
+                self.forward_buffers
+                    .v_data
+                    .copy_from_slice(&self.forward_buffers.qkv[q_dim + kv_dim..]);
+            } else {
+                matvec_into(
+                    layer.wq.data(),
+                    &self.forward_buffers.normed,
+                    q_dim,
+                    dim,
+                    &mut self.forward_buffers.q_data,
+                );
+                matvec_into(
+                    layer.wk.data(),
+                    &self.forward_buffers.normed,
+                    kv_dim,
+                    dim,
+                    &mut self.forward_buffers.k_data,
+                );
+                matvec_into(
+                    layer.wv.data(),
+                    &self.forward_buffers.normed,
+                    kv_dim,
+                    dim,
+                    &mut self.forward_buffers.v_data,
+                );
+            }
+
+            // Attention biases (Qwen2)
+            if let Some(bias) = &layer.attn_q_bias {
+                for (q, &b) in self
+                    .forward_buffers
+                    .q_data
+                    .iter_mut()
+                    .zip(bias.data().iter())
+                {
+                    *q += b;
+                }
+            }
+            if let Some(bias) = &layer.attn_k_bias {
+                for (k, &b) in self
+                    .forward_buffers
+                    .k_data
+                    .iter_mut()
+                    .zip(bias.data().iter())
+                {
+                    *k += b;
+                }
+            }
+            if let Some(bias) = &layer.attn_v_bias {
+                for (v, &b) in self
+                    .forward_buffers
+                    .v_data
+                    .iter_mut()
+                    .zip(bias.data().iter())
+                {
+                    *v += b;
+                }
+            }
+            apply_rope(
+                &mut self.forward_buffers.q_data,
+                num_heads,
+                head_dim,
+                pos,
+                config.rope_theta,
+            );
+            apply_rope(
+                &mut self.forward_buffers.k_data,
+                num_kv_heads,
+                head_dim,
+                pos,
+                config.rope_theta,
+            );
+
+            self.kv_cache.write(
+                layer_idx,
+                &self.forward_buffers.k_data,
+                &self.forward_buffers.v_data,
+            );
+            if let Some(ref mut qkv) = self.quantized_kv_cache {
+                qkv.write(
+                    layer_idx,
+                    &self.forward_buffers.k_data,
+                    &self.forward_buffers.v_data,
+                );
+            }
+            self.backend.gpu_kv_write(
+                layer_idx,
+                pos,
+                num_kv_heads,
+                head_dim,
+                &self.forward_buffers.k_data,
+                &self.forward_buffers.v_data,
+            );
+
+            let seq_len = self.kv_cache.len() + 1;
+            if self.backend.has_gpu_kv_cache() {
+                let attn_tmp = self.backend.grouped_query_attention_from_gpu_cache(
+                    &self.forward_buffers.q_data,
+                    layer_idx,
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                    seq_len,
+                    config.attn_logit_softcap,
+                );
+                self.forward_buffers.attn_output.copy_from_slice(&attn_tmp);
+            } else if let Some(ref qkv) = self.quantized_kv_cache {
+                let dequant_keys = qkv.dequant_keys(layer_idx);
+                let dequant_values = qkv.dequant_values(layer_idx);
+                cpu_grouped_query_attention_into(
+                    &self.forward_buffers.q_data,
+                    &dequant_keys,
+                    &dequant_values,
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                    seq_len,
+                    config.attn_logit_softcap,
+                    &mut self.forward_buffers.attn_output,
+                );
+            } else {
+                cpu_grouped_query_attention_into(
+                    &self.forward_buffers.q_data,
+                    self.kv_cache.keys(layer_idx).data(),
+                    self.kv_cache.values(layer_idx).data(),
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                    seq_len,
+                    config.attn_logit_softcap,
+                    &mut self.forward_buffers.attn_output,
+                );
+            }
+
+            // Output projection (wo)
+            if use_raw {
+                let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                let tmp = self.backend.batched_dequant_matmul(
+                    &rw.wo,
+                    &self.forward_buffers.attn_output,
+                    1,
+                );
+                self.forward_buffers.attn_proj.copy_from_slice(&tmp);
+            } else if use_cpu_q4k {
+                let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                matvec_q4k_into(
+                    &rw.wo.data,
+                    &self.forward_buffers.attn_output,
+                    rw.wo.num_rows,
+                    num_heads * head_dim,
+                    &mut self.forward_buffers.attn_proj,
+                );
+            } else if use_cpu_q8 {
+                let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                matvec_q8_0_into(
+                    &rw.wo.data,
+                    &self.forward_buffers.attn_output,
+                    rw.wo.num_rows,
+                    num_heads * head_dim,
+                    &mut self.forward_buffers.attn_proj,
+                );
+            } else {
+                matvec_into(
+                    layer.wo.data(),
+                    &self.forward_buffers.attn_output,
+                    dim,
+                    num_heads * head_dim,
+                    &mut self.forward_buffers.attn_proj,
+                );
+            }
+
+            if let Some(ref post_norm) = layer.post_attn_norm {
+                rmsnorm_into(
+                    &self.forward_buffers.attn_proj,
+                    post_norm.data(),
+                    config.rms_norm_eps,
+                    &mut self.forward_buffers.attn_contrib,
+                );
+                let x_data = x.data_mut();
+                for i in 0..dim {
+                    x_data[i] += self.forward_buffers.attn_contrib[i];
+                }
+            } else {
+                let x_data = x.data_mut();
+                for i in 0..dim {
+                    x_data[i] += self.forward_buffers.attn_proj[i];
+                }
+            }
+
+            // --- FFN block ---
+
+            if use_cpu_q8 {
+                let fused = &self.fused_weights.as_ref().unwrap()[layer_idx];
+                prefetch_weight_bytes(&fused.gate_up_data);
+            } else if self.fused_f32_gate_up.is_some() {
+                prefetch_weight_f32(&self.fused_f32_gate_up.as_ref().unwrap()[layer_idx]);
+            } else if !use_raw {
+                prefetch_weight_f32(layer.w_gate.data());
+            }
+
+            rmsnorm_into(
+                x.data(),
+                layer.ffn_norm.data(),
+                config.rms_norm_eps,
+                &mut self.forward_buffers.ffn_normed,
+            );
+
+            let inter_dim = config.intermediate_dim;
+            if use_raw {
+                let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                let gate_tmp = self.backend.batched_dequant_matmul(
+                    &rw.w_gate,
+                    &self.forward_buffers.ffn_normed,
+                    1,
+                );
+                self.forward_buffers.gate.copy_from_slice(&gate_tmp);
+                let up_tmp = self.backend.batched_dequant_matmul(
+                    &rw.w_up,
+                    &self.forward_buffers.ffn_normed,
+                    1,
+                );
+                self.forward_buffers.up.copy_from_slice(&up_tmp);
+            } else if use_cpu_q4k {
+                let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                matvec_q4k_into(
+                    &rw.w_gate.data,
+                    &self.forward_buffers.ffn_normed,
+                    rw.w_gate.num_rows,
+                    dim,
+                    &mut self.forward_buffers.gate,
+                );
+                matvec_q4k_into(
+                    &rw.w_up.data,
+                    &self.forward_buffers.ffn_normed,
+                    rw.w_up.num_rows,
+                    dim,
+                    &mut self.forward_buffers.up,
+                );
+            } else if use_cpu_q8 {
+                quantize_input_q8_0_into(
+                    &self.forward_buffers.ffn_normed,
+                    &mut self.forward_buffers.ffn_normed_q8,
+                );
+                let fused = &self.fused_weights.as_ref().unwrap()[layer_idx];
+                matvec_q8_0_preq_into(
+                    &fused.gate_up_data,
+                    &self.forward_buffers.ffn_normed_q8,
+                    fused.gate_up_rows,
+                    &mut self.forward_buffers.gate_up,
+                );
+                self.forward_buffers
+                    .gate
+                    .copy_from_slice(&self.forward_buffers.gate_up[..inter_dim]);
+                self.forward_buffers
+                    .up
+                    .copy_from_slice(&self.forward_buffers.gate_up[inter_dim..]);
+            } else if let Some(ref fused_gu) = self.fused_f32_gate_up {
+                matvec_into(
+                    &fused_gu[layer_idx],
+                    &self.forward_buffers.ffn_normed,
+                    inter_dim * 2,
+                    dim,
+                    &mut self.forward_buffers.gate_up,
+                );
+                self.forward_buffers
+                    .gate
+                    .copy_from_slice(&self.forward_buffers.gate_up[..inter_dim]);
+                self.forward_buffers
+                    .up
+                    .copy_from_slice(&self.forward_buffers.gate_up[inter_dim..]);
+            } else {
+                matvec_into(
+                    layer.w_gate.data(),
+                    &self.forward_buffers.ffn_normed,
+                    inter_dim,
+                    dim,
+                    &mut self.forward_buffers.gate,
+                );
+                matvec_into(
+                    layer.w_up.data(),
+                    &self.forward_buffers.ffn_normed,
+                    inter_dim,
+                    dim,
+                    &mut self.forward_buffers.up,
+                );
+            }
+
+            if config.architecture == Architecture::Gemma2 {
+                gelu_mul_into(
+                    &self.forward_buffers.gate,
+                    &self.forward_buffers.up,
+                    &mut self.forward_buffers.ffn_hidden,
+                );
+            } else {
+                silu_mul_into(
+                    &self.forward_buffers.gate,
+                    &self.forward_buffers.up,
+                    &mut self.forward_buffers.ffn_hidden,
+                );
+            }
+
+            if use_raw {
+                let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                let tmp = self.backend.batched_dequant_matmul(
+                    &rw.w_down,
+                    &self.forward_buffers.ffn_hidden,
+                    1,
+                );
+                self.forward_buffers.ffn_out.copy_from_slice(&tmp);
+            } else if use_cpu_q4k {
+                let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                matvec_q4k_into(
+                    &rw.w_down.data,
+                    &self.forward_buffers.ffn_hidden,
+                    rw.w_down.num_rows,
+                    config.intermediate_dim,
+                    &mut self.forward_buffers.ffn_out,
+                );
+            } else if use_cpu_q8 {
+                let rw = &self.raw_weights.as_ref().unwrap()[layer_idx];
+                matvec_q8_0_into(
+                    &rw.w_down.data,
+                    &self.forward_buffers.ffn_hidden,
+                    rw.w_down.num_rows,
+                    config.intermediate_dim,
+                    &mut self.forward_buffers.ffn_out,
+                );
+            } else {
+                matvec_into(
+                    layer.w_down.data(),
+                    &self.forward_buffers.ffn_hidden,
+                    dim,
+                    config.intermediate_dim,
+                    &mut self.forward_buffers.ffn_out,
+                );
+            }
+
+            if let Some(ref post_norm) = layer.post_ffn_norm {
+                rmsnorm_into(
+                    &self.forward_buffers.ffn_out,
+                    post_norm.data(),
+                    config.rms_norm_eps,
+                    &mut self.forward_buffers.attn_contrib,
+                );
+                let x_data = x.data_mut();
+                for i in 0..dim {
+                    x_data[i] += self.forward_buffers.attn_contrib[i];
+                }
+            } else {
+                let x_data = x.data_mut();
+                for i in 0..dim {
+                    x_data[i] += self.forward_buffers.ffn_out[i];
+                }
+            }
+        }
+
+        // Advance KV cache after processing the selected layers
+        self.kv_cache.advance();
+        if let Some(ref mut qkv) = self.quantized_kv_cache {
+            qkv.advance();
+        }
+
+        // Final RMSNorm + output projection
+        rmsnorm_into(
+            x.data(),
+            self.weights.output_norm.data(),
+            config.rms_norm_eps,
+            &mut self.forward_buffers.final_normed,
+        );
+
+        let vocab_size = config.vocab_size;
+        if let Some(ref row) = self.raw_output_weight {
+            if row.format == WeightFormat::Q4K && use_cpu_q4k {
+                matvec_q4k_into(
+                    &row.data,
+                    &self.forward_buffers.final_normed,
+                    row.num_rows,
+                    dim,
+                    &mut self.forward_buffers.logits,
+                );
+            } else if row.format == WeightFormat::Q8_0 && use_cpu_q8 {
+                quantize_input_q8_0_into(
+                    &self.forward_buffers.final_normed,
+                    &mut self.forward_buffers.output_q8,
+                );
+                matvec_q8_0_preq_into(
+                    &row.data,
+                    &self.forward_buffers.output_q8,
+                    row.num_rows,
+                    &mut self.forward_buffers.logits,
+                );
+            } else {
+                matvec_into(
+                    self.weights.output_weight.data(),
+                    &self.forward_buffers.final_normed,
+                    vocab_size,
+                    dim,
+                    &mut self.forward_buffers.logits,
+                );
+            }
+        } else {
+            matvec_into(
+                self.weights.output_weight.data(),
+                &self.forward_buffers.final_normed,
+                vocab_size,
+                dim,
+                &mut self.forward_buffers.logits,
+            );
+        }
+
+        if config.final_logit_softcap > 0.0 {
+            let cap = config.final_logit_softcap;
+            for l in &mut self.forward_buffers.logits {
+                *l = (*l / cap).tanh() * cap;
+            }
+        }
+
+        Tensor::from_vec(self.forward_buffers.logits.clone(), &[vocab_size]).unwrap()
+    }
+
+    /// Roll back the KV cache to `target_len` valid entries.
+    ///
+    /// Used by self-speculative decoding to undo draft-phase KV entries
+    /// before re-running the verify phase with the full model.
+    pub fn truncate_kv_cache(&mut self, target_len: usize) {
+        self.kv_cache.truncate_to(target_len);
+        if let Some(ref mut qkv) = self.quantized_kv_cache {
+            qkv.truncate_to(target_len);
+        }
+    }
 }
 
 /// RMSNorm: normalize and scale (CPU implementation).

--- a/flare-core/src/sampling.rs
+++ b/flare-core/src/sampling.rs
@@ -8,7 +8,7 @@
 /// use flare_core::sampling::SamplingParams;
 ///
 /// // Greedy (deterministic) decoding
-/// let greedy = SamplingParams { temperature: 0.0, top_p: 1.0, top_k: 0, repeat_penalty: 1.0, min_p: 0.0, speculative: true };
+/// let greedy = SamplingParams { temperature: 0.0, top_p: 1.0, top_k: 0, repeat_penalty: 1.0, min_p: 0.0, speculative: true, self_speculative: false, draft_skip: 2, draft_tokens: 4 };
 /// assert_eq!(greedy.temperature, 0.0);
 ///
 /// // Default creative sampling
@@ -34,6 +34,22 @@ pub struct SamplingParams {
     /// accepting the longest correct prefix for a 1.5-2x speedup on
     /// repetitive text.
     pub speculative: bool,
+    /// Enable self-speculative decoding via layer skipping (default: false).
+    ///
+    /// When enabled and using greedy decoding (temperature == 0.0), the
+    /// generator uses the model itself as a draft model by skipping layers.
+    /// Draft tokens are generated quickly with fewer layers, then verified
+    /// with the full model.  Achieves 1.3-1.8x speedup with zero extra
+    /// memory.
+    pub self_speculative: bool,
+    /// Layer skip stride for self-speculative decoding (default: 2).
+    ///
+    /// Controls which layers run during draft generation.  A value of 2
+    /// runs every other layer (0, 2, 4, ...), a value of 3 runs every
+    /// third layer, etc.
+    pub draft_skip: usize,
+    /// Maximum number of draft tokens per self-speculative step (default: 4).
+    pub draft_tokens: usize,
 }
 
 impl Default for SamplingParams {
@@ -45,6 +61,9 @@ impl Default for SamplingParams {
             repeat_penalty: 1.1,
             min_p: 0.0,
             speculative: true,
+            self_speculative: false,
+            draft_skip: 2,
+            draft_tokens: 4,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Implements self-speculative decoding that uses the model itself as its own draft model by skipping layers (e.g., running only every other layer), achieving 1.3-1.8x speedup with zero extra memory
- Draft tokens are generated quickly with the reduced-layer model, then verified one-by-one with the full model; the longest matching prefix is accepted
- Controlled via three new `SamplingParams` fields: `self_speculative` (enable/disable), `draft_skip` (layer stride, default 2), `draft_tokens` (max drafts per step, default 4)

## Changes

- `flare-core/src/model.rs`: Add `forward_skip_layers()` (runs specified layer indices only) and `truncate_kv_cache()` (rolls back draft KV entries)
- `flare-core/src/kv_cache.rs`: Add `truncate_to()` on both `KvCache` and `QuantizedKvCache`
- `flare-core/src/generate.rs`: Add `self_speculative_step()` with draft/verify loop, wire into `generate()`
- `flare-core/src/sampling.rs`: Add `self_speculative`, `draft_skip`, `draft_tokens` fields

## Test plan

- [x] `test_self_speculative_output_matches_greedy` - output is identical to greedy baseline (correctness)
- [x] `test_self_speculative_disabled_with_temperature` - disabled when temperature > 0
- [x] `test_self_speculative_disabled_by_flag` - disabled when flag is false
- [x] `test_self_speculative_stats_populated` - stats tracking works
- [x] `test_self_speculative_single_layer_model_noop` - graceful fallback for single-layer models
- [x] Full `cargo test --workspace` passes (all 581 tests)
- [x] `cargo build --release` succeeds

Closes #396