### PR TITLE
Release flare-web 0.2.2

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
## Summary

Patch release chasing the fix from #474. Bumps version 0.2.1 → 0.2.2.

0.2.1 shipped WASM SIMD128 kernels but a `dim >= 1024` dispatch gate — designed for aarch64 AMX — kept small models (SmolLM2-135M, dim=576) on the f32 path, making the SIMD work effectively dead code for that model shape. #474 replaces the gate with a WASM-aware helper.

## Expected BrowserAI 135M numbers post-release

| Metric | 0.2.0 | 0.2.1 (shipped dead code on 135M) | 0.2.2 (predicted) |
|---|---|---|---|
| tok/s | 23.1 | 24.7 | **50-80** |
| TTFT | 1326ms | 1248ms | **300-500ms** |
| Model load | 4.4s | 2.1s | ~2.1s |

2-3× decode speedup on 135M comes from every layer's matmul now routing through the SIMD int8 path instead of f32. Still won't match MLC (WebGPU), but closes the honest CPU-WASM gap.

## Test plan

- [x] `wasm-pack build flare-web --target web --release` passes
- [x] Native aarch64 benchmarks unchanged (135M at 194 tok/s sustained)
- [ ] Post-merge: tag `flare-web-v0.2.2`, publish to npm, create GitHub Release
- [ ] BrowserAI upgrades to 0.2.2, re-benchmarks, we see actual browser-perf wins