### PR TITLE
Async GPU decode via forward_single_token_gpu_async

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -528,6 +528,11 @@ pub trait ComputeBackend: Send + Sync {
     ///
     /// Returns `None` if GPU weights/KV cache are not initialized, or the
     /// backend does not support GPU-resident forward.
+    ///
+    /// **wasm32 note:** this sync variant deadlocks on the browser main thread
+    /// because wgpu's final `map_async` + `recv()` readback needs JS
+    /// microtasks (which don't run during a sync WASM call).  Prefer
+    /// [`Self::forward_single_token_gpu_async`] on wasm32.
     #[allow(clippy::too_many_arguments)]
     fn forward_single_token_gpu(
         &self,
@@ -545,6 +550,44 @@ pub trait ComputeBackend: Send + Sync {
         _seq_len: usize,
     ) -> Option<Vec<f32>> {
         None
+    }
+
+    /// Async variant of [`Self::forward_single_token_gpu`].  Required on wasm32
+    /// so the WebGPU `map_async` callback can fire during `.await`.
+    ///
+    /// Default impl delegates to the sync version — backends that don't need
+    /// async readback (CPU, native wgpu) get this for free.
+    #[allow(clippy::too_many_arguments)]
+    fn forward_single_token_gpu_async<'a>(
+        &'a self,
+        token_embedding: &'a [f32],
+        pos: usize,
+        dim: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        intermediate_dim: usize,
+        vocab_size: usize,
+        rms_norm_eps: f32,
+        rope_theta: f32,
+        num_layers: usize,
+        seq_len: usize,
+    ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Option<Vec<f32>>> + 'a>> {
+        let sync = self.forward_single_token_gpu(
+            token_embedding,
+            pos,
+            dim,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_dim,
+            vocab_size,
+            rms_norm_eps,
+            rope_theta,
+            num_layers,
+            seq_len,
+        );
+        Box::pin(async move { sync })
     }
 
     /// Short identifier for this backend, used in diagnostics.
@@ -1667,6 +1710,65 @@ impl Model {
         }
 
         Tensor::from_vec(self.forward_buffers.logits.clone(), &[vocab_size]).unwrap()
+    }
+
+    /// Async variant of [`Self::forward`].  Required on wasm32 browsers because
+    /// the sync GPU path hits a `map_async` + `recv()` deadlock (the mapping
+    /// callback can't fire while the JS event loop is frozen in a sync WASM
+    /// call).  Falls through to the sync path on CPU-only backends.
+    ///
+    /// Advances the KV cache on success and applies Gemma-2's final logit
+    /// soft-cap when configured.  On backends that don't implement
+    /// `forward_single_token_gpu_async`, the default trait impl forwards to
+    /// the sync version — so this is a safe drop-in for `forward` in both
+    /// browser and native contexts.
+    pub async fn forward_async(&mut self, token_id: u32, pos: usize) -> Tensor {
+        let dim = self.config.hidden_dim;
+        let head_dim = self.config.head_dim;
+        let num_heads = self.config.num_heads;
+        let num_kv_heads = self.config.num_kv_heads;
+        let vocab_size = self.config.vocab_size;
+
+        if self.backend.has_gpu_weights() && self.backend.has_gpu_kv_cache() {
+            let embed_data = self.weights.token_embedding.data();
+            let embed_offset = token_id as usize * dim;
+            let token_embed = &embed_data[embed_offset..embed_offset + dim];
+            let seq_len = self.kv_cache.len() + 1;
+
+            let maybe_logits = self
+                .backend
+                .forward_single_token_gpu_async(
+                    token_embed,
+                    pos,
+                    dim,
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                    self.config.intermediate_dim,
+                    vocab_size,
+                    self.config.rms_norm_eps,
+                    self.config.rope_theta,
+                    self.config.num_layers,
+                    seq_len,
+                )
+                .await;
+
+            if let Some(mut logits) = maybe_logits {
+                self.kv_cache.advance();
+                if self.config.final_logit_softcap > 0.0 {
+                    let cap = self.config.final_logit_softcap;
+                    for l in &mut logits {
+                        *l = (*l / cap).tanh() * cap;
+                    }
+                }
+                return Tensor::from_vec(logits, &[vocab_size]).unwrap();
+            }
+        }
+
+        // Fall back to the sync path.  On CPU backends that's the normal
+        // hot path; on GPU backends it's only reached when the async GPU
+        // call returned `None` (GPU state missing).
+        self.forward(token_id, pos)
     }
 
     /// Greedy forward pass: runs the full transformer but returns only the

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -3821,6 +3821,12 @@ impl WebGpuBackend {
     /// * `token_embedding` — token embedding slice `[dim]`
     /// * `k_data_per_layer` — mutable slices for writing K back to CPU KV cache
     /// * `v_data_per_layer` — mutable slices for writing V back to CPU KV cache
+    ///
+    /// Sync variant of the GPU-resident forward pass.
+    ///
+    /// Deadlocks on wasm32 main-thread because the final `map_async` readback
+    /// can't fire while the JS event loop is frozen in a sync WASM call.
+    /// Use [`Self::forward_single_token_gpu_async`] in browsers.
     #[allow(clippy::too_many_arguments)]
     pub fn forward_single_token_gpu(
         &self,
@@ -3837,6 +3843,110 @@ impl WebGpuBackend {
         num_layers: usize,
         seq_len: usize,
     ) -> Vec<f32> {
+        let (staging, _size) = self.forward_single_token_gpu_submit(
+            token_embedding,
+            pos,
+            dim,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_dim,
+            vocab_size,
+            rms_norm_eps,
+            rope_theta,
+            num_layers,
+            seq_len,
+        );
+
+        let slice = staging.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            tx.send(result).ok();
+        });
+        self.device.poll(wgpu::Maintain::Wait);
+        rx.recv()
+            .expect("GPU readback channel closed")
+            .expect("GPU readback failed");
+        let data = slice.get_mapped_range();
+        let logits: Vec<f32> = bytemuck::cast_slice(&data).to_vec();
+        drop(data);
+        staging.unmap();
+        self.pool.return_staging(staging);
+        logits
+    }
+
+    /// Async variant — identical command-encoder build, but awaits the
+    /// logits readback so WebGPU's `map_async` callback can fire.  This is
+    /// the only path that works on wasm32 main thread and in Web Workers.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn forward_single_token_gpu_async(
+        &self,
+        token_embedding: &[f32],
+        pos: usize,
+        dim: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        intermediate_dim: usize,
+        vocab_size: usize,
+        rms_norm_eps: f32,
+        rope_theta: f32,
+        num_layers: usize,
+        seq_len: usize,
+    ) -> Vec<f32> {
+        let (staging, _size) = self.forward_single_token_gpu_submit(
+            token_embedding,
+            pos,
+            dim,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_dim,
+            vocab_size,
+            rms_norm_eps,
+            rope_theta,
+            num_layers,
+            seq_len,
+        );
+
+        let slice = staging.slice(..);
+        let (tx, rx) = futures_channel::oneshot::channel();
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = tx.send(result);
+        });
+        #[cfg(not(target_arch = "wasm32"))]
+        self.device.poll(wgpu::Maintain::Wait);
+        rx.await
+            .expect("GPU readback channel closed")
+            .expect("GPU readback failed");
+        let data = slice.get_mapped_range();
+        let logits: Vec<f32> = bytemuck::cast_slice(&data).to_vec();
+        drop(data);
+        staging.unmap();
+        self.pool.return_staging(staging);
+        logits
+    }
+
+    /// Build the single-token forward command encoder + submit.  Returns the
+    /// staging buffer (caller reads back the logits via their preferred
+    /// sync or async path) and the output size in bytes.  Keeping the heavy
+    /// body private lets the sync and async wrappers share it verbatim.
+    #[allow(clippy::too_many_arguments)]
+    fn forward_single_token_gpu_submit(
+        &self,
+        token_embedding: &[f32],
+        pos: usize,
+        dim: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        intermediate_dim: usize,
+        vocab_size: usize,
+        rms_norm_eps: f32,
+        rope_theta: f32,
+        num_layers: usize,
+        seq_len: usize,
+    ) -> (wgpu::Buffer, u64) {
         let guard = self.gpu_weights.lock().expect("gpu_weights mutex poisoned");
         let weights = guard
             .as_ref()
@@ -4175,7 +4285,10 @@ impl WebGpuBackend {
             }
         }
 
