### PR TITLE
Async Q8_0 matvec primitive for prefill GPU dispatch

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -474,6 +474,21 @@ pub trait ComputeBackend: Send + Sync {
         )
     }
 
+    /// Async variant of [`Self::batched_dequant_matmul`] — returns the same
+    /// `Vec<f32>` but via a `Pin<Box<dyn Future>>` so GPU backends on wasm32
+    /// can `.await` the `map_async` readback without deadlocking the JS
+    /// event loop.  Default impl forwards to the sync version so CPU-only
+    /// callers get it for free.
+    fn batched_dequant_matmul_async<'a>(
+        &'a self,
+        weight: &'a RawWeight,
+        input: &'a [f32],
+        batch: usize,
+    ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Vec<f32>> + 'a>> {
+        let result = self.batched_dequant_matmul(weight, input, batch);
+        Box::pin(async move { result })
+    }
+
     /// Serialise the driver-managed GPU pipeline cache to bytes.
     ///
     /// On backends that support `wgpu::Features::PIPELINE_CACHE` (Vulkan native),

--- a/flare-gpu/src/backend.rs
+++ b/flare-gpu/src/backend.rs
@@ -341,12 +341,6 @@ impl WebGpuBackend {
     /// as soon as `device.poll` fires the callback, so it's a drop-in for the
     /// sync path there too.
     ///
-    /// Not yet wired into the GPU forward paths — the full propagation of
-    /// `async fn` through `ComputeBackend`, `Model::forward_prefill`, and the
-    /// `wasm-bindgen` bridge is a larger refactor.  Keeping this primitive in
-    /// place so the refactor is a mechanical propagation rather than a
-    /// design-from-scratch.
-    #[allow(dead_code)]
     async fn dispatch_and_readback_async(
         &self,
         pipeline: &wgpu::ComputePipeline,
@@ -1696,6 +1690,87 @@ impl WebGpuBackend {
                 )
             },
         );
+
+        self.pool.return_storage(raw_buf);
+        self.pool.return_storage(vec_buf);
+        self.pool.return_output(out_buf);
+        self.pool.return_uniform(params_buf);
+
+        result
+    }
+
+    /// Async variant of [`Self::dequant_matvec_q8_0`].  The pipeline is
+    /// cloned out of the cache up-front (Arc-backed, cheap) so the lock
+    /// guard doesn't need to straddle the `.await`.  Required on wasm32
+    /// because the sync readback deadlocks when the JS event loop is
+    /// frozen inside a synchronous WASM call.
+    pub async fn dequant_matvec_q8_0_async(
+        &self,
+        raw_bytes: &[u8],
+        input: &[f32],
+        num_rows: usize,
+        num_blocks_per_row: usize,
+        batch: usize,
+    ) -> Vec<f32> {
+        let output_size = num_rows as u64 * batch as u64 * 4;
+
+        #[allow(clippy::manual_is_multiple_of)]
+        let raw_buf = if raw_bytes.len() % 4 == 0 {
+            self.pool.get_storage(&self.device, &self.queue, raw_bytes)
+        } else {
+            let mut padded = raw_bytes.to_vec();
+            padded.resize((padded.len() + 3) & !3, 0);
+            self.pool.get_storage(&self.device, &self.queue, &padded)
+        };
+        let vec_buf = self
+            .pool
+            .get_storage(&self.device, &self.queue, bytemuck::cast_slice(input));
+        let out_buf = self.pool.get_output(&self.device, output_size);
+
+        let params: [u32; 3] = [num_rows as u32, num_blocks_per_row as u32, batch as u32];
+        let params_buf =
+            self.pool
+                .get_uniform(&self.device, &self.queue, bytemuck::cast_slice(&params));
+
+        let layout_entries = Self::standard_layout();
+        let (pipeline, layout) = self.cache.ensure_pipeline_cloned(
+            &self.device,
+            "dequant_matvec_q8_0",
+            DEQUANT_MATVEC_Q8_0_SHADER,
+            "dequant_matvec_q8_0",
+            &layout_entries,
+        );
+        let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: raw_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: vec_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: out_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: params_buf.as_entire_binding(),
+                },
+            ],
+        });
+        let result = self
+            .dispatch_and_readback_async(
+                &pipeline,
+                &bind_group,
+                [num_rows as u32, batch as u32, 1],
+                &out_buf,
+                output_size,
+            )
+            .await;
 
         self.pool.return_storage(raw_buf);
         self.pool.return_storage(vec_buf);
