### PR TITLE
Add 'Try SmolLM2-135M' quick-fill to demo

### DIFF
--- a/flare-web/demo/index.html
+++ b/flare-web/demo/index.html
@@ -538,6 +538,11 @@
       <p class="stats">Paste a direct URL to a GGUF file. Download progress shown in real time.</p>
       <input type="url" id="url-input" placeholder="https://example.com/model.gguf" disabled>
       <button id="url-load" disabled>Load from URL</button>
+      <p class="stats" style="margin-top:0.5rem;">
+        No GGUF file handy?
+        <a href="#" id="try-example">Try SmolLM2-135M (~138 MB)</a>
+        — fills in model + tokenizer URLs from HuggingFace.
+      </p>
     </div>
 
     <!-- Progress bar -->
@@ -1074,6 +1079,26 @@
         btn.classList.add('active');
         panel.querySelector('#tab-' + btn.dataset.tab).classList.add('active');
       });
+    });
+
+    // ---------- Example quick-fill: SmolLM2-135M Q8_0 ----------
+    // HuggingFace serves these paths with CORS enabled, so browser fetch works.
+    const EXAMPLE_MODEL_URL =
+      'https://huggingface.co/bartowski/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-Q8_0.gguf';
+    const EXAMPLE_TOK_URL =
+      'https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct/resolve/main/tokenizer.json';
+    $('try-example')?.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      $urlInput.value = EXAMPLE_MODEL_URL;
+      $tokUrlIn.value = EXAMPLE_TOK_URL;
+      // Switch both model- and tokenizer-panel tabs to "From URL" so the
+      // user can see what was filled in.
+      document.querySelectorAll('.tab-btn').forEach((btn) => {
+        if (btn.dataset.tab === 'url' || btn.dataset.tab === 'tok-url') {
+          btn.click();
+        }
+      });
+      $urlInput.focus();
     });
 
     // ---------- Progress bar ----------


### PR DESCRIPTION
## Summary

Follow-up to PR #466. The deployed demo had no default model, so first-time visitors had nothing to try unless they had a GGUF file on hand. Adds a one-click example fill:

- New link under the URL input: **"Try SmolLM2-135M (~138 MB)"**
- On click: pre-fills both the model URL (Q8_0 GGUF from bartowski's HF mirror) and the tokenizer URL (HuggingFaceTB's tokenizer.json), then switches both model- and tokenizer-panels to the "From URL" tab so the filled values are visible.
- **Deliberately does not auto-trigger the 138 MB download** — users see the URLs first and click "Load from URL" themselves.

## Why it works without a proxy

HuggingFace's `/resolve/main/` paths include `Access-Control-Allow-Origin` headers specifically for browser ML runtimes. Verified with:

```
$ curl -I -H "Origin: https://sauravpanda.github.io" \
    https://huggingface.co/bartowski/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-Q8_0.gguf
HTTP/2 302
access-control-allow-origin: https://sauravpanda.github.io
```

## Test plan

- [x] Local: link appears, clicks populate both URL fields, both panels switch to URL tab
- [x] CORS headers verified for both HF URLs from the Pages origin
- [ ] Post-deploy: click "Try SmolLM2-135M" on https://sauravpanda.github.io/flarellm/ → click "Load from URL" → model downloads and generation works