-        // 17. Readback only the logits
+        // 17. Readback only the logits — defer the map_async + wait to the
+        // caller (sync / async wrapper).  We stage the copy here and submit
+        // the encoder so the GPU starts executing immediately, minimising the
+        // await latency in the async path.
         let logits_size = (vocab_size * 4) as u64;
         let staging = self.pool.get_staging(&self.device, logits_size);
         encoder.copy_buffer_to_buffer(logits_buf, 0, &staging, 0, logits_size);
@@ -4183,25 +4296,7 @@ impl WebGpuBackend {
         // Submit the ENTIRE forward pass as ONE command buffer.
         self.queue.submit(Some(encoder.finish()));
 
-        // Map and read back logits
-        let slice = staging.slice(..);
-        let (sender, receiver) = std::sync::mpsc::channel();
-        slice.map_async(wgpu::MapMode::Read, move |result| {
-            sender.send(result).ok();
-        });
-        self.device.poll(wgpu::Maintain::Wait);
-        receiver
-            .recv()
-            .expect("GPU readback channel closed")
-            .expect("GPU readback failed");
-
-        let data = slice.get_mapped_range();
-        let logits: Vec<f32> = bytemuck::cast_slice(&data).to_vec();
-        drop(data);
-        staging.unmap();
-        self.pool.return_staging(staging);
-
-        logits
+        (staging, logits_size)
     }
 }
 
