### PR TITLE
Release flare-web 0.2.14

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
Bundles #500 (chunked GGUF load + async primitive) and #501 (async GPU decode).

Consumers can now `await engine.next_token_async()` for WebGPU-accelerated decode — see #501 for the full API.  Still requires the CPU prefill path; async prefill is a follow-up.