### PR TITLE
Add Q4_K_M download script and first Llama-3.2-1B Q4_K_M benchmark

### DIFF
--- a/BENCHMARK_HISTORY.md
+++ b/BENCHMARK_HISTORY.md
@@ -936,3 +936,34 @@ Baseline model: SmolLM2-135M-Instruct Q8_0 (138MB, 30 layers, dim=576).
 | Decode (256 tok) | 205.4 |
 | Sustained (512 tok) | **178.3** |
 
+### 2026-04-14 17:52 — `7f4c2cd` Llama-3.2-1B Q4_K_M first run (issue #441)
+
+**Hardware:** Apple M5 Pro, ARM64 (NEON SIMD)  
+**Model:** Llama, ~1498M params, 16 layers, dim=2048, **Q4_K_M** (785MB on disk)  
+**Load time:** 1.01s  
+**Notes:** First end-to-end run with a real Q4_K_M model (downloaded via
+`scripts/download_q4k_model.sh`). Q4_K layer weights activate the
+`use_cpu_q4k` path (direct 4-bit x f32 NEON matvec). Output projection stays
+on the dequantized f32 path because `output.weight` is tied to `token_embd`
+in this model (warning: "could not load raw output weight"). Inference is
+numerically healthy (no garbage, no NaN).
+
+For comparison, the same model at Q8_0 (1.3GB, tied-embedding same warning)
+sustains 37.2 tok/s on this hardware — so Q4_K_M is currently ~2x slower
+than Q8_0 despite having roughly half the weight-memory bandwidth. This
+reflects the current scalar-ish state of the Q4_K NEON matvec vs the highly
+tuned Q8_0 fused-rmsnorm path; Q4_K is functionally correct but is not yet
+bandwidth-bound and has clear headroom for SIMD tuning.
+
+| Metric | tok/s |
+|---|---|
+| Decode (16 tok) | 19.0 |
+| Decode (64 tok) | 17.4 |
+| Decode (256 tok) | 18.5 |
+| Sustained (512 tok) | **17.9** |
+
+| Format | Size | Sustained decode |
+|---|---|---|
+| Llama-3.2-1B Q8_0  | 1.3GB | 37.2 tok/s |
+| Llama-3.2-1B Q4_K_M | 785MB | 17.9 tok/s |
+

--- a/scripts/download_q4k_model.sh
+++ b/scripts/download_q4k_model.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Download a Q4_K_M benchmark model: Llama-3.2-1B-Instruct Q4_K_M (~770MB)
+#
+# Usage: ./scripts/download_q4k_model.sh
+
+set -e
+
+MODEL_DIR="${MODEL_DIR:-models}"
+MODEL_NAME="llama-3.2-1b-instruct-q4_k_m.gguf"
+MODEL_URL="https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_K_M.gguf"
+
+mkdir -p "$MODEL_DIR"
+
+if [ -f "$MODEL_DIR/$MODEL_NAME" ]; then
+    echo "Model already exists at $MODEL_DIR/$MODEL_NAME"
+    exit 0
+fi
+
+echo "Downloading Llama-3.2-1B-Instruct Q4_K_M (~770MB)..."
+curl -L "$MODEL_URL" -o "$MODEL_DIR/$MODEL_NAME" --progress-bar
+
+if [ -f "$MODEL_DIR/$MODEL_NAME" ]; then
+    SIZE=$(du -h "$MODEL_DIR/$MODEL_NAME" | cut -f1)
+    echo "Downloaded $MODEL_DIR/$MODEL_NAME ($SIZE)"
+else
+    echo "Download failed" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/download_q4k_model.sh` to fetch bartowski's Llama-3.2-1B-Instruct Q4_K_M GGUF (~785 MB).
- Records the first end-to-end benchmark of a real Q4_K_M model in `BENCHMARK_HISTORY.md`.
- Confirms the existing `use_cpu_q4k` direct 4-bit x f32 matvec path activates correctly for Q4_K layer weights and is numerically healthy across a 512-token sustained run (no NaN, no crashes, no obviously broken output).

## Results (Apple M5 Pro, NEON SIMD, CPU backend)

| Format | Size | Sustained decode |
|---|---|---|
| Llama-3.2-1B Q8_0 | 1.3 GB | 37.2 tok/s |
| Llama-3.2-1B Q4_K_M | 785 MB | 17.9 tok/s |

Q4_K_M is currently ~2x slower than Q8_0 despite roughly halving the weight-memory bandwidth, so the Q4_K NEON matvec is not yet bandwidth-bound and has clear headroom for SIMD tuning compared to the fused-RMSNorm Q8_0 path. Both Llama-3.2-1B runs show the same tied-embedding warning ("could not load raw output weight"), so the output projection stays on the dequantized f32 path in both cases — the decode delta is attributable to the per-layer matvec path only.

Refs #441.

## Test plan
- [x] `./scripts/download_q4k_model.sh` downloads ~785 MB to `models/llama-3.2-1b-instruct-q4_k_m.gguf`.
- [x] `cargo run --release -p flarellm-server --example e2e_bench -- --model models/llama-3.2-1b-instruct-q4_k_m.gguf --log` completes a full 512-token sustained decode without NaN or crashes.
- [x] Control run on the same Llama-3.2-1B Q8_0 model for direct comparison.
- [ ] (Follow-up) SIMD-tune `matvec_q4k_into` to move Q4_K_M past Q8_0 on the same hardware.