### PR TITLE
Release flare-web 0.2.3

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
Bumps version to 0.2.3 and bundles PR #476 (auto-populate raw quantized weights in FlareEngine::load). This is the release that should actually demonstrate the WASM SIMD128 work shipped in 0.2.1 and 0.2.2 — those were unreachable without the opt-in load_raw_weights() call that external consumers weren't making.