### PR TITLE
Add WASM SIMD128 Q8_0 matvec kernel (browser perf)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+# Workspace-wide Cargo config.
+#
+# Enable WASM SIMD128 for all wasm32 builds.  Without this flag Rust
+# produces no-SIMD output for the wasm32-unknown-unknown target, which
+# bypasses every SIMD-gated code path (e.g. the Q8_0 matvec kernels in
+# flare-core). Every modern browser that supports WebAssembly also
+# supports SIMD128 (Chrome 91+, Firefox 89+, Safari 16.4+), so this is
+# safe to enable by default.
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "target-feature=+simd128"]

--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -7033,7 +7033,18 @@ pub fn matvec_q8_0_preq_into(
         }
     }
 
-    #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        for (i, out) in output.iter_mut().enumerate() {
+            let row_start = i * bytes_per_row;
+            let row_bytes = &weight_data[row_start..row_start + bytes_per_row];
+            *out = unsafe {
+                dot_q8_0_q8_0_wasm_simd(row_bytes, &preq.scales, &preq.quants, blocks_per_row)
+            };
+        }
+    }
+
+    #[cfg(all(not(target_arch = "aarch64"), not(all(target_arch = "wasm32", target_feature = "simd128"))))]
     {
         for (i, out) in output.iter_mut().enumerate() {
             let row_start = i * bytes_per_row;
@@ -7066,6 +7077,140 @@ pub fn matvec_q8_0_preq_into(
             *out = sum;
         }
     }
+}
+
+/// WASM SIMD128 dot product for one Q8_0 weight row against a pre-quantized
+/// Q8_0 input.  Mirrors the aarch64 `dot_q8_0_q8_0_neon` path.
+///
+/// Uses `i16x8_extmul_*_i8x16` to widen int8 × int8 → int16 products in 8 lanes,
+/// then `i32x4_extadd_pairwise_i16x8` to pairwise-accumulate to int32, giving
+/// 4 partial sums per 16-byte chunk (equivalent to SDOT on aarch64).
+///
+/// # Safety
+/// Requires `target_feature = "simd128"`.  All slices must be valid for
+/// `blocks_per_row`.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+unsafe fn dot_q8_0_q8_0_wasm_simd(
+    row_bytes: &[u8],
+    input_q8_scales: &[f32],
+    input_q8_quants: &[i8],
+    blocks_per_row: usize,
+) -> f32 {
+    use core::arch::wasm32::*;
+
+    // 4 independent float accumulators to hide SIMD pipeline latency.
+    let mut sumv0 = f32x4_splat(0.0);
+    let mut sumv1 = f32x4_splat(0.0);
+    let mut sumv2 = f32x4_splat(0.0);
+    let mut sumv3 = f32x4_splat(0.0);
+
+    let row_ptr = row_bytes.as_ptr();
+    let iq_ptr = input_q8_quants.as_ptr();
+
+    // Process 4 blocks per iteration (matches the aarch64 unrolling).
+    let quads = blocks_per_row / 4;
+    for i in 0..quads {
+        let ib0 = i * 4;
+
+        // --- Block ib0 ---
+        let w_ptr0 = row_ptr.add(ib0 * Q8_0_BLOCK_BYTES);
+        let w_scale0 = f16_to_f32_inline(u16::from_le_bytes([*w_ptr0, *w_ptr0.add(1)]));
+        let w_qs0 = w_ptr0.add(2);
+        let i_qs0 = iq_ptr.add(ib0 * Q8_0_BLOCK_SIZE);
+        let combined_scale0 = w_scale0 * *input_q8_scales.get_unchecked(ib0);
+        let sum0 = q8_chunk_dot(w_qs0, i_qs0);
+        sumv0 = f32x4_add(sumv0, f32x4_mul(i32_to_f32(sum0), f32x4_splat(combined_scale0)));
+
+        // --- Block ib0 + 1 ---
+        let w_ptr1 = row_ptr.add((ib0 + 1) * Q8_0_BLOCK_BYTES);
+        let w_scale1 = f16_to_f32_inline(u16::from_le_bytes([*w_ptr1, *w_ptr1.add(1)]));
+        let w_qs1 = w_ptr1.add(2);
+        let i_qs1 = iq_ptr.add((ib0 + 1) * Q8_0_BLOCK_SIZE);
+        let combined_scale1 = w_scale1 * *input_q8_scales.get_unchecked(ib0 + 1);
+        let sum1 = q8_chunk_dot(w_qs1, i_qs1);
+        sumv1 = f32x4_add(sumv1, f32x4_mul(i32_to_f32(sum1), f32x4_splat(combined_scale1)));
+
+        // --- Block ib0 + 2 ---
+        let w_ptr2 = row_ptr.add((ib0 + 2) * Q8_0_BLOCK_BYTES);
+        let w_scale2 = f16_to_f32_inline(u16::from_le_bytes([*w_ptr2, *w_ptr2.add(1)]));
+        let w_qs2 = w_ptr2.add(2);
+        let i_qs2 = iq_ptr.add((ib0 + 2) * Q8_0_BLOCK_SIZE);
+        let combined_scale2 = w_scale2 * *input_q8_scales.get_unchecked(ib0 + 2);
+        let sum2 = q8_chunk_dot(w_qs2, i_qs2);
+        sumv2 = f32x4_add(sumv2, f32x4_mul(i32_to_f32(sum2), f32x4_splat(combined_scale2)));
+
+        // --- Block ib0 + 3 ---
+        let w_ptr3 = row_ptr.add((ib0 + 3) * Q8_0_BLOCK_BYTES);
+        let w_scale3 = f16_to_f32_inline(u16::from_le_bytes([*w_ptr3, *w_ptr3.add(1)]));
+        let w_qs3 = w_ptr3.add(2);
+        let i_qs3 = iq_ptr.add((ib0 + 3) * Q8_0_BLOCK_SIZE);
+        let combined_scale3 = w_scale3 * *input_q8_scales.get_unchecked(ib0 + 3);
+        let sum3 = q8_chunk_dot(w_qs3, i_qs3);
+        sumv3 = f32x4_add(sumv3, f32x4_mul(i32_to_f32(sum3), f32x4_splat(combined_scale3)));
+    }
+
+    // Remaining 0-3 blocks.
+    let remainder_start = quads * 4;
+    for ib in remainder_start..blocks_per_row {
+        let w_ptr = row_ptr.add(ib * Q8_0_BLOCK_BYTES);
+        let w_scale = f16_to_f32_inline(u16::from_le_bytes([*w_ptr, *w_ptr.add(1)]));
+        let w_qs = w_ptr.add(2);
+        let i_qs = iq_ptr.add(ib * Q8_0_BLOCK_SIZE);
+        let combined_scale = w_scale * *input_q8_scales.get_unchecked(ib);
+        let sum = q8_chunk_dot(w_qs, i_qs);
+        sumv0 = f32x4_add(sumv0, f32x4_mul(i32_to_f32(sum), f32x4_splat(combined_scale)));
+    }
+
+    // Reduce 4 accumulators to one, then horizontal sum.
+    let sum_01 = f32x4_add(sumv0, sumv1);
+    let sum_23 = f32x4_add(sumv2, sumv3);
+    let sum_all = f32x4_add(sum_01, sum_23);
+    f32x4_extract_lane::<0>(sum_all)
+        + f32x4_extract_lane::<1>(sum_all)
+        + f32x4_extract_lane::<2>(sum_all)
+        + f32x4_extract_lane::<3>(sum_all)
+}
+
+/// Compute a Q8_0 block dot product (32 int8 × 32 int8 → int32x4 with 4 partial sums).
+///
+/// Returns a `v128` holding 4 int32 partial sums (same shape as aarch64's SDOT output).
+///
+/// # Safety
+/// `w_ptr` must point to ≥32 valid u8 weight bytes.  `i_ptr` must point to ≥32
+/// valid i8 input bytes.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+unsafe fn q8_chunk_dot(w_ptr: *const u8, i_ptr: *const i8) -> core::arch::wasm32::v128 {
+    use core::arch::wasm32::*;
+
+    let w_lo = v128_load(w_ptr as *const v128);
+    let w_hi = v128_load(w_ptr.add(16) as *const v128);
+    let i_lo = v128_load(i_ptr as *const v128);
+    let i_hi = v128_load(i_ptr.add(16) as *const v128);
+
+    // i16 products (8 lanes per half × 2 halves = 32 products)
+    let prod_lo_lo = i16x8_extmul_low_i8x16(w_lo, i_lo);
+    let prod_lo_hi = i16x8_extmul_high_i8x16(w_lo, i_lo);
+    let prod_hi_lo = i16x8_extmul_low_i8x16(w_hi, i_hi);
+    let prod_hi_hi = i16x8_extmul_high_i8x16(w_hi, i_hi);
+
+    // Pairwise-accumulate i16 → i32 (4 lanes each).
+    let s0 = i32x4_extadd_pairwise_i16x8(prod_lo_lo);
+    let s1 = i32x4_extadd_pairwise_i16x8(prod_lo_hi);
+    let s2 = i32x4_extadd_pairwise_i16x8(prod_hi_lo);
+    let s3 = i32x4_extadd_pairwise_i16x8(prod_hi_hi);
+
+    // Sum all 4 partial-sum vectors: each lane holds a contribution from
+    // 8 of the 32 input-weight pairs, so the 4 output lanes together sum
+    // all 32 products.
+    i32x4_add(i32x4_add(s0, s1), i32x4_add(s2, s3))
+}
+
+/// Convert int32x4 lanes to f32x4 (WASM SIMD helper).
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+fn i32_to_f32(v: core::arch::wasm32::v128) -> core::arch::wasm32::v128 {
+    core::arch::wasm32::f32x4_convert_i32x4(v)
 }
 
 /// Compute the argmax of a Q8_0 matrix-vector product without materializing


