### PR TITLE
Prefill: silu_mul writes into preallocated buffer

### DIFF
--- a/flare-core/src/model.rs
+++ b/flare-core/src/model.rs
@@ -2798,18 +2798,21 @@ impl Model {
                     record_phase!(self, t_gate_up, gate_up_ms);
 
                     // Per-token silu_mul / gelu_mul (CPU arithmetic, no GPU dispatch).
+                    // Write directly into a preallocated buffer to avoid the
+                    // per-token Vec allocation that the iterator-collect chain
+                    // would otherwise do.
                     let t_silu = self.tick();
-                    let ffn_hidden_batch: Vec<f32> = (0..seq_len)
-                        .flat_map(|t| {
-                            let gate_t = &gate_batch[t * inter..(t + 1) * inter];
-                            let up_t = &up_batch[t * inter..(t + 1) * inter];
-                            if config.architecture == Architecture::Gemma2 {
-                                gelu_mul_cpu(gate_t, up_t)
-                            } else {
-                                self.backend.silu_mul_vec(gate_t, up_t)
-                            }
-                        })
-                        .collect();
+                    let mut ffn_hidden_batch = vec![0.0f32; seq_len * inter];
+                    for t in 0..seq_len {
+                        let gate_t = &gate_batch[t * inter..(t + 1) * inter];
+                        let up_t = &up_batch[t * inter..(t + 1) * inter];
+                        let dst = &mut ffn_hidden_batch[t * inter..(t + 1) * inter];
+                        if config.architecture == Architecture::Gemma2 {
+                            gelu_mul_into(gate_t, up_t, dst);
+                        } else {
+                            silu_mul_into(gate_t, up_t, dst);
+                        }
+                    }
                     record_phase!(self, t_silu, silu_mul_ms);
 
                     // Single batched dispatch for the down projection.
@@ -3256,17 +3259,17 @@ impl Model {
                     record_phase!(self, t_gate_up, gate_up_ms);
 
                     let t_silu = self.tick();
-                    let ffn_hidden_batch: Vec<f32> = (0..seq_len)
-                        .flat_map(|t| {
-                            let gate_t = &gate_batch[t * inter..(t + 1) * inter];
-                            let up_t = &up_batch[t * inter..(t + 1) * inter];
-                            if config.architecture == Architecture::Gemma2 {
-                                gelu_mul_cpu(gate_t, up_t)
-                            } else {
-                                self.backend.silu_mul_vec(gate_t, up_t)
-                            }
-                        })
-                        .collect();
+                    let mut ffn_hidden_batch = vec![0.0f32; seq_len * inter];
+                    for t in 0..seq_len {
+                        let gate_t = &gate_batch[t * inter..(t + 1) * inter];
+                        let up_t = &up_batch[t * inter..(t + 1) * inter];
+                        let dst = &mut ffn_hidden_batch[t * inter..(t + 1) * inter];
+                        if config.architecture == Architecture::Gemma2 {
+                            gelu_mul_into(gate_t, up_t, dst);
+                        } else {
+                            silu_mul_into(gate_t, up_t, dst);
+                        }
+                    }
                     record_phase!(self, t_silu, silu_mul_ms);
 
                     let t_down = self.tick();

--- a/flare-server/examples/prefill_profile.rs
+++ b/flare-server/examples/prefill_profile.rs
@@ -1,0 +1,123 @@
+//! Per-phase prefill profile for a 32-token prompt on SmolLM2-135M Q8_0.
+//!
+//! Mirrors what the BrowserAI bench prints from JS, so we can compare native vs
+//! browser numbers and validate kernel-level optimizations (gate_up fusion,
+//! silu_mul_into, etc.) without needing the browser harness.
+//!
+//!   cargo run -p flarellm-server --example prefill_profile --release
+
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+
+use flare_core::model::Model;
+use flare_loader::gguf::GgufFile;
+use flare_loader::weights::load_model_weights;
+
+const MODEL: &str = "models/smollm2-135m-instruct-q8_0.gguf";
+const PROMPT_LEN: usize = 32;
+const ITERATIONS: usize = 5;
+
+fn now_ms() -> f64 {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+    now.as_secs_f64() * 1000.0
+}
+
+fn main() {
+    if !Path::new(MODEL).exists() {
+        eprintln!("missing {MODEL} — run scripts/download_baseline_model.sh first");
+        std::process::exit(1);
+    }
+
+    eprintln!("loading {MODEL}");
+    let file = File::open(MODEL).unwrap();
+    let mut reader = BufReader::new(file);
+    let gguf = GgufFile::parse_header(&mut reader).unwrap();
+    let config = gguf.to_model_config().unwrap();
+    let weights = load_model_weights(&gguf, &mut reader).unwrap();
+    let mut model = Model::new(config.clone(), weights);
+
+    {
+        let file2 = File::open(MODEL).unwrap();
+        let mut reader2 = BufReader::new(file2);
+        let gguf2 = GgufFile::parse_header(&mut reader2).unwrap();
+        let n = config.num_layers;
+        let mut raw = Vec::with_capacity(n);
+        let mut ok = true;
+        for li in 0..n {
+            match gguf2.load_raw_layer_weights(&mut reader2, li) {
+                Ok(Some(rw)) => raw.push(rw),
+                _ => {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if ok && raw.len() == n {
+            model.set_raw_weights(raw);
+            if let Ok(Some(rw)) = gguf2
+                .read_raw_weight(&mut reader2, "output.weight")
+                .or_else(|_| gguf2.read_raw_weight(&mut reader2, "lm_head.weight"))
+            {
+                model.set_raw_output_weight(rw);
+            }
+        } else {
+            eprintln!("warning: raw weight load failed; running with f32 fallback");
+        }
+    }
+
+    model.build_fused_f32_weights();
+    model.warmup();
+
+    let prompt: Vec<u32> = (1..=(PROMPT_LEN as u32)).collect();
+
+    let mut totals: Vec<f32> = Vec::with_capacity(ITERATIONS);
+    let mut last_print = String::new();
+
+    for it in 0..ITERATIONS {
+        model.reset();
+        model.enable_prefill_profiling(now_ms);
+        let _ = model.forward_prefill(&prompt);
+        let profile = model.take_prefill_profile().unwrap();
+        totals.push(profile.total_ms);
+
+        let line = format!(
+            "iter {} | total {:.2} ms | embed {:.2} attn_norm {:.2} qkv {:.2} rope {:.2} attn {:.2} attn_out {:.2} ffn_norm {:.2} gate_up {:.2} silu_mul {:.2} down {:.2} resid {:.2} kv_write {:.2} final_norm {:.2} lm_head {:.2}",
+            it,
+            profile.total_ms,
+            profile.embed_ms,
+            profile.attn_norm_ms,
+            profile.qkv_proj_ms,
+            profile.rope_ms,
+            profile.attention_ms,
+            profile.attn_out_proj_ms,
+            profile.ffn_norm_ms,
+            profile.gate_up_ms,
+            profile.silu_mul_ms,
+            profile.down_ms,
+            profile.residual_ms,
+            profile.kv_write_ms,
+            profile.final_norm_ms,
+            profile.lm_head_ms,
+        );
+        println!("{line}");
+        last_print = line;
+    }
+
+    let _ = last_print;
+    let mean = totals.iter().sum::<f32>() / totals.len() as f32;
+    let mut sorted = totals.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let median = sorted[sorted.len() / 2];
+    println!(
+        "\nsummary: mean {:.2} ms | median {:.2} ms | min {:.2} ms | max {:.2} ms (over {} iters, {} tokens)",
+        mean,
+        median,
+        sorted[0],
+        sorted[sorted.len() - 1],
+        ITERATIONS,
+        PROMPT_LEN
+    );
+}


### PR DESCRIPTION
## Summary

Removes the per-token Vec allocation from the FFN block in `forward_prefill` (and `forward_prefill_async`).

The old loop was:
\`\`\`rust
let ffn_hidden_batch: Vec<f32> = (0..seq_len)
    .flat_map(|t| {
        let gate_t = &gate_batch[t * inter..(t + 1) * inter];
        let up_t = &up_batch[t * inter..(t + 1) * inter];
        self.backend.silu_mul_vec(gate_t, up_t)  // returns a fresh Vec per token
    })
    .collect();
\`\`\`

That's 32 small `Vec<f32>` allocations + 1 final flattened allocation per layer × 30 layers per prefill on SmolLM2-135M. The actual SIMD work (NEON sigmoid + element-wise multiply) is fast; allocation overhead was eating it.

New loop preallocates the output once and writes per-token via `silu_mul_into` (the existing NEON-into helper that the decode path already uses):

\`\`\`rust
let mut ffn_hidden_batch = vec![0.0f32; seq_len * inter];
for t in 0..seq_len {
    let gate_t = &gate_batch[t * inter..(t + 1) * inter];
    let up_t = &up_batch[t * inter..(t + 1) * inter];
    let dst = &mut ffn_hidden_batch[t * inter..(t + 1) * inter];
    if config.architecture == Architecture::Gemma2 { gelu_mul_into(gate_t, up_t, dst); }
    else { silu_mul_into(gate_t, up_t, dst); }
}
\`\`\`

## Numbers (SmolLM2-135M Q8_0, 32-tok prompt, M-series, release)

|  | silu_mul phase | total prefill |
|---|---|---|
| baseline | 4.82 ms | 55.23 ms |
| this PR | **0.34 ms** | **51.84 ms** |
| delta | **−4.48 ms (-92%)** | **−3.39 ms (-6.1%)** |

The silu_mul kernel itself goes 14× faster — alloc was the cost. Browser proportionally should see ~3× this gain (~10 ms off TTFT) since wasm32 has higher allocator overhead, but that's not measured here.

## Why this isn't a fused gate_up matmul

I tried fusing the gate and up projections into a single `batched_dequant_matmul` on `[w_gate; w_up]`, on the theory that one bigger matmul beats two smaller ones (single input quantize, single weight stream). On native M-series with SmolLM2's sizes the fused path measured **slower** than two separate dispatches (gate_up phase 25.7 ms vs 22.6 ms), even with no intermediate copy. Reverted; left a `prefill_profile` example so we can revisit on bigger models / wasm32 where the per-call overhead profile is different.

## What's also added

- `flare-server/examples/prefill_profile.rs` — run prefill on a 32-token prompt with the per-phase profile enabled, native, no browser harness needed. Mirrors the JSON shape the BrowserAI bench prints from JS so we can A/B kernel changes here instead of through Chrome.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo build --target wasm32-unknown-unknown -p flarellm-web`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p flarellm-core --lib` (252 passed)
- [x] `prefill_profile` example: total 55.23 → 51.84 ms (5 iters)
- [ ] After merge: re-run the BrowserAI Flare-only bench on the next 0.2.x release to confirm browser TTFT improves proportionally.

## Followups

The prefill_profile data shows native top costs are still: `gate_up_proj 22 ms`, `down_proj 11 ms`, `qkv_proj 7 ms`, `attn_out_proj 4 ms` — all in the matmul/quantize path. Future work for getting closer to MLC's TTFT lives there (better SIMD tile shapes, possibly fused QKV at the kernel level, dequant cache).