### PR TITLE
Add WebGPU subgroup operations for attention and matmul shaders

### DIFF
--- a/flare-gpu/shaders/attention_subgroup.wgsl
+++ b/flare-gpu/shaders/attention_subgroup.wgsl
@@ -1,0 +1,153 @@
+// Subgroup-optimized scaled dot-product attention for a single head.
+// Computes: softmax(Q @ K^T / sqrt(head_dim)) @ V
+//
+// Uses subgroup (warp-level) reductions for the softmax max-finding and
+// sum-of-exponentials phases, replacing the single-threaded bottleneck in the
+// baseline shader with fully parallel cross-lane operations.
+//
+// Requires the WebGPU `subgroups` feature (Chrome 144+, wgpu `SUBGROUP`).
+//
+// Bindings and params are identical to attention.wgsl so the two shaders are
+// interchangeable at runtime.
+
+enable subgroups;
+
+@group(0) @binding(0) var<storage, read> q: array<f32>;       // [head_dim]
+@group(0) @binding(1) var<storage, read> k_cache: array<f32>; // [seq_len, num_kv_heads, head_dim]
+@group(0) @binding(2) var<storage, read> v_cache: array<f32>; // [seq_len, num_kv_heads, head_dim]
+@group(0) @binding(3) var<storage, read_write> output: array<f32>; // [head_dim]
+
+struct Params {
+    seq_len: u32,
+    head_dim: u32,
+    scale: f32,
+    num_kv_heads: u32,
+    kv_head_idx: u32,
+}
+@group(0) @binding(4) var<uniform> params: Params;
+
+// Shared memory for attention scores (one per sequence position)
+var<workgroup> scores: array<f32, 4096>; // max supported seq_len
+
+// Cross-subgroup reduction scratch: one slot per subgroup in the workgroup.
+// 256 / min_subgroup_size(4) = 64 slots is the theoretical max needed.
+var<workgroup> sg_scratch: array<f32, 64>;
+
+// Final reduced values broadcast to all threads.
+var<workgroup> shared_max: f32;
+var<workgroup> shared_sum: f32;
+
+const WG_SIZE: u32 = 256u;
+
+@compute @workgroup_size(256)
+fn attention_scores(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(subgroup_invocation_id) sg_id: u32,
+    @builtin(subgroup_size) sg_size: u32,
+) {
+    let tid = lid.x;
+    let seq_len = params.seq_len;
+    let head_dim = params.head_dim;
+    let kv_stride = params.num_kv_heads * head_dim;
+    let kv_head_base = params.kv_head_idx * head_dim;
+
+    // The index of this thread's subgroup within the workgroup.
+    let sg_index = tid / sg_size;
+    // Number of active subgroups in the workgroup.
+    let num_subgroups = WG_SIZE / sg_size;
+
+    // -----------------------------------------------------------------------
+    // Phase 1: Compute Q @ K^T scores
+    // -----------------------------------------------------------------------
+    for (var t: u32 = tid; t < seq_len; t = t + WG_SIZE) {
+        var dot: f32 = 0.0;
+        let k_offset = t * kv_stride + kv_head_base;
+        for (var d: u32 = 0u; d < head_dim; d = d + 1u) {
+            dot = dot + q[d] * k_cache[k_offset + d];
+        }
+        scores[t] = dot * params.scale;
+    }
+
+    workgroupBarrier();
+
+    // -----------------------------------------------------------------------
+    // Phase 2: Find max for stable softmax using subgroup reductions
+    // -----------------------------------------------------------------------
+    var local_max: f32 = -1e30;
+    for (var t: u32 = tid; t < seq_len; t = t + WG_SIZE) {
+        local_max = max(local_max, scores[t]);
+    }
+
+    // Intra-subgroup max reduction.
+    local_max = subgroupMax(local_max);
+
+    // Cross-subgroup: each subgroup leader writes its max to shared memory.
+    if sg_id == 0u {
+        sg_scratch[sg_index] = local_max;
+    }
+    workgroupBarrier();
+
+    // First subgroup reduces across all subgroup maxes.
+    if sg_index == 0u {
+        var cross_val: f32 = -1e30;
+        if tid < num_subgroups {
+            cross_val = sg_scratch[tid];
+        }
+        cross_val = subgroupMax(cross_val);
+        if sg_id == 0u {
+            shared_max = cross_val;
+        }
+    }
+    workgroupBarrier();
+
+    // -----------------------------------------------------------------------
+    // Phase 3: Exp and sum using subgroup reductions
+    // -----------------------------------------------------------------------
+    var local_sum: f32 = 0.0;
+    for (var t: u32 = tid; t < seq_len; t = t + WG_SIZE) {
+        let e = exp(scores[t] - shared_max);
+        scores[t] = e;
+        local_sum = local_sum + e;
+    }
+
+    // Intra-subgroup sum reduction.
+    local_sum = subgroupAdd(local_sum);
+
+    // Cross-subgroup sum reduction.
+    if sg_id == 0u {
+        sg_scratch[sg_index] = local_sum;
+    }
+    workgroupBarrier();
+
+    if sg_index == 0u {
+        var cross_sum: f32 = 0.0;
+        if tid < num_subgroups {
+            cross_sum = sg_scratch[tid];
+        }
+        cross_sum = subgroupAdd(cross_sum);
+        if sg_id == 0u {
+            shared_sum = cross_sum;
+        }
+    }
+    workgroupBarrier();
+
+    // -----------------------------------------------------------------------
+    // Phase 4: Normalize scores
+    // -----------------------------------------------------------------------
+    for (var t: u32 = tid; t < seq_len; t = t + WG_SIZE) {
+        scores[t] = scores[t] / shared_sum;
+    }
+
+    workgroupBarrier();
+
+    // -----------------------------------------------------------------------
+    // Phase 5: Weighted sum of values -> output
+    // -----------------------------------------------------------------------
+    for (var d: u32 = tid; d < head_dim; d = d + WG_SIZE) {
+        var acc: f32 = 0.0;
+        for (var t: u32 = 0u; t < seq_len; t = t + 1u) {
+            acc = acc + scores[t] * v_cache[t * kv_stride + kv_head_base + d];
+        }
+        output[d] = acc;
+    }
+}