@@ -5068,6 +5163,47 @@ impl ComputeBackend for WebGpuBackend {
             num_layers,
             seq_len,
         ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn forward_single_token_gpu_async<'a>(
+        &'a self,
+        token_embedding: &'a [f32],
+        pos: usize,
+        dim: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        intermediate_dim: usize,
+        vocab_size: usize,
+        rms_norm_eps: f32,
+        rope_theta: f32,
+        num_layers: usize,
+        seq_len: usize,
+    ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Option<Vec<f32>>> + 'a>> {
+        Box::pin(async move {
+            if !WebGpuBackend::has_gpu_weights(self) || !self.has_gpu_kv_cache() {
+                return None;
+            }
+            Some(
+                WebGpuBackend::forward_single_token_gpu_async(
+                    self,
+                    token_embedding,
+                    pos,
+                    dim,
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                    intermediate_dim,
+                    vocab_size,
+                    rms_norm_eps,
+                    rope_theta,
+                    num_layers,
+                    seq_len,
+                )
+                .await,
+            )
+        })
     }
 }
 

--- a/flare-web/src/lib.rs
+++ b/flare-web/src/lib.rs
@@ -2111,6 +2111,108 @@ impl FlareEngine {
         Some(token_id)
     }
 
+    /// Async variant of [`Self::next_token`].  Required on wasm32 browsers
+    /// when WebGPU is the active backend — the sync `forward` path deadlocks
+    /// on the final `map_async` + `recv()` readback because the WebGPU
+    /// mapping callback is serviced by JS microtasks that can't run during
+    /// a sync WASM call, and `device.poll(Wait)` is a no-op on wasm32.
+    ///
+    /// Returns a Promise that resolves to the generated token id (or
+    /// `undefined` on stream end).  Identical sampling + stop-sequence +
+    /// EOS handling as `next_token`.  Safe to use on CPU backends too —
+    /// the async path falls through to the sync fast path there.
+    #[wasm_bindgen]
+    pub async fn next_token_async(&mut self) -> Option<u32> {
+        if self.stream_done || self.stream_remaining == 0 {
+            if !self.stream_done {
+                self.stream_done = true;
+                self.stream_stop_reason = "length".to_string();
+            }
+            return None;
+        }
+
+        if self.stream_decode_start_ms == 0.0 {
+            self.stream_decode_start_ms = now_ms();
+        }
+
+        let logits_tensor = self
+            .model
+            .forward_async(self.stream_last_token, self.stream_pos)
+            .await;
+        self.last_logits = logits_tensor.data().to_vec();
+        if self.top_logprobs_n > 0 {
+            self.top_logprobs_data =
+                compute_top_logprobs(&self.last_logits, self.top_logprobs_n as usize);
+        }
+        let token_id = if self.stream_params.temperature == 0.0 {
+            sampling::sample_greedy(logits_tensor.data())
+        } else {
+            let mut logits = logits_tensor.data().to_vec();
+            sampling::apply_repeat_penalty(
+                &mut logits,
+                &self.stream_recent_tokens,
+                self.stream_params.repeat_penalty,
+            );
+            sampling::apply_temperature(&mut logits, self.stream_params.temperature);
+            self.stream_rng_state = self
+                .stream_rng_state
+                .wrapping_mul(1664525)
+                .wrapping_add(1013904223);
+            let rng_val = (self.stream_rng_state as f32) / (u32::MAX as f32);
+            if self.stream_params.top_p < 1.0 {
+                sampling::sample_top_p(&logits, self.stream_params.top_p, rng_val)
+            } else if self.stream_params.min_p > 0.0 {
+                sampling::sample_min_p(&logits, self.stream_params.min_p, rng_val)
+            } else if self.stream_params.top_k > 0 {
+                sampling::sample_top_k(&logits, self.stream_params.top_k, rng_val)
+            } else {
+                sampling::sample_top_p(&logits, 1.0, rng_val)
+            }
+        };
+
+        self.stream_last_token = token_id;
+        self.stream_pos += 1;
+        self.kv_pos = self.stream_pos;
+        if self.repeat_last_n > 0 {
+            if self.stream_recent_tokens.len() >= self.repeat_last_n {
+                self.stream_recent_tokens.remove(0);
+            }
+            self.stream_recent_tokens.push(token_id);
+        }
+        self.stream_remaining -= 1;
+
+        if self.eos_token_id == Some(token_id) {
+            self.last_decode_ms = now_ms() - self.stream_decode_start_ms;
+            self.stream_done = true;
+            self.stream_stop_reason = "eos".to_string();
+            return None;
+        }
+
+        if !self.stop_sequences.is_empty() {
+            if let Some(vocab) = &self.gguf_vocab {
+                let piece = vocab.decode(&[token_id]);
+                self.stream_text_accum.push_str(&piece);
+                for seq in &self.stop_sequences {
+                    if self.stream_text_accum.ends_with(seq.as_str()) {
+                        self.last_decode_ms = now_ms() - self.stream_decode_start_ms;
+                        self.stream_done = true;
+                        self.stream_stop_reason = "stop_sequence".to_string();
+                        return None;
+                    }
+                }
+            }
+        }
+
+        if self.stream_remaining == 0 {
+            self.stream_done = true;
+            self.stream_stop_reason = "length".to_string();
+        }
+
+        self.last_tokens_generated += 1;
+        self.last_decode_ms = now_ms() - self.stream_decode_start_ms;
+        Some(token_id)
+    }
+
     /// Signal the current stream to stop after the next `next_token()` call.
     /// The JS Stop button should call this, then wait for `next_token()` to
     /// return `undefined` before updating the UI.


