### PR TITLE
Add continuous benchmark CI workflow for PRs

### DIFF
--- a/.github/scripts/check_perf_regression.py
+++ b/.github/scripts/check_perf_regression.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Compare e2e_bench JSON output against benchmarks/baseline.json.
+
+Usage:
+    check_perf_regression.py <current.json> <baseline.json>
+
+The current file is the raw output of `cargo run --example e2e_bench -- --json`
+(a single JSON object). The baseline file groups expected tok/s numbers by a
+model id, e.g. `smollm2-135m-q8_0`.
+
+Supported baseline metrics:
+    decode_16      — decode tok/s for the generation run with gen_count == 16
+    sustained_512  — sustained decode tok/s over 512 tokens
+    prefill_peak   — highest prefill tok/s across all generation runs
+
+For now this script is informational: it prints a human-readable comparison
+and always exits 0. Flip HARD_FAIL to True once we have a stable baseline on
+the CI runner.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+HARD_FAIL = False  # flip to True when the baseline is trustworthy on CI
+REGRESSION_THRESHOLD = 0.95  # >5% slower than baseline is a regression
+
+
+def extract_metrics(current: dict[str, Any]) -> dict[str, float]:
+    """Project the raw e2e_bench JSON onto the baseline metric keys."""
+    metrics: dict[str, float] = {}
+
+    gen = current.get("generation") or []
+    if isinstance(gen, list):
+        for entry in gen:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("gen_count") == 16:
+                decode = entry.get("decode_tok_s")
+                if isinstance(decode, (int, float)):
+                    metrics["decode_16"] = float(decode)
+                break
+
+        prefill_values = [
+            float(e["prefill_tok_s"])
+            for e in gen
+            if isinstance(e, dict) and isinstance(e.get("prefill_tok_s"), (int, float))
+        ]
+        if prefill_values:
+            metrics["prefill_peak"] = max(prefill_values)
+
+    sustained = current.get("sustained_512_tok_s")
+    if isinstance(sustained, (int, float)):
+        metrics["sustained_512"] = float(sustained)
+
+    return metrics
+
+
+def model_id_from_current(current: dict[str, Any]) -> str:
+    """Pick a model id key that matches the baseline file.
+
+    The e2e_bench `model` field is a free-form string like
+    `SmolLM2-135M Q8_0` — normalize it to `smollm2-135m-q8_0`.
+    """
+    raw = str(current.get("model") or "").strip().lower()
+    if not raw:
+        return ""
+    return (
+        raw.replace(" ", "-")
+        .replace("_", "-")
+        .replace("--", "-")
+    )
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <current.json> <baseline.json>", file=sys.stderr)
+        return 2
+
+    current_file, baseline_file = sys.argv[1], sys.argv[2]
+
+    try:
+        with open(current_file) as f:
+            current = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"failed to read current bench JSON {current_file}: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        with open(baseline_file) as f:
+            baseline = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"failed to read baseline JSON {baseline_file}: {e}", file=sys.stderr)
+        return 2
+
+    metrics = extract_metrics(current)
+    normalized_id = model_id_from_current(current)
+
+    # Pick the baseline entry that most closely matches the current model id.
+    # Fall back to the first non-underscore-prefixed key if we can't tell.
+    model_keys = [k for k in baseline.keys() if not k.startswith("_")]
+    if not model_keys:
+        print("baseline.json has no model entries — nothing to compare.")
+        return 0
+
+    chosen = None
+    for key in model_keys:
+        if key.lower() == normalized_id or key.lower() in normalized_id:
+            chosen = key
+            break
+    if chosen is None:
+        chosen = model_keys[0]
+
+    expected = baseline.get(chosen, {})
+    if not isinstance(expected, dict):
+        print(f"baseline entry for {chosen} is not an object — skipping.")
+        return 0
+
+    print(f"Model: {chosen}")
+    print(f"Current metrics: {metrics}")
+    print("")
+    print("| metric | current | baseline | ratio | status |")
+    print("|---|---:|---:|---:|---|")
+
+    regressions: list[str] = []
+    for metric, baseline_val in expected.items():
+        if not isinstance(baseline_val, (int, float)):
+            continue
+        current_val = metrics.get(metric)
+        if current_val is None:
+            print(f"| {metric} | — | {baseline_val} | — | MISSING |")
+            continue
+
+        ratio = current_val / baseline_val if baseline_val else float("inf")
+        status = "ok"
+        if current_val < baseline_val * REGRESSION_THRESHOLD:
+            status = "REGRESSION"
+            regressions.append(
+                f"{chosen}/{metric}: {current_val:.1f} < "
+                f"{baseline_val * REGRESSION_THRESHOLD:.1f} "
+                f"(baseline {baseline_val})"
+            )
+        print(
+            f"| {metric} | {current_val:.1f} | {baseline_val} | "
+            f"{ratio:.2f}x | {status} |"
+        )
+
+    print("")
+    if regressions:
+        print("Performance regressions detected:")
+        for r in regressions:
+            print(f"  - {r}")
+        if HARD_FAIL:
+            return 1
+        print("")
+        print("(informational only — not failing CI until baseline is stable)")
+    else:
+        print("No performance regressions detected.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -1,0 +1,160 @@
+name: Benchmark (PR)
+
+# Continuous benchmark for pull requests. Runs the full e2e benchmark against
+# the baseline model and posts results as a PR comment.
+#
+# Currently informational only — results are compared against a baseline file
+# but regressions will NOT fail the CI. Once we have a stable baseline on the
+# CI runner hardware, the check script can be flipped to fail on regression.
+#
+# The existing workflow in benchmark.yml handles manual/nightly runs.
+
+on:
+  pull_request:
+    paths:
+      - 'flare-core/**'
+      - 'flare-loader/**'
+      - 'flare-simd/**'
+      - 'flare-server/examples/e2e_bench.rs'
+      - 'benchmarks/**'
+      - '.github/workflows/benchmark-pr.yml'
+      - '.github/scripts/check_perf_regression.py'
+
+# Only keep the latest run per PR to avoid wasting runner minutes on rapid
+# pushes.
+concurrency:
+  group: benchmark-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: E2E benchmark — SmolLM2-135M Q8_0
+    runs-on: macos-14
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: bench-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            bench-${{ runner.os }}-
+
+      - name: Download baseline model
+        run: bash scripts/download_baseline_model.sh
+
+      - name: Build benchmark
+        run: cargo build --release -p flarellm-server --example e2e_bench
+
+      - name: Run benchmark
+        id: bench
+        run: |
+          cargo run --release -p flarellm-server --example e2e_bench -- --json > bench-result.json
+          echo "--- bench-result.json ---"
+          cat bench-result.json
+
+      - name: Compare against baseline (informational)
+        id: compare
+        continue-on-error: true
+        run: |
+          python3 .github/scripts/check_perf_regression.py \
+            bench-result.json \
+            benchmarks/baseline.json \
+            > bench-compare.txt
+          echo "--- bench-compare.txt ---"
+          cat bench-compare.txt
+
+      - name: Upload benchmark JSON
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-${{ github.event.pull_request.number }}-${{ github.sha }}
+          path: |
+            bench-result.json
+            bench-compare.txt
+          retention-days: 30
+
+      - name: Post results as PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const result = JSON.parse(fs.readFileSync('bench-result.json', 'utf8'));
+            let compare = '';
+            try {
+              compare = fs.readFileSync('bench-compare.txt', 'utf8');
+            } catch (e) {
+              compare = '(baseline comparison unavailable)';
+            }
+
+            const gen = Array.isArray(result.generation) ? result.generation : [];
+            const rows = gen.map(g =>
+              `| ${g.gen_count} | ${Number(g.prefill_tok_s).toFixed(1)} | ${Number(g.decode_tok_s).toFixed(1)} |`
+            ).join('\n');
+
+            const sustained = Number(result.sustained_512_tok_s || 0).toFixed(1);
+            const loadSecs = Number(result.load_secs || 0).toFixed(2);
+
+            const body = [
+              '## Benchmark results',
+              '',
+              '_Informational only — regressions do not fail CI yet._',
+              '',
+              `- **Model**: \`${result.model || 'unknown'}\``,
+              `- **Backend**: \`${result.backend || 'unknown'}\``,
+              `- **Hardware**: \`${result.hardware || 'unknown'}\``,
+              `- **Commit**: \`${result.commit || 'unknown'}\``,
+              `- **Load time**: ${loadSecs}s`,
+              '',
+              '### Generation speed (greedy)',
+              '',
+              '| gen tokens | prefill (tok/s) | decode (tok/s) |',
+              '|---:|---:|---:|',
+              rows || '| — | — | — |',
+              '',
+              `**Sustained decode (512 tokens)**: ${sustained} tok/s`,
+              '',
+              '### Baseline comparison',
+              '',
+              '```',
+              compare.trim() || '(no output)',
+              '```',
+              '',
+              `<sub>Workflow: \`benchmark-pr.yml\` — commit ${context.sha.substring(0, 7)}</sub>`,
+            ].join('\n');
+
+            const marker = '<!-- flare-benchmark-pr-comment -->';
+            const fullBody = `${marker}\n${body}`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            );
+            const prior = existing.find(c =>
+              c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)
+            );
+
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: prior.id, body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body: fullBody,
+              });
+            }

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Baseline performance numbers for the continuous benchmark CI workflow. Numbers are placeholders captured on the GitHub Actions macos-14 runner (not Apple Silicon on the free tier) and will need to be refreshed once we have a stable reading. The PR workflow treats mismatches as informational and does not fail CI. See .github/workflows/benchmark-pr.yml and .github/scripts/check_perf_regression.py.",
+  "smollm2-135m-q8_0": {
+    "decode_16": 35.0,
+    "sustained_512": 25.0,
+    "prefill_peak": 120.0
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark-pr.yml` — a PR-triggered workflow that runs `cargo run --release --example e2e_bench -- --json` on a `macos-14` runner whenever `flare-core`, `flare-loader`, `flare-simd`, or the bench example change, then posts a sticky markdown comment with the numbers.
- Adds `.github/scripts/check_perf_regression.py` — compares the raw e2e_bench JSON against `benchmarks/baseline.json` (normalizes `generation[]` + `sustained_512_tok_s` onto the flat `decode_16 / sustained_512 / prefill_peak` keys) and prints a human-readable comparison table.
- Adds `benchmarks/baseline.json` with placeholder baseline numbers for `smollm2-135m-q8_0`.
- The existing nightly/manual `benchmark.yml` is untouched.

Informational only for now: `HARD_FAIL = False` in the Python script, the workflow's compare step uses `continue-on-error: true`, and the baseline numbers are placeholders that will need to be refreshed once we have a stable reading on the CI runner (GitHub Actions `macos-14` is not Apple Silicon on free accounts). Once the baseline is trustworthy we can flip `HARD_FAIL` to `True` and drop `continue-on-error` to start failing on >5% regressions.

Closes #450

## Test plan

- [ ] Workflow YAML parses (verified locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] `check_perf_regression.py` compiles and runs against a synthetic `bench-result.json` (verified locally — detects regressions and formats the markdown table correctly)
- [ ] `benchmarks/baseline.json` parses as valid JSON (verified)
- [ ] First PR run on this branch downloads the model, builds, runs the bench, and posts a comment
- [ ] Sticky-comment logic updates the existing comment on subsequent pushes instead of appending a new one