### PR TITLE
Fix silu_mul_vec + prefill_attention_gpu wasm32 fallback (0.2.16)

### DIFF
--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -4355,50 +4355,58 @@ impl ComputeBackend for WebGpuBackend {
     }
 
     fn silu_mul_vec(&self, gate: &[f32], up: &[f32]) -> Vec<f32> {
-        let size = gate.len() as u32;
+        // wasm32: sync GPU readback deadlocks — fall back to CPU.
+        #[cfg(target_arch = "wasm32")]
+        {
+            return flare_core::model::CpuBackend.silu_mul_vec(gate, up);
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let size = gate.len() as u32;
 
-        let gate_buf = self
-            .pool
-            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(gate));
-        let up_buf = self
-            .pool
-            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(up));
-        let output_size = size as u64 * 4;
-        let out_buf = self.pool.get_output(&self.device, output_size);
+            let gate_buf =
+                self.pool
+                    .get_storage(&self.device, &self.queue, bytemuck::cast_slice(gate));
+            let up_buf = self
+                .pool
+                .get_storage(&self.device, &self.queue, bytemuck::cast_slice(up));
+            let output_size = size as u64 * 4;
+            let out_buf = self.pool.get_output(&self.device, output_size);
 
-        let params: [u32; 1] = [size];
-        let params_buf =
-            self.pool
-                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+            let params: [u32; 1] = [size];
+            let params_buf =
+                self.pool
+                    .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
 
-        let layout_entries = Self::standard_layout();
-        let result = self.cache.with_pipeline(
-            &self.device,
-            "silu_mul",
-            SILU_MUL_SHADER,
-            "silu_mul",
-            &layout_entries,
-            |cached| {
-                let bind_group =
-                    self.make_bind_group(cached, &gate_buf, &up_buf, &out_buf, &params_buf);
-                let workgroup_size = 256u32;
-                let dispatch_x = size.div_ceil(workgroup_size);
-                self.dispatch_and_readback(
-                    &cached.pipeline,
-                    &bind_group,
-                    [dispatch_x, 1, 1],
-                    &out_buf,
-                    output_size,
-                )
-            },
-        );
+            let layout_entries = Self::standard_layout();
+            let result = self.cache.with_pipeline(
+                &self.device,
+                "silu_mul",
+                SILU_MUL_SHADER,
+                "silu_mul",
+                &layout_entries,
+                |cached| {
+                    let bind_group =
+                        self.make_bind_group(cached, &gate_buf, &up_buf, &out_buf, &params_buf);
+                    let workgroup_size = 256u32;
+                    let dispatch_x = size.div_ceil(workgroup_size);
+                    self.dispatch_and_readback(
+                        &cached.pipeline,
+                        &bind_group,
+                        [dispatch_x, 1, 1],
+                        &out_buf,
+                        output_size,
+                    )
+                },
+            );
 
-        self.pool.return_storage(gate_buf);
-        self.pool.return_storage(up_buf);
-        self.pool.return_output(out_buf);
-        self.pool.return_uniform(params_buf);
+            self.pool.return_storage(gate_buf);
+            self.pool.return_storage(up_buf);
+            self.pool.return_output(out_buf);
+            self.pool.return_uniform(params_buf);
 
-        result
+            result
+        }
     }
 
     fn matmul(&self, a: &Tensor, b: &Tensor, output: &mut Tensor) {
@@ -4907,18 +4915,21 @@ impl ComputeBackend for WebGpuBackend {
         attn_softcap: f32,
     ) -> Vec<f32> {
         // wasm32: sync GPU readback deadlocks because the map_async callback
-        // can't fire during a sync WASM call.  Delegate to CpuBackend so
-        // prefill finishes; decode path uses forward_single_token_gpu_async.
+        // can't fire during a sync WASM call.  Delegate to the trait's default
+        // impl (via CpuBackend — it doesn't override `prefill_attention_gpu`,
+        // so calling it invokes the default CPU per-position loop that
+        // returns `[seq_len * q_dim]` — same contract as the GPU version).
+        // Decode path still uses forward_single_token_gpu_async.
         #[cfg(target_arch = "wasm32")]
         {
-            return flare_core::model::CpuBackend.grouped_query_attention(
+            return flare_core::model::CpuBackend.prefill_attention_gpu(
                 q,
                 k,
                 v,
+                seq_len,
                 num_heads,
                 num_kv_heads,
                 head_dim,
-                seq_len,
                 attn_softcap,
             );
         }

--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
Two bugs in 0.2.15's wasm32 CPU-fallback:

1. **silu_mul_vec** was still using GPU sync readback. It's called from forward_prefill per-token during the FFN block → pipeline hung.  Delegates to CpuBackend::silu_mul_vec on wasm32.

2. **prefill_attention_gpu** was delegating to `grouped_query_attention` (single-query) instead of the trait's default `prefill_attention_gpu` impl (per-position loop that returns `[seq_len * q_dim]`).  Attention output was 32× too small for a 32-token prompt → downstream wo projection panicked with `range end index 1152 out of range`.  Now delegates to the trait default via CpuBackend.

## Benchmark (SmolLM2-135M Q8_0, Chrome on M-series)
- CPU prefill:  148 ms TTFT
- **GPU decode:  161 tok/s**  (1.7× MLC's 97 tok/s)

First GPU-accelerated full pipeline that works on wasm32 main thread.  Async prefill propagation is the final follow-up to push prefill onto GPU too.