### PR TITLE
Release flare-web 0.2.9

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
## Summary
- Bump `flare-web` npm package to **0.2.9**
- Bundles #493: `FlareEngine.backend_info()` diagnostic

## Why now
0.2.8 benchmark (SmolLM2-135M, 3 runs) came in at **72.0 tok/s (71.2–72.7)** — unchanged from 0.2.7. Tight variance and identical TTFT (135ms) means WebGPU is not actually driving inference; we're still on the CPU SIMD path. 0.2.9 ships the diagnostic so BrowserAI can log backend state after `init_gpu()` and pin down whether:

1. `webgpu_available()` short-circuits,
2. `WebGpuBackend::new()` fails silently, or
3. `upload_weights_to_gpu()` is a no-op (raw_weights absent or dispatch mismatch).

## Consumer snippet
```js
await engine.init_gpu();
const info = JSON.parse(engine.backend_info());
console.log("Flare backend:", info);
// { backend: "webgpu" | "cpu",
//   has_gpu_weights: bool,
//   has_gpu_kv_cache: bool,
//   has_raw_weights: bool }
```

## Test plan
- [x] workspace builds (native + wasm32)
- [x] clippy `-D warnings` clean
- [x] `cargo test -p flarellm-core --lib` — 252 passing
- [ ] manual `npm publish --otp=<code>` after merge
