### PR TITLE
Make Q8_0/Q4_K dispatch WASM-aware — fix sub-1024-dim browser perf

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -1617,7 +1617,7 @@ impl Model {
 
         // Base Q8_0 eligibility: raw weights present and in Q8_0 format.
         let has_q8 = !use_raw
-            && dim >= 1024
+            && use_quant_for_dim(dim)
             && self.raw_weights.is_some()
             && self
                 .raw_weights
@@ -1638,7 +1638,7 @@ impl Model {
         // memory bandwidth requirements compared to Q8_0.
         let use_cpu_q4k = !use_raw
             && !has_q8
-            && dim >= 1024
+            && use_quant_for_dim(dim)
             && self.raw_weights.is_some()
             && self
                 .raw_weights
@@ -2571,11 +2571,11 @@ impl Model {
         let use_output_q4k = self
             .raw_output_weight
             .as_ref()
-            .is_some_and(|rw| rw.format == WeightFormat::Q4K && dim >= 1024);
+            .is_some_and(|rw| rw.format == WeightFormat::Q4K && use_quant_for_dim(dim));
         let use_output_q8 = self
             .raw_output_weight
             .as_ref()
-            .is_some_and(|rw| rw.format == WeightFormat::Q8_0 && dim >= 1024);
+            .is_some_and(|rw| rw.format == WeightFormat::Q8_0 && use_quant_for_dim(dim));
         let mut logits = if use_output_q4k {
             let row = self.raw_output_weight.as_ref().unwrap();
             let mut out = vec![0.0f32; config.vocab_size];
@@ -2715,7 +2715,7 @@ impl Model {
 
         // Base Q8_0 eligibility: raw weights present and in Q8_0 format.
         let has_q8 = !use_raw
-            && dim >= 1024
+            && use_quant_for_dim(dim)
             && self.raw_weights.is_some()
             && self
                 .raw_weights
@@ -2731,7 +2731,7 @@ impl Model {
 
         let use_cpu_q4k = !use_raw
             && !has_q8
-            && dim >= 1024
+            && use_quant_for_dim(dim)
             && self.raw_weights.is_some()
             && self
                 .raw_weights
@@ -3358,7 +3358,7 @@ impl Model {
 
         // Base Q8_0 eligibility: raw weights present and in Q8_0 format.
         let has_q8 = !use_raw
-            && dim >= 1024
+            && use_quant_for_dim(dim)
             && self.raw_weights.is_some()
             && self
                 .raw_weights
@@ -3374,7 +3374,7 @@ impl Model {
 
         let use_cpu_q4k = !use_raw
             && !has_q8
-            && dim >= 1024
+            && use_quant_for_dim(dim)
             && self.raw_weights.is_some()
             && self
                 .raw_weights
@@ -4455,9 +4455,45 @@ const Q8_MATRIX_BYTE_THRESHOLD: usize = 16 * 1024 * 1024;
 /// Returns `true` when the matrix is too large for L2 cache (bandwidth-bound),
 /// meaning Q8_0's ~2x bandwidth reduction outweighs the AMX f32 throughput
 /// advantage.  For cache-resident matrices, f32 BLAS is faster.
+///
+/// On non-aarch64 targets (notably WASM), there is no AMX / Accelerate f32
+/// path — f32 matmul is plain SIMD or scalar — so Q8_0's int8 SIMD always wins
+/// and this always returns `true`.
 #[inline]
 fn should_use_q8_for_size(rows: usize, cols: usize) -> bool {
-    rows * cols * 4 > Q8_MATRIX_BYTE_THRESHOLD
+    #[cfg(target_arch = "aarch64")]
+    {
+        rows * cols * 4 > Q8_MATRIX_BYTE_THRESHOLD
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let _ = (rows, cols);
+        true
+    }
+}
+
+/// Decide whether a given hidden dimension should route through the Q8_0 or
+/// Q4_K quantized path (vs the f32 path).
+///
+/// On aarch64, small matrices (dim < 1024) are L2-resident and the f32
+/// Accelerate/AMX path outperforms Q8_0's int8 SIMD — AMX matrix throughput
+/// dominates the ~2x bandwidth reduction.  On WASM and other non-AMX targets,
+/// there is no equivalent f32 acceleration, so Q8_0 int8 SIMD always wins for
+/// quantized models regardless of dim.
+///
+/// This helper replaces ad-hoc `dim >= 1024` checks so future dispatch changes
+/// stay consistent.
+#[inline]
+fn use_quant_for_dim(dim: usize) -> bool {
+    #[cfg(target_arch = "aarch64")]
+    {
+        dim >= 1024
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let _ = dim;
+        true
+    }
 }
 
 /// Issue software prefetch hints for the first `PREFETCH_BYTES` of a byte slice.


### PR DESCRIPTION
## Summary

The 0.2.1 release shipped WASM SIMD128 kernels for Q8_0 and Q4_K, but the BrowserAI benchmark on SmolLM2-135M barely moved (23 → 25 tok/s). **The reason: those kernels were never executing for SmolLM2-135M.**

The decode matmul dispatch gated the Q8_0/Q4_K fast paths behind `dim >= 1024` at 8 call sites. That threshold was picked for **aarch64** where the f32 Accelerate/AMX path outperforms Q8_0 for small matrices — AMX matrix throughput dominates the ~2× bandwidth reduction from int8 weights.

**On WASM there is no AMX.** The f32 path is plain SIMD128 (or scalar without `relaxed_simd`), which is slower than our int8 SIMD128 path. But the `dim >= 1024` gate was silently routing every sub-1024-dim model through f32, making all the 0.2.1 SIMD kernels dead code for SmolLM2-135M (`dim=576`), TinyLlama (likely affected), and every other small model people actually run in browsers.

## Fix

Replace the literal `dim >= 1024` at all 8 dispatch sites with a `use_quant_for_dim(dim)` helper:

```rust
#[inline]
fn use_quant_for_dim(dim: usize) -> bool {
    #[cfg(target_arch = "aarch64")]
    { dim >= 1024 }  // AMX beats Q8 for L2-resident matrices
    #[cfg(not(target_arch = "aarch64"))]
    { let _ = dim; true }  // no AMX — Q8 always wins
}
```

Also update `should_use_q8_for_size` (the `Q8_MATRIX_BYTE_THRESHOLD` check for the output projection) to always return `true` on non-aarch64, same reasoning.

Call sites updated: `forward_layers` has_q8/use_cpu_q4k (single-token decode), `forward` output projection (both Q8 and Q4_K), `forward_partial`, `forward_skip_layers`. All 8 replaced mechanically via `sed`.

## What doesn't change

- **Native aarch64 performance** — `use_quant_for_dim` returns `dim >= 1024` on aarch64, preserving the existing AMX-vs-Q8 behavior. Verified: SmolLM2-135M sustained decode unchanged at ~194 tok/s.
- **Large models on WASM** — 1B models (dim=2048) already satisfied the gate.
- **Output projection selection** — the `should_use_q8_for_size` threshold still applies on aarch64.

## Expected impact

On the BrowserAI benchmark (SmolLM2-135M, WASM SIMD128 path):
- Every layer's QKV/FFN/output matmul now routes through the Q8 SIMD kernel instead of f32
- Expected **~2-3× decode tokens/sec** on top of the SIMD kernels that 0.2.1 already shipped
- Expected **~3× lower TTFT** (same kernels benefit the prefill path)

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test --workspace` — no regressions
- [x] `cargo build -p flarellm-core --target wasm32-unknown-unknown` passes
- [x] `wasm-pack build flare-web --target web --release` passes
- [x] Native 135M Q8_0 benchmark unchanged (~194 tok/s sustained decode)
- [ ] Post-merge: ship as 0.2.2, BrowserAI re-benchmark