--- a/flare-gpu/shaders/batched_matvec_subgroup.wgsl
+++ b/flare-gpu/shaders/batched_matvec_subgroup.wgsl
@@ -1,0 +1,80 @@
+// Subgroup-optimized batched matrix-vector multiply.
+//
+// Computes: output[b * out_rows + i] = Sum_j weight[i * in_cols + j] * input[b * in_cols + j]
+//
+// Uses subgroupAdd for the dot-product reduction, replacing the explicit
+// tree reduction with barrier-free warp-level operations.
+//
+// Requires the WebGPU `subgroups` feature (Chrome 144+, wgpu `SUBGROUP`).
+//
+// Bindings and params are identical to batched_matvec.wgsl.
+
+enable subgroups;
+
+@group(0) @binding(0) var<storage, read> weight: array<f32>;
+@group(0) @binding(1) var<storage, read> inp: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+    out_rows: u32,
+    in_cols:  u32,
+    batch:    u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+// Cross-subgroup reduction scratch.  64 / min_subgroup_size(4) = 16 max.
+var<workgroup> sg_scratch: array<f32, 16>;
+
+@compute @workgroup_size(64)
+fn batched_matvec(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id)        wid: vec3<u32>,
+    @builtin(subgroup_invocation_id) sg_id: u32,
+    @builtin(subgroup_size) sg_size: u32,
+) {
+    let row       = wid.x;
+    let batch_idx = wid.y;
+
+    if row >= params.out_rows || batch_idx >= params.batch {
+        return;
+    }
+
+    let tid = lid.x;
+    var acc: f32 = 0.0;
+
+    let weight_base = row * params.in_cols;
+    let input_base  = batch_idx * params.in_cols;
+
+    // Each thread strides across in_cols with a step of 64.
+    var j: u32 = tid;
+    loop {
+        if j >= params.in_cols {
+            break;
+        }
+        acc = acc + weight[weight_base + j] * inp[input_base + j];
+        j = j + 64u;
+    }
+
+    // Intra-subgroup reduction (barrier-free).
+    acc = subgroupAdd(acc);
+
+    // Cross-subgroup reduction via shared memory.
+    let sg_index = tid / sg_size;
+    let num_subgroups = 64u / sg_size;
+
+    if sg_id == 0u {
+        sg_scratch[sg_index] = acc;
+    }
+    workgroupBarrier();
+
+    if sg_index == 0u {
+        var cross_sum: f32 = 0.0;
+        if tid < num_subgroups {
+            cross_sum = sg_scratch[tid];
+        }
+        cross_sum = subgroupAdd(cross_sum);
+        if sg_id == 0u {
+            output[batch_idx * params.out_rows + row] = cross_sum;
+        }
+    }
+}

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -55,7 +55,9 @@ const DEQUANT_Q5K_SHADER: &str = include_str!("../shaders/dequant_q5k.wgsl");
 const DEQUANT_Q6K_SHADER: &str = include_str!("../shaders/dequant_q6k.wgsl");
 const PREFILL_ATTENTION_SHADER: &str = include_str!("../shaders/prefill_attention.wgsl");
 const DEQUANT_Q3K_SHADER: &str = include_str!("../shaders/dequant_q3k.wgsl");
