### PR TITLE
Single-pass weight loading (fix 0.2.3 load-time regression)

### DIFF
--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -345,6 +345,26 @@ impl GgufFile {
         reader: &mut R,
         tensor_info: &TensorInfo,
     ) -> Result<Tensor, GgufError> {
+        let (tensor, _raw) = self.read_tensor_data_with_raw(reader, tensor_info, false)?;
+        Ok(tensor)
+    }
+
+    /// Like `read_tensor_data` but also optionally returns the raw
+    /// pre-dequantization bytes as a `RawWeight`.  When `keep_raw` is `true`
+    /// and the tensor format maps to a supported `WeightFormat`, the raw
+    /// bytes are kept alongside the dequantized `Tensor`.
+    ///
+    /// This exists so callers that need BOTH the f32 Tensor (for code paths
+    /// that aren't SIMD-accelerated) AND the raw quantized bytes (for the
+    /// int8 SIMD matvec kernels) can get both in a single pass over the
+    /// tensor data — no second seek + read, and no double allocation of the
+    /// read buffer.
+    pub fn read_tensor_data_with_raw<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        tensor_info: &TensorInfo,
+        keep_raw: bool,
+    ) -> Result<(Tensor, Option<RawWeight>), GgufError> {
         let absolute_offset = self.tensor_data_offset + tensor_info.offset;
         reader.seek(SeekFrom::Start(absolute_offset))?;
 
@@ -355,9 +375,33 @@ impl GgufFile {
         let numel = tensor_info.numel() as usize;
         let f32_data = dequantize_tensor(&raw, tensor_info.dtype, numel)?;
 
+        let raw_weight = if keep_raw {
+            quant_to_weight_format(tensor_info.dtype).map(|format| {
+                let num_rows = tensor_info.dimensions.last().copied().unwrap_or(1) as usize;
+                let weights_per_block = format.weights_per_block();
+                let col_elements = tensor_info
+                    .dimensions
+                    .iter()
+                    .rev()
+                    .skip(1)
+                    .product::<u64>()
+                    .max(1) as usize;
+                let blocks_per_row = col_elements.div_ceil(weights_per_block);
+                RawWeight {
+                    data: raw,
+                    format,
+                    num_rows,
+                    blocks_per_row,
+                }
+            })
+        } else {
+            None
+        };
+
         let shape: Vec<usize> = tensor_info.dimensions.iter().map(|&d| d as usize).collect();
-        Tensor::from_vec(f32_data, &shape)
-            .map_err(|e| GgufError::Io(io::Error::new(io::ErrorKind::InvalidData, e.to_string())))
+        let tensor = Tensor::from_vec(f32_data, &shape)
+            .map_err(|e| GgufError::Io(io::Error::new(io::ErrorKind::InvalidData, e.to_string())))?;
+        Ok((tensor, raw_weight))
     }
 
     /// Load all tensor data from the file, returning a map of name → Tensor.
@@ -371,6 +415,31 @@ impl GgufFile {
             tensors.insert(info.name.clone(), tensor);
         }
         Ok(tensors)
+    }
+
+    /// Load all tensor data in a single pass, returning both the f32 Tensor
+    /// map (for non-SIMD code paths) and a raw quantized-weight map (for
+    /// int8 SIMD matvec kernels).
+    ///
+    /// Tensor bytes are read exactly once: dequantized to f32 for the Tensor
+    /// and, for formats that map to a supported `WeightFormat`, retained as
+    /// raw bytes for the SIMD path.  This is the path `flare-web` uses so
+    /// that loading a quantized model doesn't pay for two full passes over
+    /// the tensor data.
+    pub fn load_all_tensors_with_raw<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+    ) -> Result<(HashMap<String, Tensor>, HashMap<String, RawWeight>), GgufError> {
+        let mut tensors = HashMap::new();
+        let mut raw_weights = HashMap::new();
+        for info in &self.tensors {
+            let (tensor, maybe_raw) = self.read_tensor_data_with_raw(reader, info, true)?;
+            if let Some(raw) = maybe_raw {
+                raw_weights.insert(info.name.clone(), raw);
+            }
+            tensors.insert(info.name.clone(), tensor);
+        }
+        Ok((tensors, raw_weights))
     }
 
     /// Read a single tensor's raw bytes without dequantizing, along with its

--- a/flare-loader/src/weights.rs
+++ b/flare-loader/src/weights.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io::{Read, Seek};
 
 use flare_core::config::{Architecture, ModelConfig};
