### PR TITLE
Fix clippy 1.95 lints

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -1,3 +1,12 @@
+// This module is dense with block-wise index arithmetic (SIMD kernels,
+// Q8/Q4 block loops, KV-cache position indexing) where the explicit
+// `for i in 0..N` form is clearer than `.iter().enumerate().take(N)`.
+// Several intermediate results also have genuinely complex nested-tuple
+// types that are more readable spelled out than aliased.  Silence both
+// lints at module scope rather than sprinkling allows on every hot loop.
+#![allow(clippy::needless_range_loop)]
+#![allow(clippy::type_complexity)]
+
 use crate::config::{Architecture, ModelConfig};
 use crate::kv_cache::{KvCache, QuantizedKvCache};
 use crate::tensor::Tensor;
@@ -678,7 +687,7 @@ impl ComputeBackend for CpuBackend {
                 if has_smmla {
                     while b + 4 <= batch {
                         quantize_input_q8_0_into(
-                            &input[(b + 0) * in_cols..(b + 1) * in_cols],
+                            &input[b * in_cols..(b + 1) * in_cols],
                             &mut preq0,
                         );
                         quantize_input_q8_0_into(
@@ -711,7 +720,7 @@ impl ComputeBackend for CpuBackend {
                 // (SDOT/SMMLA) and wasm32 + SIMD128.
                 while b + 2 <= batch {
                     quantize_input_q8_0_into(
-                        &input[(b + 0) * in_cols..(b + 1) * in_cols],
+                        &input[b * in_cols..(b + 1) * in_cols],
                         &mut preq0,
                     );
                     quantize_input_q8_0_into(

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -1,3 +1,8 @@
+// `read_tensor_data_with_raw` returns a `Result<(Tensor, Option<RawWeight>)>`
+// which trips clippy's type_complexity — the tuple is clear in context and
+// changing it to a named alias would hurt readability.
+#![allow(clippy::type_complexity)]
+
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::collections::HashMap;
 use std::io::{self, Read, Seek, SeekFrom};


### PR DESCRIPTION
Clippy 1.95 (CI) is stricter than 1.94 (local). Module-scoped `#![allow]` for `needless_range_loop` and `type_complexity` on the kernel-heavy modules, plus drops a couple of `+ 0` no-ops clippy now flags as `identity_op`.