### PR TITLE
Release flare-web 0.2.1

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
## Summary

Patch release: **0.2.0 → 0.2.1**. Bundles the browser-perf work merged since this morning's 0.2.0 release.

### What's in 0.2.1

| PR | Change | Browser impact |
|---|---|---|
| [#470](https://github.com/sauravpanda/flarellm/pull/470) | WASM SIMD128 Q8_0 matvec kernel | **~5-10× decode** (0.2.0 was scalar int8) |
| [#471](https://github.com/sauravpanda/flarellm/pull/471) | WASM SIMD128 Q4_K × Q8_0 kernel | ~5-10× decode for Q4_K_M models |
| [#472](https://github.com/sauravpanda/flarellm/pull/472) | WASM 2-row × 2-token Q8_0 tile | Halves weight bandwidth during browser prefill |

Also includes `.cargo/config.toml` enabling `+simd128` for `wasm32-unknown-unknown` — Rust doesn't enable it by default, which was silently gating out every SIMD code path.

### Why it matters (context)

BrowserAI benchmarked Flare 0.2.0 on SmolLM2-135M and we came in at 23.1 tok/s (ahead of Transformers at 16.2, behind MLC's WebGPU-backed 94). That 0.2.0 build had none of the WASM SIMD kernels — the live demo was doing scalar int8 multiply-add loops in the decode hot path. 0.2.1 unblocks a fair apples-to-apples rerun on the CPU-WASM path.

## Test plan

- [x] `wasm-pack build flare-web --target web --release` succeeds
- [x] `npm pack --dry-run` produces `sauravpanda-flare-0.2.1.tgz` with expected contents (13 files, 1.3 MB unpacked)
- [ ] Post-merge: tag `flare-web-v0.2.1`, publish to npm manually, create GitHub Release
- [ ] Post-publish: BrowserAI upgrades to 0.2.1 and re-benchmarks