### PR DESCRIPTION
## Summary

The live demo at https://sauravpanda.github.io/flarellm/ runs Q8_0 matvec through the **scalar int8 inner loop** — roughly an order of magnitude slower than the aarch64 NEON path. All the native tile work (PRs #463/#465/#469) is invisible to browser users because the wasm build never enters those code paths.

This PR adds a WASM SIMD128 kernel mirroring the NEON structure, and also fixes a silent build-config bug that was gating out every existing SIMD-flagged wasm code path.

## What changed

**`dot_q8_0_q8_0_wasm_simd`** — new kernel in `flare-core/src/model.rs`:
- 4 independent float accumulators to hide SIMD pipeline latency
- 4-block unrolled outer loop (matches the aarch64 structure)
- `i16x8_extmul_low/high_i8x16_s` for widening int8 × int8 → int16
- `i32x4_extadd_pairwise_i16x8_s` for int16 → int32 pairwise reduction
- `f32x4_convert_i32x4_s` + vector scale-fold

`matvec_q8_0_preq_into` dispatches to the WASM SIMD path when `target_arch = "wasm32"` and `target_feature = "simd128"`, falling back to the scalar loop on non-aarch64 non-simd128 targets.

**`.cargo/config.toml`** — new, enables `+simd128` for all `wasm32-unknown-unknown` builds:

