### PR TITLE
Release flare-web 0.2.5

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
Ships [PR #485](https://github.com/sauravpanda/flarellm/pull/485) — batched prefill via forward_prefill + warm-up at load.

Prompt tokens now go through the tuned batched_dequant_matmul path (2×4 SMMLA on aarch64, 2×2 WASM SIMD on browser) instead of N sequential forward() calls. Predicted TTFT drop from 598 ms to ~100-200 ms on SmolLM2-135M.

No breaking API changes.