@@ -4999,6 +5074,32 @@ impl ComputeBackend for WebGpuBackend {
 
     fn supports_dequant_matmul(&self) -> bool {
         true
+    }
+
+    fn batched_dequant_matmul_async<'a>(
+        &'a self,
+        weight: &'a RawWeight,
+        input: &'a [f32],
+        batch: usize,
+    ) -> core::pin::Pin<Box<dyn core::future::Future<Output = Vec<f32>> + 'a>> {
+        Box::pin(async move {
+            // Fast async path for Q8_0 (the dominant SmolLM2 / Llama format);
+            // other formats fall back to the sync path, which on wasm32
+            // delegates to CpuBackend to avoid the readback deadlock.
+            match weight.format {
+                WeightFormat::Q8_0 => {
+                    self.dequant_matvec_q8_0_async(
+                        &weight.data,
+                        input,
+                        weight.num_rows,
+                        weight.blocks_per_row,
+                        batch,
+                    )
+                    .await
+                }
+                _ => self.batched_dequant_matmul(weight, input, batch),
+            }
+        })
     }
 
     fn batched_dequant_matmul(&self, weight: &RawWeight, input: &[f32], batch: usize) -> Vec<f32> {

--- a/flare-gpu/src/pipeline.rs
+++ b/flare-gpu/src/pipeline.rs
@@ -71,6 +71,57 @@ impl PipelineCache {
             .unwrap_or_default()
     }
 
+    /// Ensure the pipeline for `name` exists, returning cheap clones of its
+    /// `ComputePipeline` and `BindGroupLayout`.  Both are Arc-backed in wgpu,
+    /// so the clone is refcount-only.
+    ///
+    /// Use this when you need to hold the pipeline across an `.await` — the
+    /// callback-based [`Self::with_pipeline`] holds the `RwLock` read guard
+    /// for the entire callback, which can't straddle an await boundary
+    /// without `Send`-bound issues on wasm32.
+    pub fn ensure_pipeline_cloned(
+        &self,
+        device: &wgpu::Device,
+        name: &'static str,
+        shader_source: &'static str,
+        entry_point: &'static str,
+        bind_layout_entries: &[wgpu::BindGroupLayoutEntry],
+    ) -> (wgpu::ComputePipeline, wgpu::BindGroupLayout) {
+        {
+            let read = self.cache.read().expect("pipeline cache poisoned");
+            if let Some(cached) = read.get(name) {
+                return (cached.pipeline.clone(), cached.layout.clone());
+            }
+        }
+        let mut write = self.cache.write().expect("pipeline cache poisoned");
+        if !write.contains_key(name) {
+            let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(name),
+                source: wgpu::ShaderSource::Wgsl(shader_source.into()),
+            });
+            let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some(name),
+                entries: bind_layout_entries,
+            });
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some(name),
+                bind_group_layouts: &[&layout],
+                push_constant_ranges: &[],
+            });
+            let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some(name),
+                layout: Some(&pipeline_layout),
+                module: &shader_module,
+                entry_point: Some(entry_point),
+                compilation_options: Default::default(),
+                cache: self.wgpu_cache.as_ref(),
+            });
+            write.insert(name, CachedPipeline { pipeline, layout });
+        }
+        let cached = write.get(name).expect("just inserted");
+        (cached.pipeline.clone(), cached.layout.clone())
+    }
+
     /// Run `f` with the cached pipeline for `name`, building it on first call.
     ///
     /// `bind_layout_entries` defines the bind group layout (typically 4 entries:


### PR DESCRIPTION
Foundation for moving `forward_prefill` off CPU (wasm32 fallback, #503) onto GPU. Extends the async readback pattern from #501 to the batched dequant-matmul that dominates prefill (gate_up + down + qkv + attn_out + lm_head = ~76% of the 137 ms TTFT on SmolLM2-135M).

Three additions, zero behavior change yet:

1. **`PipelineCache::ensure_pipeline_cloned`** — returns cheap Arc clones of the compute pipeline + bind group layout so the lock guard doesn't need to straddle an `.await`. Existing callback-based `with_pipeline` stays for sync callers.

2. **`WebGpuBackend::dequant_matvec_q8_0_async`** — mirrors the sync version's encoder build + submit but awaits the readback via `dispatch_and_readback_async`. Q8_0 is the dominant format for every GGUF we ship; the other ~15 formats are a mechanical follow-up once `Model::forward_prefill_async` wires this in.

3. **`ComputeBackend::batched_dequant_matmul_async`** — trait method with a default impl that forwards to the sync version (so CPU-only backends get it free). `WebGpuBackend` overrides to route Q8_0 through the new async path; other formats fall back to the sync method, which on wasm32 uses the CpuBackend delegation from #503 to avoid deadlock.

## Follow-up
- `Model::forward_prefill_async` using this
- `FlareEngine::begin_stream_with_params_async` wasm-bindgen method
- BrowserAI benchmark awaits it
- Close the 137 ms → ~20 ms TTFT gap vs MLC

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo check -p flarellm-web --target wasm32-unknown-unknown`
- [x] `cargo clippy --workspace --all-targets -D warnings` — clean
- [x] `cargo test -p flarellm-core --lib` — 252 passing
- [x] `cargo test -p flarellm-loader --lib` — 306 passing