### PR TITLE
Restore warm-up in FlareEngine::load (revert #487)

### DIFF
--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -469,14 +469,17 @@ impl FlareEngine {
             );
         }
 
-        // Note: no explicit warm-up here.  The first `begin_stream` call
-        // runs `forward_prefill` over the prompt, which pages in the same
-        // weight pages and warms the same CPU caches as a synthetic warm-up
-        // forward would.  Adding a throwaway forward(0, 0) at load time cost
-        // ~500 ms of load latency for <100 ms of TTFT benefit (measured on
-        // BrowserAI's SmolLM2-135M benchmark), which is a net UX loss: load
-        // is a one-shot visible wait, and the batched prefill already
-        // handles the cold-cache work on the first real request.
+        // Warm-up: run a throwaway forward(0, 0) + KV reset so the decode
+        // path's hot kernels are fully tier-up'd and weight pages are resident
+        // before the first real inference.
+        //
+        // I initially removed this in 0.2.6 thinking batched prefill would
+        // cover it — it doesn't.  Dropping warmup regressed SmolLM2-135M
+        // decode from a stable 72 tok/s (0.2.5) to 40 tok/s averaged with a
+        // 20-73 range (0.2.6): the first few decode calls run cold and drag
+        // the average down.  Load-time cost is ~500 ms; paid once per
+        // session, saves ~30 tok/s on every decoded token — clear net win.
+        model.warmup();
 
         Ok(FlareEngine {
             model,


### PR DESCRIPTION
Revert of #487. The BrowserAI 0.2.6 benchmark showed dropping warmup wasn't the net UX win I predicted — it was a real regression:

| Metric | 0.2.5 (warmup) | 0.2.6 (no warmup) |
|---|---|---|
| Decode tok/s | **72 (stable: 72.0-72.7)** | 40 (range: 19.8-73.2) |
| TTFT | **136 ms (stable: 134-139)** | 401 ms (range: 132-542) |
| Load | 2.7 s | 2.9 s |

The blown-out variance on decode and TTFT is the tell: without warmup, the first few decode calls land cold and drag the averages down. Warmup tier-ups the JIT and pages in weights so every inference starts warm.

Net: the 500ms warmup cost buys ~30 tok/s stable decode and ~265ms stable TTFT — very clearly the right trade.