### PR TITLE
Use worker-safe clock for prefill profiling (0.2.11)

### DIFF
--- a/flare-web/Cargo.toml
+++ b/flare-web/Cargo.toml
@@ -24,6 +24,8 @@ web-sys = { workspace = true, features = [
     "Navigator",
     "Window",
     "Worker",
+    "WorkerGlobalScope",
+    "DedicatedWorkerGlobalScope",
     "Request",
     "Response",
     "Cache",

--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -188,15 +188,27 @@ fn now_ms_f64() -> f64 {
 
 /// Return the current wall-clock time in milliseconds.
 ///
-/// In WASM uses `performance.now()` for sub-millisecond accuracy.
+/// In WASM, tries `window.performance.now()` on the main thread first, then
+/// `self.performance.now()` when running inside a Web Worker (where `window`
+/// is undefined), finally falling back to `Date.now()` if neither is available.
+/// Sub-millisecond when `performance` is reachable, millisecond otherwise.
 /// In native builds uses `SystemTime` for coarser but portable timing.
 fn now_ms() -> f64 {
     #[cfg(target_arch = "wasm32")]
     {
-        web_sys::window()
-            .and_then(|w| w.performance())
-            .map(|p| p.now())
-            .unwrap_or(0.0)
+        if let Some(perf) = web_sys::window().and_then(|w| w.performance()) {
+            return perf.now();
+        }
+        // Worker context: `window` is undefined but the worker's global scope
+        // has its own `performance` object.  Reach it via `js_sys::global()`
+        // cast to `WorkerGlobalScope`.
+        if let Ok(scope) = js_sys::global().dyn_into::<web_sys::WorkerGlobalScope>() {
+            if let Some(perf) = scope.performance() {
+                return perf.now();
+            }
+        }
+        // Last resort — Date.now has only 1ms resolution but always works.
+        js_sys::Date::now()
     }
     #[cfg(not(target_arch = "wasm32"))]
     {


### PR DESCRIPTION
## Summary
- Fix `now_ms()` to work in Web Worker contexts
- Bump `flare-web` npm package to **0.2.11**

## Why
0.2.10 added per-phase profiling, but the BrowserAI benchmark reported:
```
[Flare] prefill profile: { seq_len: 0, num_layers: 0, embed_ms: 0, ... }
```

Root cause: `now_ms()` was reading `window.performance`, which is `undefined` inside a Web Worker. Since Flare runs in a Worker in all real consumers (per CLAUDE.md), every `performance.now()` call returned `0.0` and every phase delta came out as zero. The profile was silently "working" but recording nothing.

## Fix
`now_ms()` now falls through three options in order:
1. `window.performance.now()` — main-thread (unchanged)
2. `(self as WorkerGlobalScope).performance.now()` — worker context
3. `Date.now()` — last-resort fallback (1 ms granularity)

Adds `WorkerGlobalScope` and `DedicatedWorkerGlobalScope` to the `web-sys` feature list.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo check -p flarellm-web --target wasm32-unknown-unknown`
- [x] `cargo clippy -p flarellm-web --target wasm32-unknown-unknown -D warnings`
- [ ] manual `npm publish --otp=<code>` after merge
- [ ] BrowserAI benchmark with 0.2.11 → confirm non-zero phase timings
