### PR TITLE
Chunked GGUF load + async-readback primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,10 +443,13 @@ dependencies = [
  "byteorder",
  "flarellm-core",
  "flarellm-loader",
+ "futures-channel",
  "half",
  "log",
  "pollster",
  "thiserror 2.0.18",
+ "wasm-bindgen-futures",
+ "web-sys",
  "wgpu",
 ]
 

--- a/flare-gpu/Cargo.toml
+++ b/flare-gpu/Cargo.toml
@@ -21,6 +21,11 @@ byteorder = { workspace = true }
 bytemuck = { workspace = true }
 half = { workspace = true }
 pollster = "0.4"
+futures-channel = "0.3"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = { workspace = true, features = ["console"] }
+wasm-bindgen-futures = "0.4"
 
 [dev-dependencies]
 pollster = "0.4"

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -333,6 +333,66 @@ impl WebGpuBackend {
     ///
     /// The staging buffer used for readback is pooled; it is returned to the
     /// pool after the GPU results are copied to the returned `Vec<f32>`.
+    /// Async variant of [`Self::dispatch_and_readback`] that awaits the WebGPU
+    /// mapping promise via `futures_channel::oneshot` instead of blocking on a
+    /// sync `std::sync::mpsc` channel.  This is the only pattern that works on
+    /// wasm32 — the `map_async` callback is serviced by JS microtasks which
+    /// don't run during a sync WASM call.  On native the `.await` completes
+    /// as soon as `device.poll` fires the callback, so it's a drop-in for the
+    /// sync path there too.
+    ///
+    /// Not yet wired into the GPU forward paths — the full propagation of
+    /// `async fn` through `ComputeBackend`, `Model::forward_prefill`, and the
+    /// `wasm-bindgen` bridge is a larger refactor.  Keeping this primitive in
+    /// place so the refactor is a mechanical propagation rather than a
+    /// design-from-scratch.
+    #[allow(dead_code)]
+    async fn dispatch_and_readback_async(
+        &self,
+        pipeline: &wgpu::ComputePipeline,
+        bind_group: &wgpu::BindGroup,
+        dispatch: [u32; 3],
+        output_buf: &wgpu::Buffer,
+        output_size: u64,
+    ) -> Vec<f32> {
+        let staging = self.pool.get_staging(&self.device, output_size);
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: None,
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, bind_group, &[]);
+            pass.dispatch_workgroups(dispatch[0], dispatch[1], dispatch[2]);
+        }
+        encoder.copy_buffer_to_buffer(output_buf, 0, &staging, 0, output_size);
+        self.queue.submit(Some(encoder.finish()));
+
+        let slice = staging.slice(..);
+        let (tx, rx) = futures_channel::oneshot::channel();
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = tx.send(result);
+        });
+        // Native: device.poll drains the callback.  Wasm32: no-op; we rely on
+        // `rx.await` yielding microtasks so the browser can fire map_async.
+        #[cfg(not(target_arch = "wasm32"))]
+        self.device.poll(wgpu::Maintain::Wait);
+        rx.await
+            .expect("GPU readback channel closed")
+            .expect("GPU readback failed");
+
+        let data = slice.get_mapped_range();
+        let result: Vec<f32> = bytemuck::cast_slice(&data).to_vec();
+        drop(data);
+        staging.unmap();
+        self.pool.return_staging(staging);
+        result
+    }
+
     fn dispatch_and_readback(
         &self,
         pipeline: &wgpu::ComputePipeline,

--- a/flare-loader/src/gguf.rs
+++ b/flare-loader/src/gguf.rs
@@ -478,6 +478,69 @@ impl GgufFile {
         Ok((tensors, raw_weights))
     }
 
+    /// Decode a single tensor from its pre-read bytes.
+    ///
+    /// This is the "no Reader" form of [`Self::read_tensor_data_with_raw_opt`]:
+    /// callers stream the bulk GGUF from JS and hand WASM one tensor's bytes
+    /// at a time, so there's no need for a seekable reader and no copy of the
+    /// full file is held in WASM memory.  The return tuple mirrors
+    /// `read_tensor_data_with_raw_opt`.
+    pub fn decode_tensor_from_bytes(
+        tensor_info: &TensorInfo,
+        raw_bytes: &[u8],
+        keep_raw: bool,
+        skip_f32: bool,
+    ) -> Result<(Tensor, Option<RawWeight>), GgufError> {
+        let byte_size = tensor_info.byte_size() as usize;
+        if raw_bytes.len() != byte_size {
+            return Err(GgufError::InvalidFormat(format!(
+                "tensor {} byte length mismatch: got {}, expected {}",
+                tensor_info.name,
+                raw_bytes.len(),
+                byte_size
+            )));
+        }
+
+        let format = quant_to_weight_format(tensor_info.dtype);
+        let can_skip = skip_f32 && keep_raw && format.is_some();
+        let shape: Vec<usize> = tensor_info.dimensions.iter().map(|&d| d as usize).collect();
+        let numel = tensor_info.numel() as usize;
+
+        let tensor = if can_skip {
+            Tensor::from_vec(Vec::new(), &shape)
+                .unwrap_or_else(|_| Tensor::from_vec(Vec::new(), &[0]).expect("0-el tensor"))
+        } else {
+            let f32_data = dequantize_tensor(raw_bytes, tensor_info.dtype, numel)?;
+            Tensor::from_vec(f32_data, &shape).map_err(|e| {
+                GgufError::Io(io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+            })?
+        };
+
+        let raw_weight = if keep_raw {
+            format.map(|format| {
+                let num_rows = tensor_info.dimensions.last().copied().unwrap_or(1) as usize;
+                let weights_per_block = format.weights_per_block();
+                let col_elements = tensor_info
+                    .dimensions
+                    .iter()
+                    .rev()
+                    .skip(1)
+                    .product::<u64>()
+                    .max(1) as usize;
+                let blocks_per_row = col_elements.div_ceil(weights_per_block);
+                RawWeight {
+                    data: raw_bytes.to_vec(),
+                    format,
+                    num_rows,
+                    blocks_per_row,
+                }
+            })
+        } else {
+            None
+        };
+        Ok((tensor, raw_weight))
+    }
+
     /// Like [`Self::read_tensor_data_with_raw`] but with an extra flag that
     /// skips the f32 dequantization step when the raw bytes are retained.
     /// Returns an empty-data `Tensor` with the correct shape when skipped.

--- a/flare-loader/src/weights.rs
+++ b/flare-loader/src/weights.rs
@@ -108,25 +108,46 @@ pub fn load_model_weights_with_raw_opt<R: Read + Seek>(
     reader: &mut R,
     skip_f32_for_matmul: bool,
 ) -> Result<(ModelWeights, Option<Vec<RawLayerWeights>>), GgufError> {
-    let (tensors, mut raw_map) = if skip_f32_for_matmul {
-        let mut skip: HashSet<String> = HashSet::new();
-        for i in 0..gguf.to_model_config()?.num_layers {
-            for suffix in [
-                "attn_q",
-                "attn_k",
-                "attn_v",
-                "attn_output",
-                "ffn_gate",
-                "ffn_up",
-                "ffn_down",
-            ] {
-                skip.insert(format!("blk.{i}.{suffix}.weight"));
-            }
-        }
+    let (tensors, raw_map) = if skip_f32_for_matmul {
+        let skip = matmul_skip_set(gguf)?;
         gguf.load_all_tensors_with_raw_skipping_f32(reader, &skip)?
     } else {
         gguf.load_all_tensors_with_raw(reader)?
     };
+    assemble_model_weights_from_maps(gguf, tensors, raw_map)
+}
+
+/// Name set of the 7 per-layer matmul tensors (wq/wk/wv/wo/w_gate/w_up/w_down)
+/// for every layer in the model.  Passed to
+/// [`GgufFile::load_all_tensors_with_raw_skipping_f32`] to skip the f32 dequant
+/// pass for those weights when a raw-dispatchable backend will serve them.
+pub fn matmul_skip_set(gguf: &GgufFile) -> Result<HashSet<String>, GgufError> {
+    let mut skip: HashSet<String> = HashSet::new();
+    for i in 0..gguf.to_model_config()?.num_layers {
+        for suffix in [
+            "attn_q",
+            "attn_k",
+            "attn_v",
+            "attn_output",
+            "ffn_gate",
+            "ffn_up",
+            "ffn_down",
+        ] {
+            skip.insert(format!("blk.{i}.{suffix}.weight"));
+        }
+    }
+    Ok(skip)
+}
+
+/// Assemble `ModelWeights` + per-layer raw weight bundles from pre-loaded
+/// `tensors` and `raw_map` maps.  Exposed so streaming / chunked loaders can
+/// reuse the layer-name lookup + raw-weight extraction logic after populating
+/// the maps tensor-by-tensor.
+pub fn assemble_model_weights_from_maps(
+    gguf: &GgufFile,
+    tensors: HashMap<String, flare_core::tensor::Tensor>,
+    mut raw_map: HashMap<String, RawWeight>,
+) -> Result<(ModelWeights, Option<Vec<RawLayerWeights>>), GgufError> {
     let config = gguf.to_model_config()?;
 
     let token_embedding = find_tensor(

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -22,6 +22,7 @@
 //! const tokens = engine.generate_tokens(ids, 50);
 //! ```
 
+use std::collections::HashMap;
 use std::io::Cursor;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -34,7 +35,10 @@ use flare_core::tokenizer::{BpeTokenizer, Tokenizer};
 use flare_gpu::WebGpuBackend;
 use flare_loader::gguf::{GgufFile, MetadataValue};
 use flare_loader::tokenizer::GgufVocab;
-use flare_loader::weights::{load_model_weights_with_progress, load_model_weights_with_raw_opt};
+use flare_loader::weights::{
+    assemble_model_weights_from_maps, load_model_weights_with_progress,
+    load_model_weights_with_raw_opt, matmul_skip_set,
+};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
@@ -445,8 +449,271 @@ pub struct FlareEngine {
     utf8_byte_buf: Vec<u8>,
 }
 
+// ---------------------------------------------------------------------------
+// Chunked load API — state machine for UI-responsive GGUF parse
+// ---------------------------------------------------------------------------
+
+/// In-progress GGUF load.  Breaks the monolithic [`FlareEngine::load`] into
+/// per-tensor steps so JS can `await Promise.resolve()` between them and keep
+/// the main thread responsive.  JS owns the source `Uint8Array` and hands
+/// WASM a per-tensor slice each step — the loader itself stores no copy of
+/// the bulk data, so peak memory stays at one model's worth.
+///
+/// ```javascript
+/// const loader = FlareEngine.begin_load(gguf_bytes);       // parses header only
+/// const total = loader.total_tensors;
+/// for (let i = 0; i < total; i++) {
+///   const off = loader.tensor_byte_offset(i);
+///   const len = loader.tensor_byte_length(i);
+///   loader.load_tensor(i, gguf_bytes.subarray(off, off + len));
+///   if (i % 10 === 0) await new Promise(r => setTimeout(r, 0)); // yield
+/// }
+/// const engine = loader.finalize();
+/// ```
+///
+/// Per-tensor work is a single memcpy + optional dequant.  The yields let GC
+/// run and keep Chrome from declaring the page unresponsive.
+#[wasm_bindgen]
+pub struct FlareLoader {
+    gguf: GgufFile,
+    skip_names: std::collections::HashSet<String>,
+    tensor_map: HashMap<String, flare_core::tensor::Tensor>,
+    raw_map: HashMap<String, flare_core::model::RawWeight>,
+    loaded: usize,
+    // Cached metadata so `finalize` doesn't re-parse.
+    chat_template: ChatTemplate,
+    eos_token_id: Option<u32>,
+    bos_token_id: Option<u32>,
+    add_bos_token: bool,
+    raw_chat_template: Option<String>,
+    architecture: String,
+    model_name: String,
+    metadata_json: String,
+    config: flare_core::config::ModelConfig,
+}
+
+#[wasm_bindgen]
+impl FlareLoader {
+    /// Total number of tensors in the GGUF file.
+    #[wasm_bindgen(getter)]
+    pub fn total_tensors(&self) -> u32 {
+        self.gguf.tensors.len() as u32
+    }
+
+    /// Number of tensors loaded so far (via successful `load_tensor` calls).
+    #[wasm_bindgen(getter)]
+    pub fn loaded_tensors(&self) -> u32 {
+        self.loaded as u32
+    }
+
+    /// Byte offset (within the original GGUF file) where tensor `i`'s data
+    /// starts.  JS uses this to slice its `Uint8Array` and hand WASM just the
+    /// bytes for that tensor.  f64 return because tensor offsets in large
+    /// GGUFs can exceed `u32::MAX`.
+    #[wasm_bindgen]
+    pub fn tensor_byte_offset(&self, i: u32) -> f64 {
+        let info = &self.gguf.tensors[i as usize];
+        (self.gguf.tensor_data_offset + info.offset) as f64
+    }
+
+    /// Byte length of tensor `i`'s data in the original GGUF file.
+    #[wasm_bindgen]
+    pub fn tensor_byte_length(&self, i: u32) -> f64 {
+        self.gguf.tensors[i as usize].byte_size() as f64
+    }
+
+    /// Tensor name — useful for progress UIs.
+    #[wasm_bindgen]
+    pub fn tensor_name(&self, i: u32) -> String {
+        self.gguf.tensors[i as usize].name.clone()
+    }
+
+    /// Load tensor `i` from the caller-provided byte slice, which must be
+    /// exactly `tensor_byte_length(i)` bytes and positioned at
+    /// `tensor_byte_offset(i)` within the original GGUF.
+    #[wasm_bindgen]
+    pub fn load_tensor(&mut self, i: u32, tensor_bytes: &[u8]) -> Result<(), JsError> {
+        let idx = i as usize;
+        if idx >= self.gguf.tensors.len() {
+            return Err(JsError::new(&format!(
+                "tensor index {idx} out of range (total {})",
+                self.gguf.tensors.len()
+            )));
+        }
+        let info = &self.gguf.tensors[idx];
+        let expected = info.byte_size() as usize;
+        if tensor_bytes.len() != expected {
+            return Err(JsError::new(&format!(
+                "tensor {} byte length mismatch: got {}, expected {}",
+                info.name,
+                tensor_bytes.len(),
+                expected
+            )));
+        }
+        let skip = self.skip_names.contains(&info.name);
+        let (tensor, maybe_raw) =
+            GgufFile::decode_tensor_from_bytes(info, tensor_bytes, true, skip)
+                .map_err(|e| JsError::new(&format!("Tensor decode error ({}): {e}", info.name)))?;
+        if let Some(raw) = maybe_raw {
+            self.raw_map.insert(info.name.clone(), raw);
+        }
+        self.tensor_map.insert(info.name.clone(), tensor);
+        self.loaded += 1;
+        Ok(())
+    }
+
+    /// Finalise the load: assemble `ModelWeights`, build the `Model`, run
+    /// warmup, and return a ready-to-use `FlareEngine`.  Consumes the loader.
+    ///
+    /// If any layer's matmul tensors couldn't be retained as raw (mixed-quant
+    /// model), this returns an error — the caller should fall back to the
+    /// sync `FlareEngine.load` which can do a second f32 dequant pass.
+    #[wasm_bindgen]
+    pub fn finalize(self) -> Result<FlareEngine, JsError> {
+        let FlareLoader {
+            gguf,
+            skip_names: _,
+            tensor_map,
+            raw_map,
+            loaded: _,
+            chat_template,
+            eos_token_id,
+            bos_token_id,
+            add_bos_token,
+            raw_chat_template,
+            architecture,
+            model_name,
+            metadata_json,
+            config,
+        } = self;
+
+        let (weights, raw_layers) = assemble_model_weights_from_maps(&gguf, tensor_map, raw_map)
+            .map_err(|e| JsError::new(&format!("Weight assembly error: {e}")))?;
+
+        if raw_layers.is_none() {
+            return Err(JsError::new(
+                "chunked load: mixed-quant model has unsupported tensor format. \
+                 Fall back to FlareEngine.load(bytes) which can re-read with full f32 dequant.",
+            ));
+        }
+
+        let mut model = Model::new(config.clone(), weights);
+        if let Some(rl) = raw_layers {
+            model.set_raw_weights(rl);
+        } else {
+            web_sys::console::log_1(
+                &"flare: raw quantized weights not available, using f32 path".into(),
+            );
+        }
+        model.warmup();
+
+        let gguf_vocab = GgufVocab::from_gguf(&gguf).ok();
+        Ok(FlareEngine {
+            model,
+            chat_template,
+            gguf_vocab,
+            eos_token_id,
+            bos_token_id,
+            add_bos_token,
+            raw_chat_template,
+            architecture,
+            model_name,
+            kv_pos: 0,
+            stream_params: SamplingParams {
+                temperature: 0.0,
+                ..Default::default()
+            },
+            stream_rng_state: 0x12345678,
+            stream_last_token: 0,
+            stream_recent_tokens: Vec::new(),
+            repeat_last_n: 64,
+            stream_pos: 0,
+            stream_remaining: 0,
+            stream_done: true,
+            stream_stop_reason: String::new(),
+            last_prefill_ms: 0.0,
+            last_decode_ms: 0.0,
+            last_tokens_generated: 0,
+            stream_decode_start_ms: 0.0,
+            stop_sequences: Vec::new(),
+            stream_text_accum: String::new(),
+            rng_seed: 0x12345678,
+            metadata_json,
+            last_logits: Vec::new(),
+            top_logprobs_n: 0,
+            top_logprobs_data: Vec::new(),
+            utf8_byte_buf: Vec::new(),
+        })
+    }
+}
+
 #[wasm_bindgen]
 impl FlareEngine {
+    /// Start a chunked GGUF load.  The passed bytes only need to span the
+    /// GGUF header (typically < 1 MB) — after header parsing WASM retains no
+    /// copy of the bulk tensor data.  Follow with `tensor_byte_offset` /
+    /// `load_tensor` per tensor, yielding between calls so the UI stays
+    /// responsive.
+    ///
+    /// Prefer this over [`FlareEngine::load`] in the browser — the sync
+    /// `load` method does ~2-3 s of uninterrupted work which Chrome flags
+    /// as "not responding" on memory-pressured tabs.
+    #[wasm_bindgen]
+    pub fn begin_load(gguf_bytes: &[u8]) -> Result<FlareLoader, JsError> {
+        let mut reader = Cursor::new(gguf_bytes);
+        let gguf = GgufFile::parse_header(&mut reader)
+            .map_err(|e| JsError::new(&format!("GGUF parse error: {e}")))?;
+        let chat_template = detect_chat_template(&gguf);
+        let eos_token_id = gguf
+            .metadata
+            .get("tokenizer.ggml.eos_token_id")
+            .and_then(|v| v.as_u32());
+        let bos_token_id = gguf
+            .metadata
+            .get("tokenizer.ggml.bos_token_id")
+            .and_then(|v| v.as_u32());
+        let add_bos_token = gguf
+            .metadata
+            .get("tokenizer.ggml.add_bos_token")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let raw_chat_template = gguf
+            .metadata
+            .get("tokenizer.chat_template")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let architecture = gguf.architecture().unwrap_or("unknown").to_string();
+        let model_name = gguf
+            .metadata
+            .get("general.name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let metadata_json = build_metadata_json(&gguf);
+        let config = gguf
+            .to_model_config()
+            .map_err(|e| JsError::new(&format!("Model config error: {e}")))?;
+        let skip_names =
+            matmul_skip_set(&gguf).map_err(|e| JsError::new(&format!("Skip set error: {e}")))?;
+
+        Ok(FlareLoader {
+            gguf,
+            skip_names,
+            tensor_map: HashMap::new(),
+            raw_map: HashMap::new(),
+            loaded: 0,
+            chat_template,
+            eos_token_id,
+            bos_token_id,
+            add_bos_token,
+            raw_chat_template,
+            architecture,
+            model_name,
+            metadata_json,
+            config,
+        })
+    }
+
     /// Load a GGUF model from a Uint8Array of bytes (e.g. from `fetch`).
     #[wasm_bindgen]
     pub fn load(gguf_bytes: &[u8]) -> Result<FlareEngine, JsError> {


### PR DESCRIPTION
## Summary
Two foundation pieces that unblock browser-facing improvements, paired because the follow-up benchmark PR in BrowserAI uses both:

1. **Chunked GGUF parse** (`FlareEngine::begin_load` → `FlareLoader` state machine) — JS holds the source bytes (or OPFS-backed slice), WASM sees per-tensor slices, callers yield to the event loop between tensors to keep the page responsive.
2. **`WebGpuBackend::dispatch_and_readback_async`** — async variant of the sync GPU readback that uses `futures_channel::oneshot` + `wasm_bindgen_futures`. Not yet wired through the stack; marked `#[allow(dead_code)]`. Lands the primitive so the async-propagation PR is mechanical rather than design-from-scratch.

## Why

### Chunked load
The sync `FlareEngine::load(bytes)` does 2–3 s of uninterrupted WASM work for a 138 MB Q8_0 GGUF. Combined with the JS Uint8Array already holding that buffer, peak JS+WASM memory is ~276 MB. On memory-pressured Chrome tabs (DevTools open, many other tabs) this trips the renderer's OOM kill mid-parse. Chunked load lets the embedder stream from OPFS or any other source one tensor at a time, and yielding between tensors keeps the event loop alive.

### Async readback
Live CDP trace pinpointed `wgpu::BufferSlice::map_async` + sync `receiver.recv()` as the hang site on wasm32 main-thread:

```
[flare-gpu-trace] dispatch_and_readback: submitted, awaiting readback (size=73728)
[flare-gpu-trace] dispatch_and_readback: device.poll returned, calling recv()
...no further events for 5+ minutes...
```

The WebGPU mapping callback is serviced by JS microtasks, which don't run during a sync WASM call, and `device.poll(Wait)` is a no-op on wasm32. `.await` on a `futures_channel::oneshot::Receiver` yields microtasks, so the callback can fire and unblock the receiver.

## New API
```rust
// flare-loader
pub fn matmul_skip_set(gguf: &GgufFile) -> Result<HashSet<String>, GgufError>;
pub fn assemble_model_weights_from_maps(gguf, tensors, raw_map) -> Result<(...), _>;

impl GgufFile {
    pub fn decode_tensor_from_bytes(info, raw_bytes, keep_raw, skip_f32)
        -> Result<(Tensor, Option<RawWeight>), GgufError>;
    pub fn load_all_tensors_with_raw_skipping_f32(reader, skip_f32_for)
        -> Result<(HashMap<String, Tensor>, HashMap<String, RawWeight>), GgufError>;
}

// flare-web (wasm-bindgen)
impl FlareEngine {
    pub fn begin_load(gguf_bytes: &[u8]) -> Result<FlareLoader, JsError>;
}

#[wasm_bindgen]
pub struct FlareLoader { ... }

impl FlareLoader {
    pub fn total_tensors(&self) -> u32;
    pub fn loaded_tensors(&self) -> u32;
    pub fn tensor_byte_offset(&self, i: u32) -> f64;
    pub fn tensor_byte_length(&self, i: u32) -> f64;
    pub fn tensor_name(&self, i: u32) -> String;
    pub fn load_tensor(&mut self, i: u32, tensor_bytes: &[u8]) -> Result<(), JsError>;
    pub fn finalize(self) -> Result<FlareEngine, JsError>;
}

// flare-gpu (internal, #[allow(dead_code)])
impl WebGpuBackend {
    async fn dispatch_and_readback_async(&self, pipeline, bind_group,
        dispatch, output_buf, output_size) -> Vec<f32>;
}
```

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo check -p flarellm-web --target wasm32-unknown-unknown`
- [x] `cargo clippy --workspace --all-targets -D warnings` — clean
- [x] `cargo test -p flarellm-core --lib` — 252 passing
- [x] `cargo test -p flarellm-loader --lib` — 306 passing
- [x] Verified end-to-end via `FlareEngine.begin_load` → `load_tensor` loop → `finalize` in the BrowserAI benchmark (see BrowserAI PR) — 0.4 s load from OPFS, 67 tok/s CPU decode

## Follow-up
Async-propagation PR: convert the relevant GPU methods and `Model::forward_prefill` / `Model::forward` to async using the `dispatch_and_readback_async` primitive, expose `FlareEngine.next_token_async` / `begin_stream_with_params_async` wasm-bindgen methods so WebGPU can actually drive inference. Scope: ~600-800 LOC, mechanical once the primitive is in.
