### PR TITLE
Release flare-web 0.2.21

### DIFF
--- a/flare-web/package.json
+++ b/flare-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sauravpanda/flare",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "WASM-first LLM inference engine with WebGPU acceleration — run LLMs in the browser with zero server costs",
   "type": "module",
   "main": "pkg/flare_web.js",


### PR DESCRIPTION
Bumps `flare-web` npm package version to 0.2.21.

## What's new vs 0.2.20

- **Fused QKV prefill matmul** (#515) — `forward_prefill` now does one batched matmul on the concatenated `[wq; wk; wv]` Q8_0 weight when available, instead of three separate calls. Input is quantized once instead of three times; rayon spawn cost is paid once instead of three times.

## Numbers (SmolLM2-135M Q8_0, 32-tok prompt, M-series 10-core, native release)

|  | total prefill | qkv |
|---|---|---|
| 0.2.20 | 27.54 ms | 5.92 ms |
| **0.2.21** | **26.14 ms** | **3.85 ms** |
| delta | **-5%** | **-35%** |

Browser TTFT delta is expected to be relatively larger (wasm32 gets the dispatch-count and quantize-count wins but not the rayon savings).

## Test plan

- [x] PR #515 already passed full CI on the same code; this PR is a one-line version bump.