### PR TITLE
Add backend_info() diagnostic to FlareEngine

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -546,6 +546,14 @@ pub trait ComputeBackend: Send + Sync {
     ) -> Option<Vec<f32>> {
         None
     }
+
+    /// Short identifier for this backend, used in diagnostics.
+    ///
+    /// Defaults to `"cpu"`. GPU backends should override to return e.g.
+    /// `"webgpu"` so consumers can confirm which compute path is active.
+    fn name(&self) -> &'static str {
+        "cpu"
+    }
 }
 
 /// Default CPU compute backend. Uses optimized scalar loops.

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -4970,6 +4970,10 @@ impl ComputeBackend for WebGpuBackend {
         WebGpuBackend::has_gpu_weights(self)
     }
 
+    fn name(&self) -> &'static str {
+        "webgpu"
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn forward_single_token_gpu(
         &self,

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -609,6 +609,34 @@ impl FlareEngine {
         self.model.backend().pipeline_cache_data()
     }
 
+    /// Diagnostic snapshot of the current compute backend as a JSON string.
+    ///
+    /// Returns an object with:
+    /// - `backend` — backend identifier (`"cpu"` or `"webgpu"`).
+    /// - `has_gpu_weights` — `true` once weights have been uploaded to GPU buffers.
+    /// - `has_gpu_kv_cache` — `true` once GPU-resident KV storage is initialised.
+    /// - `has_raw_weights` — `true` once raw quantized weights are held on the CPU side.
+    ///
+    /// Benchmarks can call this after `init_gpu()` to confirm WebGPU is
+    /// actually driving inference instead of silently falling back to CPU.
+    ///
+    /// ```javascript
+    /// await engine.init_gpu();
+    /// console.log(JSON.parse(engine.backend_info()));
+    /// // { backend: "webgpu", has_gpu_weights: true, has_gpu_kv_cache: true, has_raw_weights: true }
+    /// ```
+    #[wasm_bindgen]
+    pub fn backend_info(&self) -> String {
+        let backend = self.model.backend();
+        format!(
+            "{{\"backend\":\"{}\",\"has_gpu_weights\":{},\"has_gpu_kv_cache\":{},\"has_raw_weights\":{}}}",
+            backend.name(),
+            backend.has_gpu_weights(),
+            backend.has_gpu_kv_cache(),
+            self.model.has_raw_weights()
+        )
+    }
+
     /// Run a single dummy forward pass to pre-compile WebGPU shader pipelines.
     ///
     /// WebGPU (and wgpu on native) compiles shader pipelines lazily on the


### PR DESCRIPTION
## Summary
- New `FlareEngine.backend_info()` returning a JSON string with `backend`, `has_gpu_weights`, `has_gpu_kv_cache`, `has_raw_weights`
- Adds `ComputeBackend::name()` trait method (default `"cpu"`); `WebGpuBackend` overrides to `"webgpu"`
- Zero behavior change — read-only introspection

## Motivation
Before 0.2.8, `init_gpu()` swapped the backend but never uploaded weights, so `forward()` silently fell back to CPU SIMD. We only noticed because the benchmark didn't move. With this diagnostic consumers (BrowserAI benchmark, user apps) can assert WebGPU is active in one line:

```js
const info = JSON.parse(engine.backend_info());
if (info.backend !== "webgpu" || !info.has_gpu_weights) {
  console.warn("Flare fell back to CPU:", info);
}
```

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo check -p flarellm-web --target wasm32-unknown-unknown`
- [x] `cargo clippy -D warnings` on flare-core/gpu/web
- [x] `cargo test -p flarellm-core --lib` — 252 passing
