### PR TITLE
Release flare-web 0.2.19

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
Bumps `flare-web` npm package version to 0.2.19.

## What's new vs 0.2.18

- **Prefill silu_mul allocates once, not per-token** (#511) — `silu_mul` phase 14× faster (4.82 → 0.34 ms native), total prefill -6.1% on SmolLM2-135M / 32-tok prompt. Browser TTFT should improve proportionally; wasm32 allocator overhead is higher than native so the relative gain is likely larger there.

## Post-merge steps

1. Tag `flare-web-v0.2.19` on the merge commit + create GitHub release.
2. The `npm-publish.yml` workflow runs but errors at the `npm publish` step (no `NPM_TOKEN` secret) — the actual publish is manual via `npm publish --access public` from a logged-in shell, just like 0.2.18.
3. Re-run BrowserAI Flare-only bench on SmolLM2-135M to confirm browser TTFT drops below the post-0.2.18 baseline of ~142 ms.

## Test plan

- [x] PR #511 already passed full CI on the same code; this PR is a one-line version bump.