### PR TITLE
Slash TTFT: batched prefill + warm-start

### DIFF
--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -469,6 +469,17 @@ impl FlareEngine {
             );
         }
 
+        // Warm-start: run a throwaway forward pass now so the first real
+        // token after `begin_stream` doesn't pay the one-time cost of cold
+        // weight prefetches, cold branch predictors, and the JIT tiering
+        // up.  `Model::warmup` resets the KV cache afterwards so the engine
+        // is in the same state the caller would see without this call.
+        //
+        // This moves the TTFT cost from the first inference tick (where
+        // the user is waiting) into the load phase (where they're already
+        // waiting on the download).  Net user-visible latency is lower.
+        model.warmup();
+
         Ok(FlareEngine {
             model,
             chat_template,
@@ -1484,11 +1495,16 @@ impl FlareEngine {
     fn begin_stream_impl(&mut self, prompt_tokens: &[u32], max_tokens: u32) {
         let effective = self.with_bos(prompt_tokens);
         let t0 = now_ms();
-        let mut pos = 0usize;
-        for &tok in effective.iter() {
-            self.model.forward(tok, pos);
-            pos += 1;
-        }
+        // Batched prefill: one pass over all prompt tokens using the tuned
+        // batched_dequant_matmul path (2×4 tile on aarch64 / 2×2 on wasm+
+        // simd128) instead of N sequential single-token forward() calls.
+        // Dramatically lower TTFT on multi-token prompts.
+        let pos = if effective.is_empty() {
+            0
+        } else {
+            let _ = self.model.forward_prefill(&effective);
+            effective.len()
+        };
         self.last_prefill_ms = now_ms() - t0;
         self.last_decode_ms = 0.0;
         self.last_tokens_generated = 0;
@@ -1526,12 +1542,14 @@ impl FlareEngine {
         }
         let last_idx = effective.len() - 1;
         let t0 = now_ms();
-        // Prefill all tokens except the last.
-        let mut pos = 0usize;
-        for &tok in &effective[..last_idx] {
-            self.model.forward(tok, pos);
-            pos += 1;
-        }
+        // Batched prefill for the all-but-last tokens; the last prompt token
+        // is held back so next_token() runs it at its correct RoPE position.
+        let pos = if last_idx == 0 {
+            0
+        } else {
+            let _ = self.model.forward_prefill(&effective[..last_idx]);
+            last_idx
+        };
         self.last_prefill_ms = now_ms() - t0;
         self.last_decode_ms = 0.0;
         self.last_tokens_generated = 0;


### PR DESCRIPTION
Two wins targeting the 598 ms TTFT that BrowserAI flagged as our last major gap vs MLC (24 ms).

## 1. Batched prefill in `begin_stream`

`begin_stream_impl` was doing **N sequential single-token forward() calls** to prefill prompt tokens — i.e. the decode path, one token at a time:

```rust
for &tok in effective.iter() {
    self.model.forward(tok, pos);
    pos += 1;
}
```

Every one of those calls re-streams the full weight tensor for each matmul. For a 6-token prompt on 1B Q8 that's 6× the weight bandwidth the batched path uses.

Replaced with a single `forward_prefill` call that goes through `batched_dequant_matmul` — which on aarch64 uses the 2×4 SMMLA tile (PR #465) and on wasm32+simd128 uses the 2×2 WASM SIMD tile (PR #472). Same weight stream amortized across all prompt tokens.

Same fix applied to `begin_stream_healed_impl` (which intentionally holds the last prompt token for decode).

## 2. Warm-up at load

`Model::warmup()` already existed (it does one throwaway `forward(0, 0)` + KV reset) but was never called from `FlareEngine::load`. Wired it in.

This moves the one-time cost of cold weight prefetches, cold branch predictors, and JIT tier-up from the user-visible first inference tick into the load phase (where the user is already waiting on the download). Net user-visible latency is strictly lower.

## Expected impact

BrowserAI SmolLM2-135M TTFT:

| | 0.2.4 | 0.2.5 (predicted) |
|---|---|---|
| TTFT | 598 ms | **100-200 ms** |
| Decode | 67 tok/s | ~same (already hit the SIMD tile path) |
| Load | 2.2 s | +~50 ms from warmup; still well under 3 s |

Note: the benchmark measures TTFT *including* prefill, and a 6-token prompt at ~100 ms per token on the old serial path is consistent with the observed 598 ms (with some variance).

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test --workspace` — no regressions
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `wasm-pack build flare-web --target web --release` passes
- [ ] Post-merge: ship 0.2.5, BrowserAI re-benchmarks, confirm TTFT drops