### PR TITLE
Release flare-web 0.1.1 on npm

### DIFF
--- a/BENCHMARK_HISTORY.md
+++ b/BENCHMARK_HISTORY.md
@@ -1058,3 +1058,42 @@ bandwidth-bound and has clear headroom for SIMD tuning.
 | Decode (256 tok) | 33.5 |
 | Sustained (512 tok) | **32.8** |
 
+### 2026-04-14 18:15 — `968a3fa Add Q4_K x Q8_0-input matvec path (decode 20 -> 34 tok/s ...`
+
+**Hardware:** Apple M5 Pro, ARM64 (NEON SIMD)  
+**Model:** Llama, ~1498M params, 16 layers, dim=2048  
+**Load time:** 1.08s
+
+| Metric | tok/s |
+|---|---|
+| Decode (16 tok) | 34.5 |
+| Decode (64 tok) | 33.3 |
+| Decode (256 tok) | 33.2 |
+| Sustained (512 tok) | **31.9** |
+
+### 2026-04-14 18:15 — `968a3fa Add Q4_K x Q8_0-input matvec path (decode 20 -> 34 tok/s ...`
+
+**Hardware:** Apple M5 Pro, ARM64 (NEON SIMD)  
+**Model:** Llama, ~1498M params, 16 layers, dim=2048  
+**Load time:** 1.00s
+
+| Metric | tok/s |
+|---|---|
+| Decode (16 tok) | 43.9 |
+| Decode (64 tok) | 37.5 |
+| Decode (256 tok) | 40.6 |
+| Sustained (512 tok) | **38.4** |
+
+### 2026-04-14 18:15 — `968a3fa Add Q4_K x Q8_0-input matvec path (decode 20 -> 34 tok/s ...`
+
+**Hardware:** Apple M5 Pro, ARM64 (NEON SIMD)  
+**Model:** Llama, ~162M params, 30 layers, dim=576  
+**Load time:** 0.12s
+
+| Metric | tok/s |
+|---|---|
+| Decode (16 tok) | 225.2 |
+| Decode (64 tok) | 221.2 |
+| Decode (256 tok) | 192.2 |
+| Sustained (512 tok) | **177.6** |
+

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -23,30 +23,26 @@ use crate::tensor::Tensor;
 /// that need a different count can set `RAYON_NUM_THREADS` before loading
 /// the library, or pre-build rayon's global pool themselves — this call is
 /// idempotent and silently no-ops if the pool is already initialized.
+#[cfg(any(not(target_arch = "wasm32"), feature = "wasm_threads"))]
 fn init_rayon_pool_once() {
     use std::sync::Once;
     static INIT: Once = Once::new();
     INIT.call_once(|| {
-        // Respect an explicit env var override (rayon honours this anyway,
-        // but we skip our own builder call so users see the exact count
-        // they requested).
         if std::env::var_os("RAYON_NUM_THREADS").is_some() {
             return;
         }
         let logical = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(4);
-        // Cap at 10 — anything above that hurts on the platforms we've
-        // profiled.  On machines with <= 10 logical cores this is a no-op.
         let target = logical.min(10);
-        // Ignore the error — if rayon's global pool was already built by
-        // something else (tests, another library), we can't override it
-        // and that's fine.
         let _ = rayon::ThreadPoolBuilder::new()
             .num_threads(target)
             .build_global();
     });
 }
+
+#[cfg(all(target_arch = "wasm32", not(feature = "wasm_threads")))]
+fn init_rayon_pool_once() {}
 
 /// Identifies the quantization format for a raw weight tensor stored on the GPU path.
 ///

--- a/flare-web/LICENSE
+++ b/flare-web/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Saurav Panda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@aspect/flare",
-  "version": "0.1.0",
+  "name": "@sauravpanda/flare",
+  "version": "0.1.1",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",
@@ -13,7 +13,8 @@
     "pkg/flare_web.d.ts",
     "pkg/package.json",
     "js/",
-    "demo/"
+    "demo/",
+    "LICENSE"
   ],
   "scripts": {
     "build": "wasm-pack build --target web --out-dir pkg",


### PR DESCRIPTION
## Summary

- Ship flare-web as `@sauravpanda/flare@0.1.1` on npm — first public npm release of the browser integration crate.
- Fix a wasm build regression introduced by PR #461: `init_rayon_pool_once` called `rayon::ThreadPoolBuilder` unconditionally, but rayon is an optional dep on wasm32 (only pulled in via `wasm_threads`). Now gated with `cfg(any(not(target_arch = "wasm32"), feature = "wasm_threads"))` and a no-op fallback for wasm-without-threads.
- Rename the npm package from `@aspect/flare` (scope not ours) to `@sauravpanda/flare`.
- Add `flare-web/LICENSE` so the published tarball ships with a license file (silences a wasm-pack warning on every build).
- Append recent `e2e_bench` session runs to `BENCHMARK_HISTORY.md`.

Published: https://www.npmjs.com/package/@sauravpanda/flare

## Test plan

- [x] `cargo build -p flarellm-core --target wasm32-unknown-unknown --release` passes
- [x] `wasm-pack build flare-web --target web --release` passes
- [x] `npm publish` succeeded for 0.1.1
- [x] `npm view @sauravpanda/flare version` returns `0.1.1`