### PR TITLE
Add WebTransport detection and progressive loader (closes #397)

### DIFF
--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -689,7 +689,7 @@
   <script type="module">
     import init, {
       FlareEngine, FlareProgressiveLoader, FlareTokenizer,
-      webgpu_available, supports_webnn, init_thread_pool,
+      webgpu_available, supports_webnn, supports_webtransport, init_thread_pool,
       is_model_cached, cache_model, load_cached_model,
       delete_cached_model, list_cached_models, storage_estimate
     } from '../pkg/flare_web.js';
@@ -1246,7 +1246,8 @@
 
         $status.textContent = 'WASM module loaded. Load a model to begin.';
         const webnnAvailable = supports_webnn();
-        $env.textContent = `WebGPU: ${webgpu_available() ? 'available' : 'not available'} | WebNN: ${webnnAvailable ? 'available' : 'not available'}${threadsInfo} | OPFS: ${opfsAvailable ? 'yes' : 'no'}`;
+        const webtransportAvailable = supports_webtransport();
+        $env.textContent = `WebGPU: ${webgpu_available() ? 'available' : 'not available'} | WebNN: ${webnnAvailable ? 'available' : 'not available'} | WebTransport: ${webtransportAvailable ? 'available' : 'not available'}${threadsInfo} | OPFS: ${opfsAvailable ? 'yes' : 'no'}`;
         [$fileInput, $urlInput, $urlLoad, $tokFileIn, $tokUrlIn, $tokUrlLoad]
           .forEach(el => { el.disabled = false; });
 

--- a/flare-web/js/webtransport-loader.js
+++ b/flare-web/js/webtransport-loader.js
@@ -1,0 +1,126 @@
+/**
+ * Progressive model loader using WebTransport for parallel stream downloads.
+ *
+ * WebTransport is built on HTTP/3 QUIC and allows multiple bidirectional
+ * streams over a single connection, avoiding the head-of-line blocking that
+ * plagues HTTP/1.1/2 range requests when downloading large model files.
+ *
+ * NOTE ON SERVER SUPPORT:
+ *   For parallel stream downloads to actually happen, the server must:
+ *     1. Speak HTTP/3 and expose a WebTransport endpoint at the model URL.
+ *     2. Accept a per-stream protocol where the client sends a byte range
+ *        (e.g. as a small framed message) and the server streams those bytes
+ *        back on the same bidirectional stream.
+ *   No such server is shipped with Flare today. Until one exists, this loader
+ *   transparently falls back to `fetch()` with streaming, which still gives
+ *   progressive load + progress callbacks over HTTP/1.1 or HTTP/2.
+ *
+ * Usage:
+ *   const loader = new WebTransportLoader('https://example.com/model.gguf', 4);
+ *   const bytes = await loader.load((loaded, total) => {
+ *     console.log(`${loaded} / ${total}`);
+ *   });
+ */
+export class WebTransportLoader {
+    /**
+     * @param {string} url   Absolute URL to the model file.
+     * @param {number} numStreams  Number of parallel streams to attempt when
+     *                             WebTransport + a cooperating server are
+     *                             available. Ignored by the fetch fallback.
+     */
+    constructor(url, numStreams = 4) {
+        this.url = url;
+        this.numStreams = numStreams;
+    }
+
+    /**
+     * Load the model bytes, invoking `onProgress(loaded, total)` as data
+     * arrives. Returns a Uint8Array containing the full file.
+     *
+     * @param {(loaded: number, total: number) => void} [onProgress]
+     * @returns {Promise<Uint8Array>}
+     */
+    async load(onProgress) {
+        if (typeof WebTransport === 'undefined') {
+            // Browser has no WebTransport at all — use fetch streaming.
+            return this.loadViaFetch(onProgress);
+        }
+
+        try {
+            const wt = new WebTransport(this.url);
+            await wt.ready;
+
+            // Server-side protocol for parallel range streaming is not yet
+            // standardized in this project. Once a Flare WebTransport server
+            // exists, this block should:
+            //   1. HEAD the resource (or open a control stream) to learn the
+            //      total byte length.
+            //   2. Open `this.numStreams` bidirectional streams via
+            //      `wt.createBidirectionalStream()`.
+            //   3. Send a framed { offset, length } request on each stream.
+            //   4. Reassemble the chunks in offset order as they arrive,
+            //      invoking `onProgress` on every chunk.
+            //
+            // Until that server exists, we close the WebTransport session and
+            // fall back to fetch — the browser has already done a QUIC
+            // handshake, which is wasted work but harmless. We log so that
+            // anyone instrumenting this path can see it.
+            console.info(
+                'WebTransport session opened, but no parallel-range server ' +
+                'protocol is implemented yet; falling back to fetch().'
+            );
+            await wt.close();
+        } catch (e) {
+            console.warn('WebTransport failed, falling back to fetch:', e);
+        }
+
+        return this.loadViaFetch(onProgress);
+    }
+
+    /**
+     * Fallback path: stream the body via `fetch()` and report progress from
+     * the Content-Length header. Works on any HTTP/1.1+ origin.
+     *
+     * @param {(loaded: number, total: number) => void} [onProgress]
+     * @returns {Promise<Uint8Array>}
+     */
+    async loadViaFetch(onProgress) {
+        const response = await fetch(this.url);
+        if (!response.ok) {
+            throw new Error(
+                `Failed to fetch model: ${response.status} ${response.statusText}`
+            );
+        }
+        if (!response.body) {
+            // Non-streaming environment (very old browser or CORS-restricted).
+            const buf = new Uint8Array(await response.arrayBuffer());
+            if (onProgress) onProgress(buf.length, buf.length);
+            return buf;
+        }
+
+        const contentLength = parseInt(
+            response.headers.get('content-length') || '0',
+            10
+        );
+        const reader = response.body.getReader();
+        const chunks = [];
+        let loaded = 0;
+
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            chunks.push(value);
+            loaded += value.length;
+            if (onProgress) onProgress(loaded, contentLength);
+        }
+
+        // Concatenate chunks into a single contiguous Uint8Array.
+        const result = new Uint8Array(loaded);
+        let offset = 0;
+        for (const chunk of chunks) {
+            result.set(chunk, offset);
+            offset += chunk.length;
+        }
+        return result;
+    }
+}

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -84,6 +84,25 @@ pub fn supports_webnn() -> bool {
         .is_some_and(|ml| !ml.is_undefined() && !ml.is_null())
 }
 
