### PR TITLE
Release flare-web 0.2.7

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
Reverts the 0.2.6 warmup removal. Restores 0.2.5's stable 72 tok/s decode and 136 ms TTFT.

The 500 ms load cost turns out to buy ~30 tok/s on every decoded token plus stable TTFT — that's worth it.