### PR DESCRIPTION
## Summary
Unblocks **WebGPU-backed decode on wasm32 browsers**. The sync GPU path deadlocks on wasm32 main thread because wgpu's final logits readback uses `map_async` + blocking `receiver.recv()`, and the mapping callback is serviced by JS microtasks that can't run during a sync WASM call (`device.poll(Wait)` is a no-op on wasm32).

Adds `forward_single_token_gpu_async` end-to-end. Prefill stays on the sync path for now — `forward_prefill` calls many individual backend methods that each hit the same deadlock; converting those is a separate follow-up. The benchmark will default to **CPU prefill + async GPU decode** once BrowserAI is updated.

## New API
```rust
// flare-core
impl Model {
    pub async fn forward_async(&mut self, token_id: u32, pos: usize) -> Tensor;
}

// flare-core trait (default impl delegates to sync variant)
pub trait ComputeBackend {
    fn forward_single_token_gpu_async<'a>(&'a self, /* ...same args... */)
        -> Pin<Box<dyn Future<Output = Option<Vec<f32>>> + 'a>>;
}

// flare-gpu
impl WebGpuBackend {
    pub async fn forward_single_token_gpu_async(&self, /* ... */) -> Vec<f32>;
}

// flare-web (wasm-bindgen → Promise<u32|undefined>)
impl FlareEngine {
    pub async fn next_token_async(&mut self) -> Option<u32>;
}
```

## Implementation notes
- The 400-line `forward_single_token_gpu` body is refactored into a private `_submit` helper that returns `(staging_buffer, size)` after encoder submit. Sync and async public wrappers share it verbatim — no duplication.
- Async readback uses `futures_channel::oneshot` + `.await`. The `.await` yields JS microtasks so the WebGPU mapping callback can fire.
- Trait method uses a hand-written `Pin<Box<dyn Future>>` return type rather than `async-trait`. Keeps `dyn ComputeBackend` object-safe without the extra dep, and the default impl forwards to the sync variant so CPU/native backends get the async method for free.
- `FlareEngine::next_token_async` is a wasm-bindgen `async fn` — it bridges to a JavaScript Promise automatically; the JS side can `await engine.next_token_async()`.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo check -p flarellm-web --target wasm32-unknown-unknown`
- [x] `cargo clippy --workspace --all-targets -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo test -p flarellm-core --lib` — 252 passing
- [x] `cargo test -p flarellm-loader --lib` — 306 passing
- [ ] BrowserAI PR wires `next_token_async` into the decode loop and reports real GPU numbers

## Follow-up
Async prefill: `forward_prefill` has ~5 backend method types that need async variants (`batched_rmsnorm`, `batched_rope`, `batched_matmul`, `batched_dequant_matmul`, `prefill_attention_gpu`). Same propagation pattern — `async fn` on trait via `Pin<Box<dyn Future>>`, WebGpuBackend overrides, Model::forward_prefill becomes async, FlareEngine::begin_stream_with_params_async exposed. Once shipped, benchmark runs fully on GPU.