-use flare_core::model::{ExpertWeights, LayerWeights, ModelWeights, MoeLayerWeights};
+use flare_core::model::{ExpertWeights, LayerWeights, ModelWeights, MoeLayerWeights, RawLayerWeights, RawWeight};
 use flare_core::tensor::Tensor;
 
 use crate::gguf::{GgufError, GgufFile};
@@ -62,6 +62,80 @@ where
         layers,
         output_norm,
         output_weight,
+    })
+}
+
+/// Load ModelWeights AND per-layer raw quantized weights in a single pass
+/// over the tensor data.
+///
+/// Use this when the caller wants both the f32 Tensor representation (for
+/// code paths that aren't SIMD-accelerated) AND the raw quantized bytes (for
+/// the int8 SIMD matvec kernels).  `load_model_weights` does one pass, and
+/// before this existed callers that also wanted raw weights had to do a
+/// second full pass via `load_raw_layer_weights` — roughly doubling load
+/// time on a 100+MB model.
+///
+/// Returns `(weights, Some(raw_layers))` when every layer has the full set
+/// of 7 raw tensors in a supported format.  If any layer is missing a raw
+/// tensor (e.g. mixed-quant model with a Q6_K layer), raw_layers is `None`
+/// and the caller should fall back to the f32 path.
+pub fn load_model_weights_with_raw<R: Read + Seek>(
+    gguf: &GgufFile,
+    reader: &mut R,
+) -> Result<(ModelWeights, Option<Vec<RawLayerWeights>>), GgufError> {
+    let (tensors, mut raw_map) = gguf.load_all_tensors_with_raw(reader)?;
+    let config = gguf.to_model_config()?;
+
+    let token_embedding = find_tensor(
+        &tensors,
+        &["token_embd.weight", "model.embed_tokens.weight"],
+    )?;
+    let output_norm = find_tensor(&tensors, &["output_norm.weight", "model.norm.weight"])?;
+    let output_weight = find_tensor(&tensors, &["output.weight", "lm_head.weight"])
+        .unwrap_or_else(|_| token_embedding.clone());
+
+    let total = config.num_layers;
+    let mut layers = Vec::with_capacity(total);
+    let mut raw_layers: Option<Vec<RawLayerWeights>> = Some(Vec::with_capacity(total));
+
+    for i in 0..total {
+        let layer = load_layer_weights(&tensors, i, &config)?;
+        layers.push(layer);
+
+        if let Some(ref mut rl) = raw_layers {
+            // Take ownership from raw_map to avoid cloning the Vec<u8> data;
+            // each RawWeight is ~10-30 MB.
+            match assemble_raw_layer(&mut raw_map, i) {
+                Some(raw_layer) => rl.push(raw_layer),
+                None => raw_layers = None,
+            }
+        }
+    }
+
+    let weights = ModelWeights {
+        token_embedding,
+        layers,
+        output_norm,
+        output_weight,
+    };
+    Ok((weights, raw_layers))
+}
+
+/// Take ownership of the 7 per-layer raw weight tensors from the raw-weight
+/// map.  Returns `None` and leaves the map partially drained if any are
+/// missing (callers discard the drained entries).
+fn assemble_raw_layer(
+    raw_map: &mut HashMap<String, RawWeight>,
+    i: usize,
+) -> Option<RawLayerWeights> {
+    Some(RawLayerWeights {
+        wq: raw_map.remove(&format!("blk.{i}.attn_q.weight"))?,
+        wk: raw_map.remove(&format!("blk.{i}.attn_k.weight"))?,
+        wv: raw_map.remove(&format!("blk.{i}.attn_v.weight"))?,
+        wo: raw_map.remove(&format!("blk.{i}.attn_output.weight"))?,
+        w_gate: raw_map.remove(&format!("blk.{i}.ffn_gate.weight"))?,
+        w_up: raw_map.remove(&format!("blk.{i}.ffn_up.weight"))?,
+        w_down: raw_map.remove(&format!("blk.{i}.ffn_down.weight"))?,
     })
 }
 

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -34,7 +34,9 @@ use flare_core::tokenizer::{BpeTokenizer, Tokenizer};
 use flare_gpu::WebGpuBackend;
 use flare_loader::gguf::{GgufFile, MetadataValue};
 use flare_loader::tokenizer::GgufVocab;