+/// Check if WebTransport is available in the current browser.
+///
+/// WebTransport (`window.WebTransport`) is a modern transport API built on
+/// HTTP/3 QUIC streams. It allows opening multiple parallel bidirectional
+/// streams to the same origin with lower head-of-line blocking than fetch().
+/// Useful for progressive model loading where different byte ranges of the
+/// GGUF file can be downloaded concurrently.
+///
+/// Note: actually using WebTransport for parallel range downloads requires
+/// server-side support (HTTP/3 endpoint that accepts byte-range requests
+/// on streams). This check only reports browser capability — the JS loader
+/// will fall back to `fetch()` when the server does not cooperate.
+#[wasm_bindgen]
+pub fn supports_webtransport() -> bool {
+    web_sys::window()
+        .and_then(|w| js_sys::Reflect::get(&w, &"WebTransport".into()).ok())
+        .is_some_and(|wt| !wt.is_undefined() && !wt.is_null())
+}
+
 /// Check if this WASM build was compiled with relaxed SIMD support.
 ///
 /// Relaxed SIMD provides hardware-specific faster operations like fused


### PR DESCRIPTION
## Summary
- Add `supports_webtransport()` wasm_bindgen export that probes `window.WebTransport` at runtime.
- Add `flare-web/js/webtransport-loader.js` with a `WebTransportLoader` class that opens a WebTransport session when available and transparently falls back to streaming `fetch()` (with progress callback) otherwise.
- Surface WebTransport availability in the demo environment badge next to WebGPU / WebNN.

WebTransport is a browser-only JS API with no direct Rust/WASM bindings, and parallel-range streaming requires a cooperating HTTP/3 server that Flare does not yet ship. This PR therefore lands the detection plumbing and the fetch-based fallback so that higher-level loaders can start calling `WebTransportLoader` today and pick up parallel streams for free once a server is available. The JS module documents the server-side protocol requirements inline.

Closes #397.

## Test plan
- [x] `cargo build -p flarellm-web --target wasm32-unknown-unknown`
- [x] `cargo check -p flarellm-web` (native)
- [ ] Manually load the demo in a WebTransport-capable browser and confirm the badge reports `WebTransport: available`
- [ ] Manually load the demo in a browser without WebTransport and confirm the fetch fallback path still streams the model with progress updates