### PR TITLE
Upload weights to GPU automatically after init_gpu

### DIFF
--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -540,6 +540,14 @@ impl FlareEngine {
         match WebGpuBackend::new().await {
             Ok(gpu) => {
                 self.model.set_backend(Box::new(gpu));
+                // Upload the raw quantized weights (populated in `load`) to
+                // GPU buffers so forward() takes the fused single-encoder
+                // path instead of falling back to CPU SIMD.  Without this,
+                // the GPU backend is active but `has_gpu_weights() == false`
+                // and every matmul still runs on the CPU — silently wasting
+                // the WebGPU init.  No-ops if raw weights aren't present or
+                // the backend doesn't support GPU forward.
+                self.model.upload_weights_to_gpu();
                 true
             }
             Err(_) => false,
@@ -579,6 +587,9 @@ impl FlareEngine {
         match result {
             Ok(gpu) => {
                 self.model.set_backend(Box::new(gpu));
+                // See `init_gpu` — upload raw quantized weights to GPU buffers
+                // so forward() takes the fused single-encoder path.
+                self.model.upload_weights_to_gpu();
                 true
             }
             Err(_) => false,


### PR DESCRIPTION
## Summary

The entire WebGPU backend in `flare-gpu` has been production-complete this whole time. The fused single-encoder `forward_single_token_gpu` at `flare-gpu/src/backend.rs:3765` runs the full transformer in one command encoder — it just needed the weight bytes uploaded to GPU buffers before the first `forward()` call.

### The actual bug

`FlareEngine::init_gpu` swaps the backend to WebGPU and initializes the GPU KV cache, but **never calls `Model::upload_weights_to_gpu()`**. Combined with #476 (auto-populated `raw_weights` on load), the flow was:

| Step | State |
|---|---|
| `FlareEngine::load` | `self.raw_weights` populated on CPU ✓ |
| `engine.init_gpu()` | Backend swapped to GPU ✓ |
| | GPU KV cache initialized ✓ |
| | **Weights NOT uploaded to GPU buffers ✗** |
| `forward()` | `backend.has_gpu_weights() == false` → falls back to CPU SIMD via `has_q8` path |

So every BrowserAI benchmark we've been running — where they DO call `init_gpu` — has been measuring the **CPU SIMD ceiling** (72 tok/s on SmolLM2-135M), not WebGPU. The WebGPU backend has been active but running zero matmuls.

### The fix

After `set_backend(gpu)`, call `self.model.upload_weights_to_gpu()` in both `init_gpu` and `init_gpu_with_cache`. Method is a no-op when raw weights aren't present or the backend doesn't support GPU forward, so no new failure modes for callers without raw weights.

```rust
match WebGpuBackend::new().await {
    Ok(gpu) => {
        self.model.set_backend(Box::new(gpu));
        self.model.upload_weights_to_gpu();  // NEW
        true
    }
    Err(_) => false,
}
```

## Expected impact on BrowserAI benchmark

| Metric | 0.2.7 (CPU SIMD) | 0.2.8 (WebGPU, predicted) | MLC reference |
|---|---|---|---|
| Decode | 72 tok/s | **90-120 tok/s** | 91 tok/s |
| TTFT | 136 ms | ~50-100 ms | 28 ms |
| Load | 2.7 s | ~3.0 s (GPU weight upload adds some) | 0.4 s |

Beating MLC on decode is plausible because `forward_single_token_gpu` builds the whole layer stack into one command encoder — MLC's TVM-compiled kernels are well-tuned but they're individual dispatches.

## Risks

- **First forward pass after init is cold** — all WGSL shaders compile on first use, 200 ms-2 s. The existing `warmup()` in `Model` absorbs this into load time. Load time regression from ~2.7 s to maybe 3-4 s on first run; second-run loads with pipeline cache (`init_gpu_with_cache`) will be faster.
- **Adapter may not actually provide WebGPU in the benchmark browser** — if `init_gpu()` fails, `upload_weights_to_gpu` is never called and behavior is identical to 0.2.7. Safe fallback.
- **1B models may OOM on mobile GPU** — total weight buffer is ~1 GB for 1B Q8_0. Not a 135M concern. Follow-up work for mobile if needed.

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test --workspace` — no regressions
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `wasm-pack build flare-web --target web --release` passes
- [ ] Post-merge: ship 0.2.8, BrowserAI re-benchmarks — expect decode 90+ tok/s