### PR TITLE
Release flare-web 0.2.17

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
Bumps `flare-web` npm package version to 0.2.17.

## What's new vs 0.2.16

- **Async prefill propagation** (#506) — `Model::forward_prefill_async` + `FlareEngine::begin_stream_with_params_async`. On wasm32 + WebGPU this lets the dequant matmul `map_async` readback fire between projections instead of deadlocking the JS event loop. Unblocks GPU prefill and should drop TTFT meaningfully on browser builds.

Existing sync `begin_stream_with_params` still works for CPU backend callers — the async variant is purely additive.

## Post-merge steps

1. Tag `flare-web-v0.2.17` on the merge commit.
2. `npm publish --otp=<code>` (user-driven, OTP required).
3. Update BrowserAI benchmark to pin `@sauravpanda/flare@0.2.17` and `await engine.begin_stream_with_params_async(...)`.

## Test plan

- [x] PR #506 already passed full CI on the same code; this PR is a one-line version bump only.
- [ ] After publish: BrowserAI benchmark TTFT comparison vs 0.2.16 baseline (~137 ms CPU prefill) and MLC (~19 ms).