### PR TITLE
Add P2P collaborative inference primitives (#389)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,30 @@ while (!engine.stream_done()) {
 }
 ```
 
+### P2P collaborative inference primitives
+
+For experiments in splitting inference across multiple peers (e.g. a
+WebRTC mesh), `FlareEngine` exposes the "head" and "tail" of a forward
+pass. A coordinator peer can embed a token, hand the hidden state off
+through a chain of peers running some subset of transformer layers, and
+then run the final RMSNorm + output projection locally to recover
+logits:
+
+```javascript
+// Coordinator peer: embed the next input token.
+const hidden = engine.embed_token(tokenId); // Float32Array, hidden_dim
+
+// ... ship `hidden` through the peer mesh; each peer runs some layers
+// on its local `FlareEngine` and forwards the updated hidden state ...
+
+// Coordinator peer: project the final hidden state to logits.
+const logits = engine.output_projection(finalHidden); // Float32Array, vocab_size
+```
+
+The full WebRTC orchestration layer lives in JavaScript; these two
+primitives plus the existing `forward*` methods are the minimum Rust
+surface needed to start P2P experimentation ([#389](../../issues/389)).
+
 ## Architecture
 
 ```

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -747,6 +747,44 @@ pub struct Model {
 }
 
 impl Model {
+    /// Look up the token embedding vector for a given token ID.
+    ///
+    /// Returns a copy of the row `token_id` of the token embedding table,
+    /// of length `config.hidden_dim`. Exposed as a primitive for P2P /
+    /// collaborative inference scenarios where one peer runs the embedding
+    /// step and streams the hidden state to downstream peers.
+    pub fn embed_token(&self, token_id: u32) -> Vec<f32> {
+        let dim = self.config.hidden_dim;
+        let offset = token_id as usize * dim;
+        let embed = self.weights.token_embedding.data();
+        embed[offset..offset + dim].to_vec()
+    }
+
+    /// Apply the final RMSNorm + output weight matvec to compute logits
+    /// from a post-last-layer hidden state.
+    ///
+    /// This is the inverse counterpart to [`Model::embed_token`]: it is the
+    /// tail of a forward pass. It is exposed as a primitive for P2P /
+    /// collaborative inference: a downstream peer can hand back the final
+    /// hidden state and an orchestrator can run this step to get logits.
+    ///
+    /// Note: this uses the dequantised f32 `output_weight` path and does
+    /// not apply Gemma 2's final logit soft-cap. P2P callers that need the
+    /// soft-cap should apply it themselves on the returned logits.
+    pub fn output_projection(&self, hidden: &[f32]) -> Vec<f32> {
+        let normed = self.backend.rmsnorm_vec(
+            hidden,
+            self.weights.output_norm.data(),
+            self.config.rms_norm_eps,
+        );
+        matvec(
+            self.weights.output_weight.data(),
+            &normed,
+            self.config.vocab_size,
+            self.config.hidden_dim,
+        )
+    }
+
     pub fn new(config: ModelConfig, weights: ModelWeights) -> Self {
         let kv_cache = KvCache::new(
             config.num_layers,

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -2049,6 +2049,41 @@ impl FlareEngine {
             .map_err(|e| JsError::new(&format!("LoRA merge error: {e}")))?;
         Ok(())
     }
+
+    // --- P2P / collaborative inference primitives (issue #389) ---
+    //
+    // These primitives expose the "head" and "tail" of a forward pass so
+    // that a JavaScript orchestrator (e.g. a WebRTC mesh) can split
+    // inference across multiple peers. A coordinator peer calls
+    // `embed_token` to get the initial hidden state, ships it through a
+    // chain of peers that each run some subset of transformer layers, and
+    // finally calls `output_projection` on the returned hidden state to
+    // obtain logits.
+    //
+    // Note: processing an arbitrary individual transformer layer is not
+    // exposed here because the KV cache state for that layer lives inside
+    // the owning `Model`. Full P2P layer sharding will require additional
+    // KV-cache plumbing; these two primitives are sufficient to begin
+    // P2P experimentation on top of the existing forward methods.
+
+    /// Look up the token embedding row for `token_id` as a flat `Float32Array`.
+    ///
+    /// The length of the returned vector is `hidden_dim`. See also
+    /// [`FlareEngine::output_projection`] for the inverse tail step.
+    #[wasm_bindgen]
+    pub fn embed_token(&self, token_id: u32) -> Vec<f32> {
+        self.model.embed_token(token_id)
+    }
+
+    /// Apply final RMSNorm + output projection to a hidden state and
+    /// return logits over the vocabulary.
+    ///
+    /// `hidden` must have length `hidden_dim`. The returned vector has
+    /// length `vocab_size`.
+    #[wasm_bindgen]
+    pub fn output_projection(&self, hidden: Vec<f32>) -> Vec<f32> {
+        self.model.output_projection(&hidden)
+    }
 }
 
 /// Progressive loader that fetches a GGUF model from a URL with streaming


### PR DESCRIPTION
## Summary
- Expose `embed_token` and `output_projection` on `Model` and `FlareEngine` as Rust/WASM primitives for P2P / collaborative inference.
- A JS orchestrator (e.g. WebRTC mesh) can now embed a token, stream the hidden state through a chain of peers running subsets of transformer layers, and project the final hidden state to logits locally.
- Adds a short P2P primitives section to the main README showing the JS flow.

Per-layer `forward_layer()` is intentionally deferred because the KV cache state for that layer lives inside the owning `Model`; these two primitives plus the existing `forward*` methods are the minimum surface needed to start P2P experimentation.

Closes #389.

## Test plan
- [x] cargo check --workspace passes
- [ ] wasm-pack build flare-web --target web
- [ ] JS smoke test: embed_token then output_projection on a fresh hidden state matches the embedding-only path