### PR TITLE
Release flare-web 0.2.20

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
Bumps `flare-web` npm package version to 0.2.20.

## What's new vs 0.2.19

- **Parallel Q8_0 prefill matmul tiles** (#513) — `CpuBackend::batched_dequant_matmul` now dispatches the 4-token SMMLA / 2-token pair tile loops through rayon on native. Pre-quantizes all batch inputs once, kernels write directly into per-tile output slices (scratch + memcpy gone), threshold-gated at `out_rows ≥ 384` so small K/V projections don't pay rayon spawn overhead.

## Numbers (SmolLM2-135M Q8_0, 32-tok prompt, M-series 10-core, native release)

|  | total prefill | gate_up | down | attn_out | qkv |
|---|---|---|---|---|---|
| 0.2.19 | 51.77 ms | 22.6 ms | 11.1 ms | 4.20 ms | 7.16 ms |
| **0.2.20** | **27.54 ms** | **8.83 ms** | **3.99 ms** | **3.28 ms** | **5.92 ms** |
| delta | **-47%** | **-61%** | **-64%** | **-22%** | **-17%** |

Browser TTFT impact is expected to be small (wasm32 doesn't get rayon parallelism yet, but the cleanup helps everywhere).

## Test plan

- [x] PR #513 already passed full CI on the same code; this PR is a one-line version bump.