+const ATTENTION_SUBGROUP_SHADER: &str = include_str!("../shaders/attention_subgroup.wgsl");
 const BATCHED_MATVEC_SHADER: &str = include_str!("../shaders/batched_matvec.wgsl");
+const BATCHED_MATVEC_SUBGROUP_SHADER: &str = include_str!("../shaders/batched_matvec_subgroup.wgsl");
 const BATCHED_RMSNORM_SHADER: &str = include_str!("../shaders/batched_rmsnorm.wgsl");
 const BATCHED_ROPE_SHADER: &str = include_str!("../shaders/batched_rope.wgsl");
 const ADD_RESIDUAL_SHADER: &str = include_str!("../shaders/add_residual.wgsl");
@@ -177,6 +179,9 @@ pub struct WebGpuBackend {
     /// Pre-allocated intermediate buffers for `forward_single_token_gpu`.
     /// Allocated once when `upload_weights_to_gpu` is called.
     gpu_forward_buffers: Mutex<Option<GpuForwardBuffers>>,
+    /// Whether the GPU adapter supports the `subgroups` feature for
+    /// warp-level SIMT reductions (subgroupAdd, subgroupMax, etc.).
+    has_subgroups: bool,
 }
 
 impl WebGpuBackend {
@@ -215,15 +220,22 @@ impl WebGpuBackend {
             .await
             .ok_or(GpuError::NoAdapter)?;
 
-        // Enable PIPELINE_CACHE if the backend supports it (Vulkan).
-        // On WebGPU / Metal / DX12 the feature flag is absent; requesting an
-        // absent feature is an error, so we check first.
+        // Enable optional features if the backend supports them.
+        // Requesting an absent feature is an error, so we check first.
         let adapter_features = adapter.features();
-        let extra_features = if adapter_features.contains(wgpu::Features::PIPELINE_CACHE) {
-            wgpu::Features::PIPELINE_CACHE
-        } else {
-            wgpu::Features::empty()
-        };
+        let mut extra_features = wgpu::Features::empty();
+
+        if adapter_features.contains(wgpu::Features::PIPELINE_CACHE) {
+            extra_features |= wgpu::Features::PIPELINE_CACHE;
+        }
+
+        // Enable subgroup operations for warp-level reductions in attention
+        // and matmul shaders.  Available on Vulkan, Metal, and Chrome 144+.
+        let has_subgroups = adapter_features.contains(wgpu::Features::SUBGROUP);
+        if has_subgroups {
+            extra_features |= wgpu::Features::SUBGROUP;
+            log::info!("flare-gpu: subgroup operations enabled");
+        }
 
         let (device, queue) = adapter
             .request_device(
@@ -258,6 +270,7 @@ impl WebGpuBackend {
             gpu_kv_cache: Mutex::new(None),
             gpu_weights: Mutex::new(None),
             gpu_forward_buffers: Mutex::new(None),
+            has_subgroups,
         })
     }
 
@@ -389,6 +402,26 @@ impl WebGpuBackend {
             storage_rw_entry(3),
             uniform_entry(4),
         ]
+    }
+
+    /// Returns the attention shader source and pipeline cache key, selecting the
+    /// subgroup-optimized variant when the GPU supports it.
+    fn attention_shader_pair(&self) -> (&'static str, &'static str) {
+        if self.has_subgroups {
+            ("attention_scores_subgroup", ATTENTION_SUBGROUP_SHADER)
+        } else {
+            ("attention_scores", ATTENTION_SHADER)
+        }
+    }
+
+    /// Returns the batched matvec shader source and pipeline cache key, selecting
+    /// the subgroup-optimized variant when the GPU supports it.
+    fn batched_matvec_shader_pair(&self) -> (&'static str, &'static str) {
+        if self.has_subgroups {
+            ("batched_matvec_subgroup", BATCHED_MATVEC_SUBGROUP_SHADER)
+        } else {
+            ("batched_matvec", BATCHED_MATVEC_SHADER)
+        }
     }
 
     /// 5-binding layout for fused kernels with 3 read-only inputs, 1 read-write output, 1 uniform.
