### PR TITLE
webgpu_available(): detect WebGPU in Worker contexts (0.2.12)

### DIFF
--- a/flare-web/Cargo.toml
+++ b/flare-web/Cargo.toml
@@ -26,6 +26,7 @@ web-sys = { workspace = true, features = [
     "Worker",
     "WorkerGlobalScope",
     "DedicatedWorkerGlobalScope",
+    "WorkerNavigator",
     "Request",
     "Response",
     "Cache",

--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -59,17 +59,31 @@ pub fn init_thread_pool(num_threads: usize) -> Result<(), JsValue> {
 }
 
 /// Check if WebGPU is available in the current browser.
+///
+/// Works on both the main thread (reads `window.navigator`) and inside a
+/// dedicated Web Worker (reads `self.navigator` via `WorkerGlobalScope`).
+/// Returning `true` means `WebGpuBackend::new()` has a chance of succeeding;
+/// it does not guarantee an adapter or device will actually be granted.
 #[wasm_bindgen]
 pub fn webgpu_available() -> bool {
-    let window = match web_sys::window() {
-        Some(w) => w,
-        None => return false,
-    };
-
-    let navigator: JsValue = window.navigator().into();
-    js_sys::Reflect::get(&navigator, &JsValue::from_str("gpu"))
-        .map(|v| !v.is_undefined() && !v.is_null())
-        .unwrap_or(false)
+    // Try main-thread navigator first.
+    if let Some(nav) = web_sys::window().map(|w| JsValue::from(w.navigator())) {
+        if js_sys::Reflect::get(&nav, &JsValue::from_str("gpu"))
+            .map(|v| !v.is_undefined() && !v.is_null())
+            .unwrap_or(false)
+        {
+            return true;
+        }
+    }
+    // Worker context: `window` is undefined but the worker's global scope
+    // has its own navigator with `.gpu` in Chrome 113+, Safari 17.4+, etc.
+    if let Ok(scope) = js_sys::global().dyn_into::<web_sys::WorkerGlobalScope>() {
+        let nav: JsValue = scope.navigator().into();
+        return js_sys::Reflect::get(&nav, &JsValue::from_str("gpu"))
+            .map(|v| !v.is_undefined() && !v.is_null())
+            .unwrap_or(false);
+    }
+    false
 }
 
 /// Check if WebNN is available in the current browser.


### PR DESCRIPTION
## Summary
- `webgpu_available()` now detects WebGPU from Web Worker contexts as well as the main thread
- Bumps `flare-web` to **0.2.12**

## Motivation
The 0.2.11 release fixed the profile clock in workers but left a sibling bug: `webgpu_available()` read `window.navigator.gpu`, which is `undefined` inside a dedicated Worker. `FlareEngine.init_gpu()` short-circuits on that check, so **every worker-based consumer was silently falling back to CPU SIMD.**

Observed on the latest BrowserAI benchmark (post-#309 worker wiring):
```
backend_info: {backend: "cpu", has_gpu_weights: false, has_gpu_kv_cache: false, ...}
Flare decode:  20.9 tok/s   (vs 70 tok/s on main thread with GPU active)
Flare TTFT:    448 ms       (vs 156 ms)
```

## Fix
`webgpu_available()` falls through two sources in order:
1. `window.navigator.gpu` — main thread (unchanged)
2. `(self as WorkerGlobalScope).navigator.gpu` — worker context

Uses `Reflect.get` on the resulting `JsValue` so the check stays version-tolerant. The actual `wgpu::Instance::request_adapter` call already works from workers — only the pre-flight gate was broken.

Adds `WorkerNavigator` to the `web-sys` feature list.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo check -p flarellm-web --target wasm32-unknown-unknown`
- [x] `cargo clippy -D warnings` on flare-web
- [x] `cargo test -p flarellm-core --lib` — 252 passing
- [ ] Manual npm publish + BrowserAI re-benchmark — should recover the 70 tok/s decode + ~150 ms TTFT on Flare