```toml
[target.wasm32-unknown-unknown]
rustflags = ["-C", "target-feature=+simd128"]
```

Rust does not enable `simd128` by default for this target (verified: `rustc --print cfg --target wasm32-unknown-unknown` lists `bulk-memory`, `multivalue`, `reference-types`, `sign-ext` — no `simd128`). Without this flag, every `#[cfg(target_feature = "simd128")]`-gated code path silently falls through to scalar. Browser compat is fine — SIMD128 is universally available in Chrome 91+, Firefox 89+, Safari 16.4+.

## Verification

Inspected the built `flare_web_bg.wasm`:

| Instruction | Before this PR | After |
|---|---|---|
| `i16x8.extmul_low_i8x16_s` | 0 | 10 |
| `i16x8.extmul_high_i8x16_s` | 0 | 10 |
| `i32x4.extadd_pairwise_i16x8_s` | 0 | 20 |
| `f32x4.convert_i32x4_s` | 0 | 117 |
| `i32x4.add` | 0 | 113 |

Bundle size: 1020 KB → 1029 KB (+9 KB, negligible).

## Expected browser impact

The Q8_0 hot path goes from 4-wide scalar int8 muls to 16-wide SIMD multiply-accumulate chains. **Expected ~5-10× speedup** on the live demo for 1B Q8_0 inference, based on the ratio between scalar and NEON paths on native hardware.

Can't easily benchmark browser perf from CLI — next step after merge is opening the live demo, loading SmolLM2-135M, and timing.

## Scope notes

- **Q4_K WASM SIMD is out of scope for this PR.** Follow-up — the Q4_K nibble unpack needs a different SIMD recipe.
- **2-token and 4-token WASM tiles are out of scope.** The existing tile dispatch in `batched_dequant_matmul` is `#[cfg(target_arch = "aarch64")]` only; browser prefill uses single-row matvec. Follow-up can port the tile kernels to WASM SIMD.

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test --workspace` — 622 tests pass, no regressions
- [x] `wasm-pack build flare-web --target web --release` passes
- [x] `wasm-dis` on the built wasm confirms SIMD instructions are present
- [x] Native 1B Q8_0 bench still at ~140 tok/s prefill, no regression
- [ ] Post-deploy: open https://sauravpanda.github.io/flarellm/, "Try SmolLM2-135M", time decode — expect ~5-10× speedup over current