### PR TITLE
Auto-populate raw weights in FlareEngine::load — real fix for browser perf

### DIFF
--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -455,8 +455,36 @@ impl FlareEngine {
         let weights = load_model_weights(&gguf, &mut reader)
             .map_err(|e| JsError::new(&format!("Weight load error: {e}")))?;
 
+        let mut model = Model::new(config.clone(), weights);
+
+        // Auto-populate raw quantized weights so Q8_0 / Q4_K models take the
+        // hand-tuned WASM SIMD128 matvec paths by default.  This used to be
+        // opt-in via `load_raw_weights()`, which callers frequently forgot —
+        // the result was every model silently running on the f32 fallback.
+        // Failure here is non-fatal: f16 / unsupported-quant models stay on
+        // the f32 path.
+        let num_layers = config.num_layers;
+        let mut raw_layers = Vec::with_capacity(num_layers);
+        let mut all_ok = true;
+        for layer_idx in 0..num_layers {
+            match gguf.load_raw_layer_weights(&mut reader, layer_idx) {
+                Ok(Some(rw)) => raw_layers.push(rw),
+                _ => {
+                    all_ok = false;
+                    break;
+                }
+            }
+        }
+        if all_ok && raw_layers.len() == num_layers {
+            model.set_raw_weights(raw_layers);
+        } else {
+            web_sys::console::log_1(
+                &"flare: raw quantized weights not available, using f32 path".into(),
+            );
+        }
+
         Ok(FlareEngine {
-            model: Model::new(config, weights),
+            model,
             chat_template,
             gguf_vocab,
             eos_token_id,


### PR DESCRIPTION
## The actual bug

Two releases of WASM SIMD kernel work (#470-#472) and the WASM dispatch fix (#474) **did not move the BrowserAI SmolLM2-135M benchmark** because the SIMD code paths were literally unreachable.

Root cause: `FlareEngine::load()` does NOT populate `raw_weights`. That's gated behind an opt-in `load_raw_weights()` API call. Without it, every matmul — regardless of format, regardless of dim, regardless of kernel optimization — falls through to the f32 dequantize-and-matmul path.

Verified: [BrowserAI's flare wrapper](https://github.com/Cloud-Code-AI/BrowserAI/blob/main/src/engines/flare-engine-wrapper.ts#L306) calls `FlareEngine.load(modelBytes)` and nothing else. The benchmark at `examples/benchmark/index.html` (line 655) does the same. Every external consumer hits the slow path.

## Fix

`load()` now automatically attempts to populate `raw_weights` after parsing the GGUF:

```rust
let num_layers = config.num_layers;
let mut raw_layers = Vec::with_capacity(num_layers);
let mut all_ok = true;
for layer_idx in 0..num_layers {
    match gguf.load_raw_layer_weights(&mut reader, layer_idx) {
        Ok(Some(rw)) => raw_layers.push(rw),
        _ => { all_ok = false; break; }
    }
}
if all_ok && raw_layers.len() == num_layers {
    model.set_raw_weights(raw_layers);
} else {
    web_sys::console::log_1(&"flare: raw quantized weights not available, using f32 path".into());
}
```

Failure is non-fatal — f16 and unsupported-quant models stay on the f32 path and log a one-line warning. The existing `load_raw_weights()` API stays as-is for callers that explicitly clear and reload.

## Expected impact on BrowserAI benchmark (SmolLM2-135M, after 0.2.3)

| Metric | 0.2.2 (SIMD unreachable) | 0.2.3 (predicted) |
|---|---|---|
| tok/s | 24.8 | 50-80 |
| TTFT | 1244ms | 300-500ms |

This is the release that should actually demonstrate the browser-perf work from the last three releases.

## Why I missed this

Every native-path benchmark in BENCHMARK_HISTORY.md uses the full CLI flow which calls `set_raw_weights` internally during model load. The opt-in API was a flare-web-only gotcha that I didn't spot without digging into the WASM entrypoint. I'll add a docs note + a test.

## Test plan

- [x] `cargo build --release` passes
- [x] `wasm-pack build flare-web --target web --release` passes
- [x] Native aarch64 benchmarks unchanged (only touches FlareEngine wasm-bindgen entry)
- [ ] Post-merge: cut 0.2.3, BrowserAI bumps `@sauravpanda/flare@0.2.3`, re-benchmarks