### PR TITLE
Deploy live demo to GitHub Pages (#446)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,82 @@
+name: Deploy demo to GitHub Pages
+
+# Builds the flare-web WASM bundle and publishes the demo page to
+# GitHub Pages on every push to main (or on manual dispatch).
+#
+# The deployed site lives at https://<owner>.github.io/<repo>/ with the
+# demo HTML at root and the WASM package under /pkg/.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'flare-core/**'
+      - 'flare-loader/**'
+      - 'flare-simd/**'
+      - 'flare-gpu/**'
+      - 'flare-web/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+# Allow only one concurrent Pages deployment. Don't cancel in-progress runs
+# — let them finish so we don't leave the site in a half-deployed state.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build WASM + demo site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust build artefacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build flare-web (release, target web)
+        run: wasm-pack build flare-web --target web --out-dir pkg --release
+
+      - name: Assemble _site
+        run: |
+          mkdir -p _site/pkg
+          # Copy demo HTML to site root, rewriting the relative import path
+          # so the demo at / can find the WASM module at /pkg/.
+          sed 's|../pkg/flare_web.js|./pkg/flare_web.js|g' \
+            flare-web/demo/index.html > _site/index.html
+          # Copy the built WASM package.
+          cp flare-web/pkg/flare_web.js        _site/pkg/
+          cp flare-web/pkg/flare_web.d.ts      _site/pkg/
+          cp flare-web/pkg/flare_web_bg.wasm   _site/pkg/
+          cp flare-web/pkg/flare_web_bg.wasm.d.ts _site/pkg/
+          cp flare-web/pkg/package.json        _site/pkg/
+          # Minimal 404 so deep links don't render the GitHub Pages 404 theme.
+          cp _site/index.html _site/404.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/BENCHMARK_HISTORY.md
+++ b/BENCHMARK_HISTORY.md
@@ -1097,3 +1097,29 @@ bandwidth-bound and has clear headroom for SIMD tuning.
 | Decode (256 tok) | 192.2 |
 | Sustained (512 tok) | **177.6** |
 
+### 2026-04-15 18:30 — `d409693 Release flare-web 0.1.1 on npm (#462)`
+
+**Hardware:** Apple M5 Pro, ARM64 (NEON SIMD)  
+**Model:** Llama, ~162M params, 30 layers, dim=576  
+**Load time:** 0.13s
+
+| Metric | tok/s |
+|---|---|
+| Decode (16 tok) | 202.5 |
+| Decode (64 tok) | 219.4 |
+| Decode (256 tok) | 198.9 |
+| Sustained (512 tok) | **174.9** |
+
+### 2026-04-15 18:31 — `d409693 Release flare-web 0.1.1 on npm (#462)`
+
+**Hardware:** Apple M5 Pro, ARM64 (NEON SIMD)  
+**Model:** Llama, ~1498M params, 16 layers, dim=2048  
+**Load time:** 1.44s
+
+| Metric | tok/s |
+|---|---|
+| Decode (16 tok) | 39.5 |
+| Decode (64 tok) | 52.0 |
+| Decode (256 tok) | 48.9 |
+| Sustained (512 tok) | **45.7** |
+

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 [![CI](https://github.com/sauravpanda/flarellm/actions/workflows/ci.yml/badge.svg)](https://github.com/sauravpanda/flarellm/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](https://www.rust-lang.org)
+[![npm](https://img.shields.io/npm/v/@sauravpanda/flare.svg)](https://www.npmjs.com/package/@sauravpanda/flare)
 
 A WASM-first LLM inference engine with WebGPU acceleration, built in pure Rust.
 
 Run large language models directly in the browser with zero server costs. Single codebase compiles to both native and WebAssembly — same WGSL shaders, same quantization kernels, same inference pipeline.
+
+**[→ Try the live browser demo](https://sauravpanda.github.io/flarellm/)** · **[npm: @sauravpanda/flare](https://www.npmjs.com/package/@sauravpanda/flare)**
 
 ## Performance
 

--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -692,13 +692,19 @@
   </div>
 
   <script type="module">
-    import init, {
+    // Use a namespace import so the page doesn't fail hard when a named
+    // export is missing from the build (e.g. `init_thread_pool`, which is
+    // only compiled in when the `wasm_threads` Cargo feature is enabled).
+    import * as flare from '../pkg/flare_web.js';
+    const init = flare.default;
+    const {
       FlareEngine, FlareProgressiveLoader, FlareTokenizer,
-      webgpu_available, supports_webnn, supports_webtransport, init_thread_pool,
+      webgpu_available, supports_webnn, supports_webtransport,
       supports_speech_recognition, supports_speech_synthesis,
       is_model_cached, cache_model, load_cached_model,
-      delete_cached_model, list_cached_models, storage_estimate
-    } from '../pkg/flare_web.js';
+      delete_cached_model, list_cached_models, storage_estimate,
+    } = flare;
+    const init_thread_pool = flare.init_thread_pool; // may be undefined without wasm_threads
 
     const $ = id => document.getElementById(id);
     const $status      = $('status');


### PR DESCRIPTION
## Summary

- **New workflow** `.github/workflows/deploy-pages.yml` — builds flare-web WASM with wasm-pack and deploys the demo page to GitHub Pages on every push to `main` that touches flare-*/** or the workflow itself. Also has `workflow_dispatch` for manual runs.
- **Demo site layout:** assembles `_site/index.html` (from `flare-web/demo/index.html` with `../pkg/` → `./pkg/` path rewrite) plus `_site/pkg/` (the built WASM package). Deployed URL: https://sauravpanda.github.io/flarellm/
- **Bug fix in `flare-web/demo/index.html`**: the demo was destructuring `init_thread_pool` from the module's named exports, but that symbol is only compiled in when the `wasm_threads` Cargo feature is enabled. On a default build the named import throws `SyntaxError` at load time and the page never boots. Switched to a namespace import so missing exports are just `undefined` rather than fatal; the pre-existing `typeof init_thread_pool === 'function'` guard then works.
- **README** — added live-demo and npm badges at the top.

Pages is already enabled on the repo with `build_type=workflow` (set via the API), so the first push to main should trigger the first deploy automatically.

## Why GitHub Pages is a good fit

- The default (non-threaded) WASM build needs no COOP/COEP headers, which GitHub Pages can't set — so the single-threaded build works out of the box.
- GitHub Pages serves `.wasm` with `application/wasm` MIME type.
- Cache API + OPFS for model persistence work on Pages.

## Limitations

- No multi-threaded WASM (needs SharedArrayBuffer, which needs COOP/COEP headers — not settable on Pages without a service-worker workaround). Can be added later via `coi-serviceworker` if we want the `wasm_threads` build.
- Cold page load is ~1 MB WASM + ~100 KB JS. Hot loads are cached.

## Test plan

- [x] `wasm-pack build flare-web --target web --release` succeeds
- [x] Simulated `_site/` assembly locally — all paths serve: `/` → HTML (200), `/pkg/flare_web.js` (200), `/pkg/flare_web_bg.wasm` (200, `application/wasm`)
- [x] Demo HTML path rewrite verified: `import * as flare from './pkg/flare_web.js'` (was `../pkg/`)
- [ ] Post-merge: first GitHub Actions run lands the site at https://sauravpanda.github.io/flarellm/
- [ ] Post-deploy: load a SmolLM2-135M URL in the live demo and verify generation works

Closes #446