@@ -1864,10 +1897,11 @@ impl WebGpuBackend {
                 .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
 
         let layout_entries = Self::standard_layout();
+        let (mv_name, mv_shader) = self.batched_matvec_shader_pair();
         let result = self.cache.with_pipeline(
             &self.device,
-            "batched_matvec",
-            BATCHED_MATVEC_SHADER,
+            mv_name,
+            mv_shader,
             "batched_matvec",
             &layout_entries,
             |cached| {
@@ -2973,10 +3007,11 @@ impl WebGpuBackend {
         let out_head_size = (head_dim * 4) as u64;
 
         let layout_entries = Self::attention_layout();
+        let (attn_name, attn_shader) = self.attention_shader_pair();
         self.cache.with_pipeline(
             &self.device,
-            "attention_scores",
-            ATTENTION_SHADER,
+            attn_name,
+            attn_shader,
             "attention_scores",
             &layout_entries,
             |cached| {
@@ -3245,10 +3280,11 @@ impl WebGpuBackend {
         let out_head_size = (head_dim * 4) as u64;
 
         let layout_entries = Self::attention_layout();
+        let (attn_name, attn_shader) = self.attention_shader_pair();
         self.cache.with_pipeline(
             &self.device,
-            "attention_scores",
-            ATTENTION_SHADER,
+            attn_name,
+            attn_shader,
             "attention_scores",
             &layout_entries,
             |cached| {
@@ -3749,10 +3785,11 @@ impl WebGpuBackend {
                 let logit_byte_size = (shard_rows * 4) as u64;
 
                 let layout_entries = Self::standard_layout();
+                let (mv_name, mv_shader) = self.batched_matvec_shader_pair();
                 self.cache.with_pipeline(
                     &self.device,
-                    "batched_matvec",
-                    BATCHED_MATVEC_SHADER,
+                    mv_name,
+                    mv_shader,
                     "batched_matvec",
                     &layout_entries,
                     |cached| {
@@ -4175,6 +4212,7 @@ impl ComputeBackend for WebGpuBackend {
         let scale = 1.0_f32 / (head_dim as f32).sqrt();
 
         let layout_entries = Self::attention_layout();
+        let (attn_name, attn_shader) = self.attention_shader_pair();
 
         for h in 0..num_heads {
             let kv_head = h / heads_per_kv;
@@ -4220,8 +4258,8 @@ impl ComputeBackend for WebGpuBackend {
 
             let head_output = self.cache.with_pipeline(
                 &self.device,
-                "attention_scores",
-                ATTENTION_SHADER,
+                attn_name,
+                attn_shader,
                 "attention_scores",
                 &layout_entries,
                 |cached| {
@@ -4339,6 +4377,7 @@ impl ComputeBackend for WebGpuBackend {
         let scale = 1.0_f32 / (head_dim as f32).sqrt();
 
         let layout_entries = Self::attention_layout();
+        let (attn_name, attn_shader) = self.attention_shader_pair();
 
         for h in 0..num_heads {
             let kv_head = h / heads_per_kv;
@@ -4369,8 +4408,8 @@ impl ComputeBackend for WebGpuBackend {
 
             let head_output = self.cache.with_pipeline(
                 &self.device,
-                "attention_scores",
-                ATTENTION_SHADER,
+                attn_name,
+                attn_shader,
                 "attention_scores",
                 &layout_entries,
                 |cached| {


### PR DESCRIPTION
## Summary

- Adds subgroup (warp-level) feature detection to `WebGpuBackend::new()` — requests `wgpu::Features::SUBGROUP` when the adapter supports it (Vulkan, Metal, Chrome 144+)
- Introduces `attention_subgroup.wgsl`: replaces the single-threaded softmax max/sum phases with `subgroupMax` + `subgroupAdd` cross-lane reductions, parallelizing the bottleneck across all threads
- Introduces `batched_matvec_subgroup.wgsl`: replaces the 6-stage tree reduction (with 5 `workgroupBarrier` calls) with a single `subgroupAdd` + lightweight cross-subgroup shared-memory reduction
- Runtime dispatch automatically selects the subgroup-optimized shaders when supported, falling back to the original shaders otherwise — no behavioral change on unsupported hardware

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test --workspace` passes
- [ ] Run `e2e_bench` on a GPU with subgroup support (Vulkan/Metal) and verify correctness matches baseline
- [ ] Run `e2e_bench` on WebGPU without subgroup support and verify fallback works correctly
- [ ] Compare tok/s with and without subgroups on supported hardware

Closes #386