### PR TITLE
Release flare-web 0.2.6

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
Ships [PR #487](https://github.com/sauravpanda/flarellm/pull/487) — drops the warm-up from FlareEngine::load. Trade measured on BrowserAI's 0.2.5 benchmark: warmup cost ~500ms load for <100ms TTFT benefit. Removing it is a net UX win (load is one-shot, TTFT is per-prompt).