-use flare_loader::weights::{load_model_weights, load_model_weights_with_progress};
+use flare_loader::weights::{
+    load_model_weights, load_model_weights_with_progress, load_model_weights_with_raw,
+};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
@@ -452,30 +454,16 @@ impl FlareEngine {
         let config = gguf
             .to_model_config()
             .map_err(|e| JsError::new(&format!("Model config error: {e}")))?;
-        let weights = load_model_weights(&gguf, &mut reader)
+        // Single-pass load: dequantized f32 tensors and raw quantized bytes
+        // come back from one read of the tensor data region, so quantized
+        // models light up the WASM SIMD128 matvec path without paying for a
+        // second full pass over weight bytes.
+        let (weights, raw_layers) = load_model_weights_with_raw(&gguf, &mut reader)
             .map_err(|e| JsError::new(&format!("Weight load error: {e}")))?;
 
         let mut model = Model::new(config.clone(), weights);
 
-        // Auto-populate raw quantized weights so Q8_0 / Q4_K models take the
-        // hand-tuned WASM SIMD128 matvec paths by default.  This used to be
-        // opt-in via `load_raw_weights()`, which callers frequently forgot —
-        // the result was every model silently running on the f32 fallback.
-        // Failure here is non-fatal: f16 / unsupported-quant models stay on
-        // the f32 path.
-        let num_layers = config.num_layers;
-        let mut raw_layers = Vec::with_capacity(num_layers);
-        let mut all_ok = true;
-        for layer_idx in 0..num_layers {
-            match gguf.load_raw_layer_weights(&mut reader, layer_idx) {
-                Ok(Some(rw)) => raw_layers.push(rw),
-                _ => {
-                    all_ok = false;
-                    break;
-                }
-            }
-        }
-        if all_ok && raw_layers.len() == num_layers {
+        if let Some(raw_layers) = raw_layers {
             model.set_raw_weights(raw_layers);
         } else {
             web_sys::console::log_1(


### PR DESCRIPTION
## Summary

Follow-up to PR #476. That PR made raw quantized weights auto-populate on `load()` (unlocking the ~3× browser-perf win verified by BrowserAI) but did so with a second full pass over tensor bytes. Result on the 135M benchmark: decode 24.8 → 73.3 tok/s ✓ but model load regressed 4.5 → 7.1 s.

This PR folds raw extraction into the single pass `load_model_weights` already does.

## How it works

`read_tensor_data` already reads the raw bytes into a `Vec<u8>` before calling `dequantize_tensor`. Previously those raw bytes were dropped. Now, on request, they're kept alongside the dequantized `Tensor`.

Three new entry points:
- **`GgufFile::read_tensor_data_with_raw(reader, info, keep_raw)`** — same behavior as `read_tensor_data`, optionally returns the raw `RawWeight` too.
- **`GgufFile::load_all_tensors_with_raw(reader)`** — returns both `HashMap<String, Tensor>` and `HashMap<String, RawWeight>` from one scan.
- **`load_model_weights_with_raw(gguf, reader)`** — the caller-facing variant in `flare-loader/src/weights.rs`. Returns `(ModelWeights, Option<Vec<RawLayerWeights>>)`. If any required per-layer raw tensor is missing (mixed-quant model, unsupported format), the `Option` is `None` and the caller falls back to the f32 path.

`flare-web`'s `FlareEngine::load` uses `load_model_weights_with_raw` and dispatches on the `Option`, replacing the per-layer `load_raw_layer_weights` loop from PR #476.

## Memory handling

Takes ownership of raw weight tensors from the `HashMap<String, RawWeight>` via `remove()` rather than `clone()` — each `RawWeight` holds 10-30 MB of tensor bytes, and cloning would cause a momentary ~2× memory spike during assembly.

## Expected impact

On the BrowserAI 135M benchmark (all vs 0.2.2):

| Metric | 0.2.2 | 0.2.3 | **0.2.4 (this PR)** |
|---|---|---|---|
| Decode | 24.8 | 73.3 (+196%) | **~73 (unchanged)** |
| TTFT | 1244 ms | 399 ms (-68%) | **~400 ms (unchanged)** |
| Model load | 4.5 s | 7.1 s (regressed) | **~4.5 s (restored)** |

The decode/TTFT wins from 0.2.3 carry over; only the load time changes.

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test --workspace` — 622 tests pass, no regressions
- [x] `cargo build -p flarellm-core --target wasm32-unknown-unknown` passes
- [x] `wasm-pack build flare-web --target web --release` passes
- [ ] Post-merge: cut 0.2.4, BrowserAI re-benchmarks, confirm load time recovers