### PR TITLE
Add WebNN detection foundation for NPU acceleration

### DIFF
--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -689,7 +689,7 @@
   <script type="module">
     import init, {
       FlareEngine, FlareProgressiveLoader, FlareTokenizer,
-      webgpu_available, init_thread_pool,
+      webgpu_available, supports_webnn, init_thread_pool,
       is_model_cached, cache_model, load_cached_model,
       delete_cached_model, list_cached_models, storage_estimate
     } from '../pkg/flare_web.js';
@@ -1245,7 +1245,8 @@
         } catch (_) { opfsAvailable = false; }
 
         $status.textContent = 'WASM module loaded. Load a model to begin.';
-        $env.textContent = `WebGPU: ${webgpu_available() ? 'available' : 'not available'}${threadsInfo} | OPFS: ${opfsAvailable ? 'yes' : 'no'}`;
+        const webnnAvailable = supports_webnn();
+        $env.textContent = `WebGPU: ${webgpu_available() ? 'available' : 'not available'} | WebNN: ${webnnAvailable ? 'available' : 'not available'}${threadsInfo} | OPFS: ${opfsAvailable ? 'yes' : 'no'}`;
         [$fileInput, $urlInput, $urlLoad, $tokFileIn, $tokUrlIn, $tokUrlLoad]
           .forEach(el => { el.disabled = false; });
 

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -72,6 +72,18 @@ pub fn webgpu_available() -> bool {
         .unwrap_or(false)
 }
 
+/// Check if WebNN is available in the current browser.
+///
+/// WebNN (`navigator.ml`) exposes neural-network acceleration through
+/// platform NPUs/DSPs. This is a foundation check so JS code can decide
+/// whether to build a WebNN graph from exported weights.
+#[wasm_bindgen]
+pub fn supports_webnn() -> bool {
+    web_sys::window()
+        .and_then(|w| js_sys::Reflect::get(&w.navigator(), &"ml".into()).ok())
+        .is_some_and(|ml| !ml.is_undefined() && !ml.is_null())
+}
+
 /// Check if this WASM build was compiled with relaxed SIMD support.
 ///
 /// Relaxed SIMD provides hardware-specific faster operations like fused


### PR DESCRIPTION
## Summary
- Adds `supports_webnn()` wasm-bindgen export that probes `navigator.ml` so JS code can decide whether to build a WebNN graph from exported weights.
- Surfaces WebNN availability in the browser demo's environment line alongside WebGPU and OPFS.
- The existing `num_layers()` / `hidden_dim()` / `vocab_size()` getters on `FlareEngine` already cover the weight-export side and require no changes.

WebNN is browser-only, so this PR intentionally lands only the detection foundation; graph construction stays in JS land.

Closes #388

## Test plan
- [x] `cargo check -p flarellm-web` (native) passes
- [ ] Manually verify in a WebNN-capable browser that the demo reports `WebNN: available`
- [ ] Manually verify in a non-WebNN browser that the demo reports `WebNN: not available`