### PR TITLE
Release flare-web 0.2.0

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   publish:
-    name: Build WASM and publish @aspect/flare
+    name: Build WASM and publish @sauravpanda/flare
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
## Summary

Bump flare-web from 0.1.1 → 0.2.0 to bundle the perf + visibility work merged since the last release.

### What's in 0.2.0

**Prefill speed (1B Llama Q8_0 on Apple M5 Pro, 6-token prompt):** **22 → 140 tok/s** (+536% over session baseline, ~2× over 0.1.1)

| Change | Perf impact |
|---|---|
| PR #463 — Q8_0 2×2 SMMLA tile | Prefill 62 → 97 tok/s |
| PR #464 — Q4_K 2-token tile | Q4_K_M prefill 44 → 60 tok/s |
| PR #465 — Q8_0 2×4 SMMLA tile | Prefill 97 → 140 tok/s |
| PR #466 — GitHub Pages workflow | Live demo at https://sauravpanda.github.io/flarellm/ |
| PR #467 — "Try SmolLM2-135M" quick-fill | First-time visitors can run inference in one click |

**Also:** fixed the npm-publish workflow job-name string to reference the current package scope (`@sauravpanda/flare`, was `@aspect/flare`).

## Test plan

- [x] `wasm-pack build flare-web --target web --release` passes
- [x] `npm pack --dry-run` shows 0.2.0 with all expected files (LICENSE, pkg/, js/, demo/)
- [ ] After merge: tag `flare-web-v0.2.0`, publish to npm manually (no `NPM_TOKEN` secret configured for the auto-publish workflow yet), create GitHub Release