### PR TITLE
Release flare-web 0.2.4

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
Ships PR #478 — fold raw quantized weight extraction into the main load_model_weights pass. Restores the model-load time that 0.2.3 regressed (7.1 s → ~4.5 s expected on SmolLM2-135M) while preserving the 3× decode + TTFT win from 0.2.3.

This is purely a load-time optimization. No behavior changes at inference time.