### PR TITLE
Fix remaining CI -D warnings failures

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -649,15 +649,19 @@ impl ComputeBackend for CpuBackend {
                     quants: vec![0i8; blocks_per_row * Q8_0_BLOCK_SIZE],
                     blocks_per_row,
                 };
+                // `preq0` / `preq1` are always used (at least by the single-token
+                // fallback on non-SIMD targets).  `preq2` / `preq3` are only used
+                // by the 4-token SMMLA tile on aarch64 with FEAT_I8MM; gate them
+                // so non-aarch64 CI builds (with `-D warnings`) don't flag them.
                 let mut preq0 = mk_preq();
                 let mut preq1 = mk_preq();
+                #[cfg(target_arch = "aarch64")]
                 let mut preq2 = mk_preq();
+                #[cfg(target_arch = "aarch64")]
                 let mut preq3 = mk_preq();
 
                 #[cfg(target_arch = "aarch64")]
                 let has_smmla = std::arch::is_aarch64_feature_detected!("i8mm");
-                #[cfg(not(target_arch = "aarch64"))]
-                let has_smmla = false;
 
                 #[cfg(any(
                     target_arch = "aarch64",
@@ -788,9 +792,15 @@ impl ComputeBackend for CpuBackend {
                     quants: vec![0i8; preq_blocks * Q8_0_BLOCK_SIZE],
                     blocks_per_row: preq_blocks,
                 };
+                // preq0 / preq1 drive the 2-token loop on all arches (non-aarch64
+                // falls back to two sequential single-token matvecs that both
+                // still need a pre-quantized input).  preq2 / preq3 are only
+                // used by the 4-token tile on aarch64.
                 let mut preq0 = mk_preq();
                 let mut preq1 = mk_preq();
+                #[cfg(target_arch = "aarch64")]
                 let mut preq2 = mk_preq();
+                #[cfg(target_arch = "aarch64")]
                 let mut preq3 = mk_preq();
 
                 #[cfg(target_arch = "aarch64")]
@@ -4509,6 +4519,7 @@ const PREFETCH_BYTES: usize = 8192;
 ///
 /// 16 MB is a conservative estimate for Apple M-series chips (~48 MB total L2)
 /// leaving headroom for activations, KV cache, and other working data.
+#[cfg(target_arch = "aarch64")]
 const Q8_MATRIX_BYTE_THRESHOLD: usize = 16 * 1024 * 1024;
 
 /// Decide whether a matvec with the given weight matrix dimensions should use

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -34,9 +34,7 @@ use flare_core::tokenizer::{BpeTokenizer, Tokenizer};
 use flare_gpu::WebGpuBackend;
 use flare_loader::gguf::{GgufFile, MetadataValue};
 use flare_loader::tokenizer::GgufVocab;
-use flare_loader::weights::{
-    load_model_weights, load_model_weights_with_progress, load_model_weights_with_raw,
-};
+use flare_loader::weights::{load_model_weights_with_progress, load_model_weights_with_raw};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 


### PR DESCRIPTION
Follow-up to #480. CI uses `RUSTFLAGS='-D warnings'` which local builds don't match, so several pre-existing cleanup items were still failing the checks.

- Remove unused `load_model_weights` import in `flare-web/src/lib.rs` (its only caller was replaced in #478 by `load_model_weights_with_raw`)
- Gate `preq2`/`preq3` allocations in both Q8_0 and Q4_K branches of `batched_dequant_matmul` behind `#[cfg(target_arch = "aarch64")]` — these drive the 4-token SMMLA tile which is aarch64-only
- Drop the dead `#[cfg(not(target_arch = "aarch64"))] let has_smmla = false` line — after the WASM 2×2 tile dispatch landed, the value is only read inside the aarch64 branch
- Gate `Q8_MATRIX_BYTE_THRESHOLD` behind `#[cfg(target_arch = "aarch64")]` — only `should_use_q8_for_size`'s aarch64 branch reads it; non-aarch64 returns `true` unconditionally

Verified with `RUSTFLAGS='-D warnings' cargo check` on native, wasm32 flarellm-core, and wasm32 flarellm-web — all clean. 622 tests still pass.