### PR TITLE
Release flare-web 0.2.10

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
## Summary
- Bump `flare-web` npm package to **0.2.10**
- Bundles #495: per-phase prefill profiling

## Why now
0.2.9's `backend_info()` confirmed WebGPU is active for SmolLM2-135M decode, but TTFT stayed at 134ms (vs MLC's 15ms). Instead of guessing which kernel is slow, 0.2.10 ships opt-in per-phase timing so the next BrowserAI benchmark can log exactly where the 134ms goes.

## Consumer snippet
```js
await engine.init_gpu();
engine.enable_prefill_profiling();
// run inference...
console.log("[flare] prefill profile:", JSON.parse(engine.prefill_profile_json()));
engine.disable_prefill_profiling();
```

Returns:
```json
{ "seq_len": 10, "num_layers": 30,
  "embed_ms": 0.2, "attn_norm_ms": 4.1, "qkv_proj_ms": 18.6,
  "rope_ms": 6.0, "attention_ms": 42.3, "attn_out_proj_ms": 8.9,
  "ffn_norm_ms": 4.0, "gate_up_ms": 15.4, "silu_mul_ms": 1.8,
  "down_ms": 9.2, "residual_ms": 0.8, "kv_write_ms": 2.1,
  "final_norm_ms": 0.1, "lm_head_ms": 20.5, "total_ms": 134.0 }
```
(numbers illustrative — actual values determine the next optimisation)

## Test plan
- [x] workspace builds (native + wasm32)
- [x] clippy `-D warnings` clean
- [x] `cargo test -p flarellm-core --lib` — 252 passing
- [x] rustdoc passes
- [ ] manual `npm publish --otp=<code>` after merge
